### PR TITLE
Wiz content pack v2.0.6: add created_at filter and limit to wiz-get-issues

### DIFF
--- a/Packs/Wiz/Integrations/Wiz/Wiz.py
+++ b/Packs/Wiz/Integrations/Wiz/Wiz.py
@@ -12,7 +12,7 @@ WIZ_API_LIMIT = 500  # limit number of returned records from the Wiz API
 MAX_NOTE_LENGTH = 1400  # Hard limit for issue note text length enforced by the Wiz API
 WIZ = "wiz"
 
-WIZ_VERSION = "1.5.0"
+WIZ_VERSION = "1.6.0"
 INTEGRATION_GUID = "8864e131-72db-4928-1293-e292f0ed699f"
 NOT_DEFINED = "Not Defined"
 
@@ -1569,6 +1569,9 @@ class WizInputParam:
     NATIVE_TYPES = "native_types"
     UPDATED_AT_BEFORE = "updated_at_before"
     UPDATED_AT_AFTER = "updated_at_after"
+    CREATED_AFTER = "created_after"
+    CREATED_BEFORE = "created_before"
+    LIMIT = "limit"
     STATUS = "status"
 
 
@@ -1806,7 +1809,7 @@ def checkAPIerrors(query, variables):
 FETCH_ALL_ISSUES_BUDGET_SECONDS = 240  # 5-min Docker timeout - 60s safety margin
 
 
-def _fetch_all_issue_nodes(query, variables, deadline_seconds=FETCH_ALL_ISSUES_BUDGET_SECONDS):
+def _fetch_all_issue_nodes(query, variables, deadline_seconds=FETCH_ALL_ISSUES_BUDGET_SECONDS, max_records=None):
     """
     Fetch all issue nodes from a paginated issues query.
 
@@ -1816,6 +1819,11 @@ def _fetch_all_issue_nodes(query, variables, deadline_seconds=FETCH_ALL_ISSUES_B
     require completeness should narrow their filter; callers that tolerate
     partial results (mirror is the exception — it has its own single-page
     code path) get an actionable signal instead of a script crash.
+
+    When `max_records` is set, pagination stops once that many nodes are
+    accumulated and the result is truncated to exactly `max_records`. This
+    gives callers a deterministic ceiling regardless of how many issues match,
+    independent of the time budget. `None` keeps the fetch-everything behavior.
     """
     variables = dict(variables)
     started = time.monotonic()
