### PR TITLE
Xsup 69286 cid fix

### DIFF
--- a/Packs/ApiModules/ReleaseNotes/2_4_22.md
+++ b/Packs/ApiModules/ReleaseNotes/2_4_22.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### MicrosoftGraphMailApiModule
+
+- Fixed an issue where the ***send-mail*** and ***reply-mail*** commands failed to render inline images when using the *attachCIDs* argument.

--- a/Packs/ApiModules/Scripts/MicrosoftGraphMailApiModule/MicrosoftGraphMailApiModule.py
+++ b/Packs/ApiModules/Scripts/MicrosoftGraphMailApiModule/MicrosoftGraphMailApiModule.py
@@ -114,7 +114,7 @@ class MsGraphMailBaseClient(MicrosoftClient):
         return file_attachments_result
 
     @classmethod
-    def _build_attachments_input(cls, ids, attach_names=None, is_inline=False):
+    def _build_attachments_input(cls, ids, attach_names=None, attach_cids=None, is_inline=False):
         """
         Builds valid attachment input of the message. Is used for both in-line and regular attachments.
 
@@ -123,6 +123,10 @@ class MsGraphMailBaseClient(MicrosoftClient):
 
         :type attach_names: ``list``
         :param attach_names: List of attachment name, not required.
+
+        :type attach_cids: ``list``
+        :param attach_cids: List of CID labels for inline attachments, mapped positionally to ids.
+            When a CID is provided for a given file, that file is marked as inline with the CID as its contentId.
 
         :type is_inline: ``bool``
         :param is_inline: Indicates whether the attachment is inline or not
@@ -139,25 +143,24 @@ class MsGraphMailBaseClient(MicrosoftClient):
         # in case that no attach names where provided, ids are zipped together and the attach_name value is ignored
         attachments = zip(ids, attach_names) if provided_names else zip(ids, ids)
 
-        for attach_id, attach_name in attachments:
-            try:
-                file_data, file_size, uploaded_file_name = GraphMailUtils.read_file(attach_id)
-            except Exception as e:
-                demisto.debug(
-                    f"send-mail: Failed to read file with ID '{attach_id}'. " f"Skipping this attachment. Error: {str(e)}"
-                )
-                # Skip this attachment if we can't read it - this can happen if the ID is invalid
-                continue
+        for index, (attach_id, attach_name) in enumerate(attachments):
+            file_data, file_size, uploaded_file_name = GraphMailUtils.read_file(attach_id)
             file_name = attach_name if provided_names or not uploaded_file_name else uploaded_file_name
+
+            # Determine CID and inline status: if a CID label is provided at this index, mark as inline
+            cid = attach_cids[index] if attach_cids and len(attach_cids) > index and attach_cids[index] else ""
+            file_is_inline = is_inline or bool(cid)
+            content_id = cid if cid else attach_id
+
             if file_size < cls.MAX_ATTACHMENT_SIZE:  # if file is less than 3MB
                 file_attachments_result.append(
                     {
                         "@odata.type": cls.FILE_ATTACHMENT,
                         "contentBytes": base64.b64encode(file_data).decode("utf-8"),
-                        "isInline": is_inline,
+                        "isInline": file_is_inline,
                         "name": file_name,
                         "size": file_size,
-                        "contentId": attach_id,
+                        "contentId": content_id,
                     }
                 )
             else:
@@ -166,9 +169,9 @@ class MsGraphMailBaseClient(MicrosoftClient):
                         "size": file_size,
                         "data": file_data,
                         "name": file_name,
-                        "isInline": is_inline,
+                        "isInline": file_is_inline,
                         "requires_upload": True,
-                        "contentId": attach_id,
+                        "contentId": content_id,
                     }
                 )
         return file_attachments_result
@@ -1740,7 +1743,8 @@ class GraphMailUtils:
         :param attach_names: List of regular attachments names to send
 
         :type attach_cids: ``list``
-        :param attach_cids: List of uploaded to War Room inline attachments to send
+        :param attach_cids: List of CID labels mapped positionally to attach_ids.
+            Files whose index has a corresponding CID label will be marked as inline attachments.
 
         :type manual_attachments: ``list``
         :param manual_attachments: List of manual attachments reports to send
@@ -1748,8 +1752,11 @@ class GraphMailUtils:
         :return: List of both inline and regular attachments of the message
         :rtype: ``list``
         """
