### PR TITLE
Update Server URL parameter description in GuardiCore v2

### DIFF
--- a/Packs/GuardiCore/Integrations/GuardiCoreV2/GuardiCoreV2.yml
+++ b/Packs/GuardiCore/Integrations/GuardiCoreV2/GuardiCoreV2.yml
@@ -12,7 +12,7 @@ configuration:
   required: true
   defaultvalue: https://example.com/api/v3.0/
   type: 0
-  additionalinfo:
+  additionalinfo: The full URL of the GuardiCore server, including the API path suffix. For example, https://my-domain.cloud.guardicore.com/api/v3.0/
   section: Connect
 - display: Username
   name: credentials
@@ -1210,7 +1210,7 @@ script:
     - contextPath: Endpoint.MACAddress
       description: The endpoint's MAC address.
       type: String
-  dockerimage: demisto/python3:3.12.11.4819260
+  dockerimage: demisto/python3:3.12.13.9059085
   isfetch: true
   runonce: false
   script: "-"

--- a/Packs/GuardiCore/Integrations/GuardiCoreV2/GuardiCoreV2.yml
+++ b/Packs/GuardiCore/Integrations/GuardiCoreV2/GuardiCoreV2.yml
@@ -12,7 +12,7 @@ configuration:
   required: true
   defaultvalue: https://example.com/api/v3.0/
   type: 0
-  additionalinfo: The full URL of the GuardiCore server, including the API path suffix. For example, https://my-domain.cloud.guardicore.com/api/v3.0/
+  additionalinfo: The full URL of the GuardiCore server, including the API path suffix. For example, https://my-domain.cloud.guardicore.com/api/v3.0/.
   section: Connect
 - display: Username
   name: credentials

--- a/Packs/GuardiCore/Integrations/GuardiCoreV2/README.md
+++ b/Packs/GuardiCore/Integrations/GuardiCoreV2/README.md
@@ -5,7 +5,7 @@ This integration was integrated and tested with version 3.0.0 of the GuardiCore 
 
 | **Parameter** | **Description** | **Required** |
 | --- | --- | --- |
-| Server URL |  | True |
+| Server URL | The full URL of the GuardiCore server, including the API path suffix. For example, https://my-domain.cloud.guardicore.com/api/v3.0/. Default value is https://example.com/api/v3.0/. | True |
 | Username |  | True |
 | Password |  | True |
 | Fetch incidents |  | False |

--- a/Packs/GuardiCore/ReleaseNotes/2_0_22.md
+++ b/Packs/GuardiCore/ReleaseNotes/2_0_22.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### GuardiCore v2
+
+- Documentation and metadata improvements.
+- Updated the Docker image to: *demisto/python3:3.12.13.9059085*.

--- a/Packs/GuardiCore/pack_metadata.json
+++ b/Packs/GuardiCore/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Akamai GuardiCore",
     "description": "Data center breach detection",
     "support": "xsoar",
-    "currentVersion": "2.0.21",
+    "currentVersion": "2.0.22",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixes: [XSUP-70029](https://jira-dc.paloaltonetworks.com/browse/XSUP-70029)

## Description
Update Server URL parameter description in GuardiCore v2 to avoid any configuration difficulties.

## Must have
- [ ] Tests
- [x] Documentation