@@ -1824,6 +1832,8 @@ def _fetch_all_issue_nodes(query, variables, deadline_seconds=FETCH_ALL_ISSUES_B
     nodes = list(response_json.get("data", {}).get("issues", {}).get("nodes", []))
 
     while response_json.get("data", {}).get("issues", {}).get("pageInfo", {}).get("hasNextPage"):
+        if max_records is not None and len(nodes) >= max_records:
+            break
         if time.monotonic() - started > deadline_seconds:
             demisto.info(
                 f"_fetch_all_issue_nodes: hit {deadline_seconds}s budget after {len(nodes)} nodes; "
@@ -1835,6 +1845,9 @@ def _fetch_all_issue_nodes(query, variables, deadline_seconds=FETCH_ALL_ISSUES_B
         page_nodes = response_json.get("data", {}).get("issues", {}).get("nodes", [])
         if page_nodes:
             nodes += page_nodes
+
+    if max_records is not None and len(nodes) > max_records:
+        nodes = nodes[:max_records]
 
     return nodes
 
@@ -2170,37 +2183,52 @@ def get_issue(issue_id):
     return issues
 
 
-def get_filtered_issues(entity_type, resource_id, severity, issue_type, limit):
+def get_filtered_issues(entity_type, resource_id, severity, issue_type, limit, created_after=None, created_before=None):
     """
     Retrieves Filtered Issues
+
+    `limit` caps the total number of issues returned. When None, all matching
+    issues are fetched (bounded only by the time budget in _fetch_all_issue_nodes).
+    `created_after` / `created_before` are ISO 8601 timestamps mapped to the Wiz
+    `createdAt` filter, letting callers bound heavy queries (e.g. TOXIC_COMBINATION)
+    up front instead of relying on the time-budget safety net.
     """
     demisto.info(
         f"Entity type is {entity_type}\n"
         f"Resource ID is {resource_id}\n"
         f"Severity is {severity}\n"
-        f"Issue type is {issue_type}"
+        f"Issue type is {issue_type}\n"
+        f"Created after is {created_after}\n"
+        f"Created before is {created_before}\n"
+        f"Limit is {limit}"
     )
     error_msg = ""
 
-    if not severity and not entity_type and not resource_id and not issue_type:
+    if not severity and not entity_type and not resource_id and not issue_type and not created_after and not created_before:
         error_msg = (
             "You should pass (at least) one of the following parameters:\n\tentity_type\n\tresource_id"
-            "\n\tseverity\n\tissue_type\n"
+            "\n\tseverity\n\tissue_type\n\tcreated_after\n\tcreated_before\n"
         )
 
     if entity_type and resource_id:
         error_msg = f"{error_msg}You cannot pass entity_type and resource_id together\n"
 
+    if limit is not None and limit < 1:
+        error_msg = f"{error_msg}limit must be a positive integer\n"
+
     if error_msg:
         demisto.error(error_msg)
         return error_msg
 
-    issue_variables = {}
+    # `first` is the per-page size (API max WIZ_API_LIMIT); `limit` is the total cap.
+    page_size = WIZ_API_LIMIT if limit is None else min(limit, WIZ_API_LIMIT)
+
+    issue_variables: Dict[str, Any] = {}
     query = PULL_ISSUES_QUERY
 
     if entity_type:
         issue_variables = {
-            "first": limit,
+            "first": page_size,
             "filterBy": {
                 "status": ["OPEN", "IN_PROGRESS"],
                 "relatedEntity": {"type": [entity_type]},
@@ -2234,7 +2262,7 @@ def get_filtered_issues(entity_type, resource_id, severity, issue_type, limit):
         if graph_resource_response_json["data"]["graphSearch"]["nodes"] != []:
             graph_resource_id = graph_resource_response_json["data"]["graphSearch"]["nodes"][0]["entities"][0]["id"]
             issue_variables = {
-                "first": limit,
+                "first": page_size,
                 "filterBy": {"status": ["OPEN", "IN_PROGRESS"], "relatedEntity": {"id": graph_resource_id}},
                 "orderBy": {"field": "SEVERITY", "direction": "DESC"},
             }
@@ -2245,7 +2273,7 @@ def get_filtered_issues(entity_type, resource_id, severity, issue_type, limit):
     if severity:
         if "filterBy" not in issue_variables:
             issue_variables["filterBy"] = {"severity": []}
-            issue_variables["first"] = limit
+            issue_variables["first"] = page_size
         if severity.upper() == "CRITICAL":
             issue_variables["filterBy"]["severity"] = ["CRITICAL"]
         elif severity.upper() == "HIGH":
@@ -2269,14 +2297,28 @@ def get_filtered_issues(entity_type, resource_id, severity, issue_type, limit):
     if issue_type:
         if "filterBy" not in issue_variables:
             issue_variables["filterBy"] = {}
-            issue_variables["first"] = limit
+            issue_variables["first"] = page_size
 
         issue_variables["filterBy"]["type"] = [issue_type]
+
+    if created_after or created_before:
+        if "filterBy" not in issue_variables:
+            issue_variables["filterBy"] = {}
+            issue_variables["first"] = page_size
+        created_at: Dict[str, str] = {}
+        if created_after:
+            created_at["after"] = created_after
+        if created_before:
+            created_at["before"] = created_before
+        issue_variables["filterBy"]["createdAt"] = created_at
+
+    # Order by severity so a `limit` truncation keeps the most severe issues, not an arbitrary page.
+    issue_variables.setdefault("orderBy", {"field": "SEVERITY", "direction": "DESC"})
 
     demisto.info(f"Query is {query}")
     demisto.info(f"Issue variables is {issue_variables}")
 
-    issues = _fetch_all_issue_nodes(query, issue_variables)
+    issues = _fetch_all_issue_nodes(query, issue_variables, max_records=limit)
     return issues
 
 
@@ -3104,12 +3146,19 @@ def main():
             resource_id = demisto_args.get(WizInputParam.RESOURCE_ID)
             severity = demisto_args.get(WizInputParam.SEVERITY)
             entity_type = demisto_args.get(WizInputParam.ENTITY_TYPE)
+            created_after = demisto_args.get(WizInputParam.CREATED_AFTER)
+            created_before = demisto_args.get(WizInputParam.CREATED_BEFORE)
+            # No limit arg => None => fetch all (preserves prior behavior, where the
+            # passed value only sized pages and pagination drained every match).
+            limit = arg_to_number(demisto_args.get(WizInputParam.LIMIT), arg_name=WizInputParam.LIMIT)
             issues = get_filtered_issues(
                 issue_type=issue_type,
                 resource_id=resource_id,
                 severity=severity,
                 entity_type=entity_type,
-                limit=WIZ_API_LIMIT,
+                limit=limit,
+                created_after=created_after,
+                created_before=created_before,
             )
             if isinstance(issues, str):
                 #  this means the Issue is an error

--- a/Packs/Wiz/Integrations/Wiz/Wiz.yml
+++ b/Packs/Wiz/Integrations/Wiz/Wiz.yml
@@ -242,6 +242,15 @@ script:
       - THREAT_DETECTION
       - CLOUD_CONFIGURATION
       description: Get Issues of a specific type.
+    - description: Get Issues created after this date (ISO 8601, e.g. 2024-01-01T00:00:00Z). Narrows heavy queries to avoid timeouts.
+      name: created_after
+      required: false
+    - description: Get Issues created before this date (ISO 8601, e.g. 2024-01-01T00:00:00Z).
+      name: created_before
+      required: false
+    - description: Maximum number of Issues to return. When omitted, all matching Issues are returned. Returns the most severe Issues first.
+      name: limit
+      required: false
     outputs:
     - contextPath: Wiz.Manager.Issues.entitySnapshot
       description: All resource details.

--- a/Packs/Wiz/Integrations/Wiz/Wiz_test.py
+++ b/Packs/Wiz/Integrations/Wiz/Wiz_test.py
@@ -673,7 +673,7 @@ def test_get_filtered_issues_bad_arguments(mocker, capfd):
         issue = get_filtered_issues(entity_type="", resource_id="", severity="", issue_type="", limit=500)
         assert (
             issue == "You should pass (at least) one of the following parameters:\n\tentity_type\n\tresource_id"
-            "\n\tseverity\n\tissue_type\n"
+            "\n\tseverity\n\tissue_type\n\tcreated_after\n\tcreated_before\n"
         )
         issue = get_filtered_issues(entity_type="virtualMachine", resource_id="", severity="BAD", issue_type="", limit=500)
         assert (
@@ -2093,6 +2093,157 @@ def test_fetch_all_issue_nodes_single_page(mock_check_api):
     assert len(result) == 1
     assert result[0]["id"] == "only-issue"
     mock_check_api.assert_called_once()
+
+
+# ===== wiz-get-issues: created_at filter + limit (WZ-114555) =====
+
+
+@patch("Wiz.checkAPIerrors")
+def test_fetch_all_issue_nodes_max_records_truncates(mock_check_api):
+    """max_records stops pagination early and truncates the result to exactly that many nodes."""
+    from Wiz import _fetch_all_issue_nodes
+
+    page1 = {
+        "data": {
+            "issues": {
+                "nodes": [{"id": "issue-1"}, {"id": "issue-2"}, {"id": "issue-3"}],
+                "pageInfo": {"hasNextPage": True, "endCursor": "cursor-1"},
+            }
+        }
+    }
+    mock_check_api.return_value = page1
+
+    result = _fetch_all_issue_nodes("some_query", {"first": 3}, max_records=2)
+
+    assert [n["id"] for n in result] == ["issue-1", "issue-2"]
+    # The first page already satisfied the cap, so no second (paginated) call was made.
+    mock_check_api.assert_called_once()
+
+
+@patch("Wiz.checkAPIerrors")
+def test_fetch_all_issue_nodes_max_records_none_fetches_all(mock_check_api):
+    """max_records=None preserves the fetch-everything behavior across pages."""
+    from Wiz import _fetch_all_issue_nodes
+
+    page1 = {"data": {"issues": {"nodes": [{"id": "i1"}, {"id": "i2"}], "pageInfo": {"hasNextPage": True, "endCursor": "c1"}}}}
+    page2 = {"data": {"issues": {"nodes": [{"id": "i3"}], "pageInfo": {"hasNextPage": False, "endCursor": None}}}}
+    mock_check_api.side_effect = [page1, page2]
+
+    result = _fetch_all_issue_nodes("some_query", {"first": 10}, max_records=None)
+
+    assert [n["id"] for n in result] == ["i1", "i2", "i3"]
+
+
+@patch("Wiz._fetch_all_issue_nodes", return_value=[])
+def test_get_filtered_issues_created_at_filter(mock_fetch):
+    """created_after / created_before are mapped to the Wiz createdAt filter."""
+    from Wiz import get_filtered_issues
+
+    get_filtered_issues(
+        entity_type="",
+        resource_id="",
+        severity="",
+        issue_type="TOXIC_COMBINATION",
+        limit=None,
+        created_after="2024-01-01T00:00:00Z",
+        created_before="2024-02-01T00:00:00Z",
+    )
+
+    variables = mock_fetch.call_args[0][1]
+    assert variables["filterBy"]["createdAt"] == {"after": "2024-01-01T00:00:00Z", "before": "2024-02-01T00:00:00Z"}
+    assert variables["filterBy"]["type"] == ["TOXIC_COMBINATION"]
+
+
+@patch("Wiz._fetch_all_issue_nodes", return_value=[])
+def test_get_filtered_issues_created_at_standalone(mock_fetch):
+    """A date filter alone is a valid query (no entity/severity/type required)."""
+    from Wiz import get_filtered_issues
+
+    result = get_filtered_issues(
+        entity_type="",
+        resource_id="",
+        severity="",
+        issue_type="",
+        limit=None,
+        created_after="2024-01-01T00:00:00Z",
+    )
+
+    # Not an error string -> the call proceeded to fetch.
+    assert not isinstance(result, str)
+    variables = mock_fetch.call_args[0][1]
+    assert variables["filterBy"]["createdAt"] == {"after": "2024-01-01T00:00:00Z"}
+
+
+@patch("Wiz._fetch_all_issue_nodes", return_value=[])
+def test_get_filtered_issues_limit_caps_page_and_records(mock_fetch):
+    """limit sizes the page (<= API max) and is passed through as the total record cap."""
+    from Wiz import get_filtered_issues
+
+    get_filtered_issues(
+        entity_type="VIRTUAL_MACHINE",
+        resource_id="",
+        severity="",
+        issue_type="",
+        limit=5,
+    )
+
+    args, kwargs = mock_fetch.call_args
+    variables = args[1]
+    assert variables["first"] == 5
+    assert kwargs["max_records"] == 5
+
+
+@patch("Wiz._fetch_all_issue_nodes", return_value=[])
+def test_get_filtered_issues_limit_above_api_max_clamps_page(mock_fetch):
+    """A limit larger than the API page size clamps `first` but keeps the full record cap."""
+    from Wiz import get_filtered_issues, WIZ_API_LIMIT
+
+    get_filtered_issues(
+        entity_type="VIRTUAL_MACHINE",
+        resource_id="",
+        severity="",
+        issue_type="",
+        limit=WIZ_API_LIMIT + 250,
+    )
+
+    args, kwargs = mock_fetch.call_args
+    assert args[1]["first"] == WIZ_API_LIMIT
+    assert kwargs["max_records"] == WIZ_API_LIMIT + 250
+
+
+def test_get_filtered_issues_no_params_errors(capfd):
+    """With no filter at all, the command returns the usage error (now listing the date args)."""
+    from Wiz import get_filtered_issues
+
+    with capfd.disabled():
+        result = get_filtered_issues(entity_type="", resource_id="", severity="", issue_type="", limit=None)
+
+    assert isinstance(result, str)
+    assert "created_after" in result
+    assert "created_before" in result
+
+
+@pytest.mark.parametrize("bad_limit", [0, -1, -100])
+def test_get_filtered_issues_non_positive_limit_errors(capfd, bad_limit):
+    """A non-positive limit is rejected up front (guards against nodes[:-n] silently dropping records)."""
+    from Wiz import get_filtered_issues
+
+    with capfd.disabled():
+        result = get_filtered_issues(entity_type="VIRTUAL_MACHINE", resource_id="", severity="", issue_type="", limit=bad_limit)
+
+    assert isinstance(result, str)
+    assert "limit must be a positive integer" in result
+
+
+@patch("Wiz._fetch_all_issue_nodes", return_value=[])
+def test_get_filtered_issues_orders_by_severity_on_all_branches(mock_fetch):
+    """Every filter branch sets SEVERITY DESC so a limit truncation keeps the most severe issues."""
+    from Wiz import get_filtered_issues
+
+    get_filtered_issues(entity_type="", resource_id="", severity="", issue_type="TOXIC_COMBINATION", limit=5)
+
+    variables = mock_fetch.call_args[0][1]
+    assert variables["orderBy"] == {"field": "SEVERITY", "direction": "DESC"}
 
 
 # ===== GAP #2: _mirror_status_to_wiz for in_progress and rejected =====

--- a/Packs/Wiz/ReleaseNotes/2_0_6.md
+++ b/Packs/Wiz/ReleaseNotes/2_0_6.md
@@ -1,0 +1,6 @@
+#### Integrations
+
+##### Wiz
+
+- Added optional ***created_after*** and ***created_before*** arguments to the ***wiz-get-issues*** command, allowing Issues to be filtered by their creation date (ISO 8601). Narrowing the time window helps heavy queries (e.g., `issue_type=TOXIC_COMBINATION`) complete within the execution window instead of timing out.
+- Added an optional ***limit*** argument to the ***wiz-get-issues*** command to cap the number of Issues returned, with the most severe Issues returned first. When omitted, all matching Issues are returned (unchanged behavior).

--- a/Packs/Wiz/pack_metadata.json
+++ b/Packs/Wiz/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Wiz",
     "description": "Integrate with Wiz for bidirectional Issue management, Detections investigation, and fetching of resource information. \n",
     "support": "partner",
-    "currentVersion": "2.0.5",
+    "currentVersion": "2.0.6",
     "author": "Wiz Inc.",
     "url": "https://wiz.io/",
     "email": "support@wiz.io",


### PR DESCRIPTION
## Summary

Adds optional **`created_after`**, **`created_before`** (ISO 8601 → Wiz `createdAt` filter), and **`limit`** arguments to the **`wiz-get-issues`** command in the Wiz integration.

These let users bound heavy Issue queries (notably `issue_type=TOXIC_COMBINATION`) up front by time window and/or result count, instead of relying solely on the request/pagination timeout safety net added in v2.0.5. `limit` caps the **total** number of Issues returned (most severe first); when omitted, behavior is unchanged (all matching Issues are returned, bounded by the existing pagination time budget).

## Changes

- **`Wiz.py`**
  - `get_filtered_issues`: new `created_after` / `created_before` (mapped to `filterBy.createdAt = {after, before}`, mirroring the existing `wiz-get-resources` `updatedAt` pattern) and `limit` parameters. A date filter alone is now a valid query. `limit` is validated as a positive integer.
  - `_fetch_all_issue_nodes`: new `max_records` parameter — stops pagination and truncates to exactly that many nodes, giving a deterministic ceiling independent of the time budget. `None` preserves fetch-everything behavior.
  - All filter branches now apply `orderBy: SEVERITY DESC`, so a `limit` truncation keeps the most severe Issues.
  - `WIZ_VERSION` 1.5.0 → 1.6.0.
- **`Wiz.yml`** — three new optional arguments on `wiz-get-issues`.
- **`Wiz_test.py`** — unit tests for the `createdAt` filter, the `max_records` cap (truncation + `None` fetch-all), standalone date filter, page-size clamping, positive-integer validation, and severity ordering.
- **Release notes** `2_0_6.md`; pack version 2.0.5 → 2.0.6.

## Testing

- `pytest Wiz_test.py` — **252 passed**.
- `ruff check` / `ruff format --check` — clean.
- `demisto-sdk validate` — all validations passed.
- Deployed to a live XSOAR 6.14 instance and smoke-tested against a real Wiz tenant:
  - `limit=N` returns exactly N Issues; omitting `limit` preserves fetch-all.
  - `created_after` constrains all returned Issues to the window.
  - `issue_type=TOXIC_COMBINATION` bounded by `created_after` + `limit=5` completes in ~107s (previously this query class timed out at the 5-minute mark).
  - Invalid `limit` (`0`, `-1`, `abc`) returns a clean validation error rather than wrong/empty results.


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-16983