-        regular_attachments = MsGraphMailBaseClient._build_attachments_input(ids=attach_ids, attach_names=attach_names)
-        inline_attachments = MsGraphMailBaseClient._build_attachments_input(ids=attach_cids, is_inline=True)
+        # Build attachments from War Room file IDs, using attach_cids as CID labels (not file IDs).
+        # Files with a corresponding CID label are automatically marked as inline.
+        attachments = MsGraphMailBaseClient._build_attachments_input(
+            ids=attach_ids, attach_names=attach_names, attach_cids=attach_cids
+        )
         # collecting manual attachments info
         manual_att_ids = [os.path.basename(att["RealFileName"]) for att in manual_attachments if "RealFileName" in att]
         manual_att_names = [att["FileName"] for att in manual_attachments if "FileName" in att]
@@ -1760,7 +1767,7 @@ class GraphMailUtils:
             inline_attachments_from_layout
         )
 
-        return regular_attachments + inline_attachments + manual_report_attachments + inline_from_layout_attachments
+        return attachments + manual_report_attachments + inline_from_layout_attachments
 
     @staticmethod
     def build_headers_input(internet_message_headers):

--- a/Packs/ApiModules/pack_metadata.json
+++ b/Packs/ApiModules/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ApiModules",
     "description": "API Modules",
     "support": "xsoar",
-    "currentVersion": "2.4.21",
+    "currentVersion": "2.4.22",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphListener/MicrosoftGraphListener.yml
+++ b/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphListener/MicrosoftGraphListener.yml
@@ -1069,7 +1069,7 @@ script:
       description: The replyTo recipients of the email.
       type: String
     polling: true
-  dockerimage: demisto/crypto:1.0.0.5490413
+  dockerimage: demisto/crypto:1.0.0.8931184
   isfetch: true
   script: ''
   type: python

--- a/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphListener/MicrosoftGraphListener_test.py
+++ b/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphListener/MicrosoftGraphListener_test.py
@@ -309,6 +309,10 @@ def test_build_message(client, tmp_path, mocker):
     attachment = tmp_path / attachment_name
     attachment.touch()
     mocker.patch.object(demisto, "getFilePath", return_value={"path": str(attachment), "name": attachment_name})
+    # attach_ids contains the War Room file ID, attach_cids contains the CID label
+    # mapped positionally to the file in attach_ids
+    attach_id = str(attachment)
+    cid_label = "inline_cid_label"
     message_input = {
         "to_recipients": ["dummy@recipient.com"],  # disable-secrets-detection
         "cc_recipients": ["dummyCC@recipient.com"],  # disable-secrets-detection
@@ -320,9 +324,9 @@ def test_build_message(client, tmp_path, mocker):
         "flag": "flagged",
         "importance": "Normal",
         "internet_message_headers": None,
-        "attach_ids": [],
+        "attach_ids": [attach_id],
         "attach_names": [],
-        "attach_cids": [str(attachment)],
+        "attach_cids": [cid_label],
         "manual_attachments": [],
     }
 
@@ -347,7 +351,7 @@ def test_build_message(client, tmp_path, mocker):
                 "isInline": True,
                 "name": attachment_name,
                 "size": 0,
-                "contentId": str(attachment),
+                "contentId": cid_label,
             }
         ],
     }

--- a/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail.yml
+++ b/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail.yml
@@ -1403,7 +1403,7 @@ script:
     - contextPath: MSGraphMail.MailTips.error.message
       description: The human-readable error message returned if the Mail Tips lookup for the recipient fails.
       type: String
-  dockerimage: demisto/crypto:1.0.0.7323034
+  dockerimage: demisto/crypto:1.0.0.8931184
   isfetch: true
   runonce: false
   script: '-'

--- a/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail_test.py
+++ b/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail_test.py
@@ -2435,23 +2435,7 @@ def test_send_mail_with_attach_cids_uses_cid_labels_not_file_ids(mocker):
       - No call to getFilePath should be made with CID labels
       - The email should be sent successfully with inline images
     """
-    from MicrosoftGraphMail import MsGraphMailClient
-    from MicrosoftGraphMailApiModule import MsGraphMailBaseClient
-
-    client = MsGraphMailBaseClient(
-        tenant_id="tenant_id",
-        auth_id="auth_id",
-        enc_key="enc_key",
-        app_name="app_name",
-        base_url="https://graph.microsoft.com/v1.0/",
-        verify=True,
-        proxy=False,
-        self_deployed=True,
-        mailbox_to_fetch="test@example.com",
-        folder_to_fetch="Inbox",
-        first_fetch_interval="1 day",
-        emails_fetch_limit=50,
-    )
+    client = self_deployed_client()
 
     args = {
         "to": ["recipient@example.com"],
@@ -2469,26 +2453,23 @@ def test_send_mail_with_attach_cids_uses_cid_labels_not_file_ids(mocker):
         return_value={"path": "test_data/plant.jpg", "name": "plant.jpg"},
     )
 
-    # Mock send_mail to capture the payload
-    send_mail_mock = mocker.patch.object(client, "send_mail", return_value=None)
-    mocker.patch.object(client, "get_access_token")
+    with requests_mock.Mocker() as request_mocker:
+        mocker.patch.object(client, "get_access_token")
+        send_mail_mocker = request_mocker.post(f"https://graph.microsoft.com/v1.0/users/{args['from']}/SendMail")
 
-    send_email_command(client, args)
+        send_email_command(client, args)
 
-    # Verify send_mail was called
-    send_mail_mock.assert_called_once()
+        assert send_mail_mocker.called
+        message = send_mail_mocker.last_request.json().get("message")
+        assert message
+        message_attachments = message.get("attachments", [])
 
-    # Get the message payload
-    call_kwargs = send_mail_mock.call_args
-    json_data = call_kwargs.kwargs.get("json_data") or call_kwargs[1].get("json_data") or call_kwargs[0][1]
-    message_attachments = json_data.get("attachments", [])
-
-    # Verify the attachment is marked as inline with the correct CID
-    assert len(message_attachments) == 1
-    attachment = message_attachments[0]
-    assert attachment["isInline"] is True
-    assert attachment["contentId"] == "mylogo"
-    assert attachment["name"] == "plant.jpg"
+        # Verify the attachment is marked as inline with the correct CID
+        assert len(message_attachments) == 1
+        attachment = message_attachments[0]
+        assert attachment["isInline"] is True
+        assert attachment["contentId"] == "mylogo"
+        assert attachment["name"] == "plant.jpg"
 
     # Verify getFilePath was called with the War Room file ID, NOT the CID label
     demisto.getFilePath.assert_called_once_with("15@8")
@@ -2506,22 +2487,7 @@ def test_send_mail_with_attach_ids_no_cids_are_not_inline(mocker):
       - The attachments should NOT be marked as inline
       - The contentId should be the file ID (backward compatibility)
     """
-    from MicrosoftGraphMailApiModule import MsGraphMailBaseClient
-
-    client = MsGraphMailBaseClient(
-        tenant_id="tenant_id",
-        auth_id="auth_id",
-        enc_key="enc_key",
-        app_name="app_name",
-        base_url="https://graph.microsoft.com/v1.0/",
-        verify=True,
-        proxy=False,
-        self_deployed=True,
-        mailbox_to_fetch="test@example.com",
-        folder_to_fetch="Inbox",
-        first_fetch_interval="1 day",
-        emails_fetch_limit=50,
-    )
+    client = self_deployed_client()
 
     args = {
         "to": ["recipient@example.com"],
@@ -2537,18 +2503,18 @@ def test_send_mail_with_attach_ids_no_cids_are_not_inline(mocker):
         return_value={"path": "test_data/plant.jpg", "name": "plant.jpg"},
     )
 
-    send_mail_mock = mocker.patch.object(client, "send_mail", return_value=None)
-    mocker.patch.object(client, "get_access_token")
+    with requests_mock.Mocker() as request_mocker:
+        mocker.patch.object(client, "get_access_token")
+        send_mail_mocker = request_mocker.post(f"https://graph.microsoft.com/v1.0/users/{args['from']}/SendMail")
 
-    send_email_command(client, args)
+        send_email_command(client, args)
 
-    send_mail_mock.assert_called_once()
+        assert send_mail_mocker.called
+        message = send_mail_mocker.last_request.json().get("message")
+        assert message
+        message_attachments = message.get("attachments", [])
 
-    call_kwargs = send_mail_mock.call_args
-    json_data = call_kwargs.kwargs.get("json_data") or call_kwargs[1].get("json_data") or call_kwargs[0][1]
-    message_attachments = json_data.get("attachments", [])
-
-    assert len(message_attachments) == 1
-    attachment = message_attachments[0]
-    assert attachment["isInline"] is False
-    assert attachment["contentId"] == "15@8"
+        assert len(message_attachments) == 1
+        attachment = message_attachments[0]
+        assert attachment["isInline"] is False
+        assert attachment["contentId"] == "15@8"

--- a/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail_test.py
+++ b/Packs/MicrosoftGraphMail/Integrations/MicrosoftGraphMail/MicrosoftGraphMail_test.py
@@ -2418,3 +2418,137 @@ def test_parse_json_arg_invalid_json_raises():
     msg = str(exc_info.value)
     assert "myarg" in msg
     assert "valid JSON" in msg
+
+
+def test_send_mail_with_attach_cids_uses_cid_labels_not_file_ids(mocker):
+    """
+    Given:
+      - send-mail command with attachIDs (War Room file IDs) and attachCIDs (CID labels)
+      - The HTML body references inline images via CID (e.g., <img src="cid:mylogo"/>)
+
+    When:
+      - Sending a mail with inline image attachments
+
+    Then:
+      - The attachCIDs values should be used as contentId labels (not as file IDs for getFilePath)
+      - The files referenced by attachIDs should be marked as inline when they have a corresponding CID
+      - No call to getFilePath should be made with CID labels
+      - The email should be sent successfully with inline images
+    """
+    from MicrosoftGraphMail import MsGraphMailClient
+    from MicrosoftGraphMailApiModule import MsGraphMailBaseClient
+
+    client = MsGraphMailBaseClient(
+        tenant_id="tenant_id",
+        auth_id="auth_id",
+        enc_key="enc_key",
+        app_name="app_name",
+        base_url="https://graph.microsoft.com/v1.0/",
+        verify=True,
+        proxy=False,
+        self_deployed=True,
+        mailbox_to_fetch="test@example.com",
+        folder_to_fetch="Inbox",
+        first_fetch_interval="1 day",
+        emails_fetch_limit=50,
+    )
+
+    args = {
+        "to": ["recipient@example.com"],
+        "htmlBody": '<html><body>Hello <img src="cid:mylogo"/> World</body></html>',
+        "subject": "test with inline CID",
+        "from": "sender@example.com",
+        "attachIDs": "15@8",
+        "attachCIDs": "mylogo",
+    }
+
+    # Mock getFilePath to return a valid file for the War Room file ID "15@8"
+    mocker.patch.object(
+        demisto,
+        "getFilePath",
+        return_value={"path": "test_data/plant.jpg", "name": "plant.jpg"},
+    )
+
+    # Mock send_mail to capture the payload
+    send_mail_mock = mocker.patch.object(client, "send_mail", return_value=None)
+    mocker.patch.object(client, "get_access_token")
+
+    send_email_command(client, args)
+
+    # Verify send_mail was called
+    send_mail_mock.assert_called_once()
+
+    # Get the message payload
+    call_kwargs = send_mail_mock.call_args
+    json_data = call_kwargs.kwargs.get("json_data") or call_kwargs[1].get("json_data") or call_kwargs[0][1]
+    message_attachments = json_data.get("attachments", [])
+
+    # Verify the attachment is marked as inline with the correct CID
+    assert len(message_attachments) == 1
+    attachment = message_attachments[0]
+    assert attachment["isInline"] is True
+    assert attachment["contentId"] == "mylogo"
+    assert attachment["name"] == "plant.jpg"
+
+    # Verify getFilePath was called with the War Room file ID, NOT the CID label
+    demisto.getFilePath.assert_called_once_with("15@8")
+
+
+def test_send_mail_with_attach_ids_no_cids_are_not_inline(mocker):
+    """
+    Given:
+      - send-mail command with attachIDs but no attachCIDs
+
+    When:
+      - Sending a mail with regular (non-inline) attachments
+
+    Then:
+      - The attachments should NOT be marked as inline
+      - The contentId should be the file ID (backward compatibility)
+    """
+    from MicrosoftGraphMailApiModule import MsGraphMailBaseClient
+
+    client = MsGraphMailBaseClient(
+        tenant_id="tenant_id",
+        auth_id="auth_id",
+        enc_key="enc_key",
+        app_name="app_name",
+        base_url="https://graph.microsoft.com/v1.0/",
+        verify=True,
+        proxy=False,
+        self_deployed=True,
+        mailbox_to_fetch="test@example.com",
+        folder_to_fetch="Inbox",
+        first_fetch_interval="1 day",
+        emails_fetch_limit=50,
+    )
+
+    args = {
+        "to": ["recipient@example.com"],
+        "htmlBody": "<html><body>Hello World</body></html>",
+        "subject": "test without CIDs",
+        "from": "sender@example.com",
+        "attachIDs": "15@8",
+    }
+
+    mocker.patch.object(
+        demisto,
+        "getFilePath",
+        return_value={"path": "test_data/plant.jpg", "name": "plant.jpg"},
+    )
+
+    send_mail_mock = mocker.patch.object(client, "send_mail", return_value=None)
+    mocker.patch.object(client, "get_access_token")
+
+    send_email_command(client, args)
+
+    send_mail_mock.assert_called_once()
+
+    call_kwargs = send_mail_mock.call_args
+    json_data = call_kwargs.kwargs.get("json_data") or call_kwargs[1].get("json_data") or call_kwargs[0][1]
+    message_attachments = json_data.get("attachments", [])
+
+    assert len(message_attachments) == 1
+    attachment = message_attachments[0]
+    assert attachment["isInline"] is False
+    assert attachment["contentId"] == "15@8"

--- a/Packs/MicrosoftGraphMail/ReleaseNotes/1_8_2.md
+++ b/Packs/MicrosoftGraphMail/ReleaseNotes/1_8_2.md
@@ -1,0 +1,9 @@
+#### Integrations
+
+##### O365 Outlook Mail (Using Graph API)
+
+- Fixed an issue where the ***send-mail*** and ***reply-mail*** commands failed to render inline images when using the *attachCIDs* argument.
+
+##### Microsoft Graph Mail Single User
+
+- Fixed an issue where the ***send-mail*** and ***reply-mail*** commands failed to render inline images when using the *attachCIDs* argument.

--- a/Packs/MicrosoftGraphMail/ReleaseNotes/1_8_2.md
+++ b/Packs/MicrosoftGraphMail/ReleaseNotes/1_8_2.md
@@ -3,7 +3,9 @@
 ##### O365 Outlook Mail (Using Graph API)
 
 - Fixed an issue where the ***send-mail*** and ***reply-mail*** commands failed to render inline images when using the *attachCIDs* argument.
+- Updated the Docker image to: *demisto/crypto:1.0.0.8931184*. 
 
 ##### Microsoft Graph Mail Single User
 
 - Fixed an issue where the ***send-mail*** and ***reply-mail*** commands failed to render inline images when using the *attachCIDs* argument.
+- Updated the Docker image to: *demisto/crypto:1.0.0.8931184*.

--- a/Packs/MicrosoftGraphMail/pack_metadata.json
+++ b/Packs/MicrosoftGraphMail/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Graph Mail",
     "description": "Microsoft Graph enables authorized access to a user’s Outlook mail data in personal or organizational accounts.",
     "support": "xsoar",
-    "currentVersion": "1.8.1",
+    "currentVersion": "1.8.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [x] Ready

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-69286

## Description
Fixed an issue where the ***send-mail*** and ***reply-mail*** commands failed to render inline images when using the *attachCIDs* argument.

<img width="713" height="633" alt="image" src="https://github.com/user-attachments/assets/49a04a7a-1833-4861-b2df-8221d1fb1f8d" />


## Must have
- [x] Tests
