### PR TITLE
GitHub: add Actions caches/artifacts and org repositories commands

### DIFF
--- a/Packs/GitHub/Integrations/GitHub/GitHub.py
+++ b/Packs/GitHub/Integrations/GitHub/GitHub.py
@@ -2221,6 +2221,123 @@ def github_revoke_credentials_command() -> None:
         )
 
 
+def github_list_organization_repositories_command() -> None:
+    args = demisto.args()
+    organization = args.get("organization") or USER
+    repo_type = args.get("type", "all")
+    page = arg_to_number(args.get("page")) or DEFAULT_PAGE_NUMBER
+    per_page = arg_to_number(args.get("per_page")) or DEFAULT_PAGE_SIZE
+
+    url_suffix = f"/orgs/{organization}/repos"
+    params: dict[str, Any] = {"type": repo_type, "per_page": per_page, "page": page}
+    results = http_request(method="GET", url_suffix=url_suffix, params=params)
+
+    return_results(
+        CommandResults(
+            outputs_prefix="GitHub.Repository",
+            outputs_key_field="id",
+            outputs=results,
+            readable_output=tableToMarkdown(
+                "Organization Repositories",
+                results,
+                headers=["id", "name", "full_name", "private", "default_branch", "updated_at"],
+                removeNull=True,
+            ),
+        )
+    )
+
+
+def github_list_actions_caches_command() -> None:
+    args = demisto.args()
+    owner = args.get("owner") or USER
+    repository = args.get("repository") or REPOSITORY
+    page = arg_to_number(args.get("page")) or DEFAULT_PAGE_NUMBER
+    per_page = arg_to_number(args.get("per_page")) or DEFAULT_PAGE_SIZE
+    ref = args.get("ref")
+    key = args.get("key")
+    sort = args.get("sort")
+    direction = args.get("direction")
+
+    url_suffix = f"/repos/{owner}/{repository}/actions/caches"
+    params: dict[str, Any] = {"per_page": per_page, "page": page}
+    if ref:
+        params["ref"] = ref
+    if key:
+        params["key"] = key
+    if sort:
+        params["sort"] = sort
+    if direction:
+        params["direction"] = direction
+
+    response = http_request(method="GET", url_suffix=url_suffix, params=params)
+    caches = response.get("actions_caches", [])
+
+    return_results(
+        CommandResults(
+            outputs_prefix="GitHub.ActionsCache",
+            outputs_key_field="id",
+            outputs=caches,
+            readable_output=tableToMarkdown(
+                f"Actions Caches for {owner}/{repository}",
+                caches,
+                headers=["id", "key", "ref", "size_in_bytes", "last_accessed_at", "created_at"],
+                removeNull=True,
+            ),
+        )
+    )
+
+
+def github_delete_actions_cache_command() -> None:
+    args = demisto.args()
+    owner = args.get("owner") or USER
+    repository = args.get("repository") or REPOSITORY
+    cache_id = args.get("cache_id")
+    url_suffix = f"/repos/{owner}/{repository}/actions/caches/{cache_id}"
+    http_request("DELETE", url_suffix=url_suffix)
+    return_results(f"Actions cache {cache_id} in {owner}/{repository} was deleted successfully.")
+
+
+def github_list_actions_artifacts_command() -> None:
+    args = demisto.args()
+    owner = args.get("owner") or USER
+    repository = args.get("repository") or REPOSITORY
+    page = arg_to_number(args.get("page")) or DEFAULT_PAGE_NUMBER
+    per_page = arg_to_number(args.get("per_page")) or DEFAULT_PAGE_SIZE
+    name = args.get("name")
+
+    url_suffix = f"/repos/{owner}/{repository}/actions/artifacts"
+    params: dict[str, Any] = {"per_page": per_page, "page": page}
+    if name:
+        params["name"] = name
+
+    response = http_request(method="GET", url_suffix=url_suffix, params=params)
+    artifacts = response.get("artifacts", [])
+
+    return_results(
+        CommandResults(
+            outputs_prefix="GitHub.ActionsArtifact",
+            outputs_key_field="id",
+            outputs=artifacts,
+            readable_output=tableToMarkdown(
+                f"Actions Artifacts for {owner}/{repository}",
+                artifacts,
+                headers=["id", "name", "size_in_bytes", "expired", "created_at", "expires_at"],
+                removeNull=True,
+            ),
+        )
+    )
+
+
+def github_delete_actions_artifact_command() -> None:
+    args = demisto.args()
+    owner = args.get("owner") or USER
+    repository = args.get("repository") or REPOSITORY
+    artifact_id = args.get("artifact_id")
+    url_suffix = f"/repos/{owner}/{repository}/actions/artifacts/{artifact_id}"
+    http_request("DELETE", url_suffix=url_suffix)
+    return_results(f"Actions artifact {artifact_id} in {owner}/{repository} was deleted successfully.")
+
+
 """ COMMANDS MANAGER / SWITCH PANEL """
 
 COMMANDS = {
@@ -2320,6 +2437,11 @@ COMMANDS = {
     "github-get-workflow-run": github_get_workflow_run_command,
     "github-delete-file": github_delete_file_command,
     "github-revoke-credentials": github_revoke_credentials_command,
+    "github-list-organization-repositories": github_list_organization_repositories_command,
+    "github-list-actions-caches": github_list_actions_caches_command,
+    "github-delete-actions-cache": github_delete_actions_cache_command,
+    "github-list-actions-artifacts": github_list_actions_artifacts_command,
+    "github-delete-actions-artifact": github_delete_actions_artifact_command,
 }
 
 

--- a/Packs/GitHub/Integrations/GitHub/GitHub.yml
+++ b/Packs/GitHub/Integrations/GitHub/GitHub.yml
@@ -7368,10 +7368,10 @@ script:
       description: The ID of the parent workflow.
       type: Number
     - contextPath: GitHub.WorkflowRun.CreatedAt
-      description: 'The datetime the workflow run was created. (ISO8601 format: 2020-01-01T00:11:22Z)'
+      description: 'The datetime the workflow run was created. (ISO8601 format: 2020-01-01T00:11:22Z).'
       type: Date
     - contextPath: GitHub.WorkflowRun.UpdatedAt
-      description: 'The datetime the workflow run was last updated. (ISO8601 format: 2020-01-01T00:11:22Z)'
+      description: 'The datetime the workflow run was last updated. (ISO8601 format: 2020-01-01T00:11:22Z).'
       type: Date
     - contextPath: GitHub.WorkflowRun.Url
       description: The workflow run API URL.
@@ -7409,6 +7409,154 @@ script:
       secret: true
     description: Revoke exposed GitHub credentials (tokens) via the GitHub credential revocation API. This endpoint is unauthenticated by design and does not use the configured token. Limited to 60 unauthenticated requests per hour.
     name: github-revoke-credentials
+  - arguments:
+    - description: The name of the organization. Defaults to the instance configured owner if not given.
+      name: organization
+    - auto: PREDEFINED
+      defaultValue: all
+      description: The type of repositories to list.
+      name: type
+      predefined:
+      - all
+      - public
+      - private
+      - forks
+      - sources
+      - member
+      - internal
+    - defaultValue: '1'
+      description: The page number of results to return (1-based).
+      name: page
+    - defaultValue: '50'
+      description: The number of results per page (max 100).
+      name: per_page
+    description: Lists repositories for the specified organization.
+    name: github-list-organization-repositories
+    outputs:
+    - contextPath: GitHub.Repository.id
+      description: The repository ID.
+      type: Number
+    - contextPath: GitHub.Repository.name
+      description: The repository name.
+      type: String
+    - contextPath: GitHub.Repository.full_name
+      description: The full repository name (org/repo).
+      type: String
+    - contextPath: GitHub.Repository.private
+      description: Whether the repository is private.
+      type: Boolean
+    - contextPath: GitHub.Repository.default_branch
+      description: The default branch name.
+      type: String
+    - contextPath: GitHub.Repository.updated_at
+      description: The date the repository was last updated, in ISO 8601 format (e.g., 2024-05-01T12:00:00Z).
+      type: Date
+  - arguments:
+    - description: The owner (organization or username) of the repository. Defaults to the instance configured owner if not given.
+      name: owner
+    - description: The repository name. Defaults to the instance configured repository if not given.
+      name: repository
+    - defaultValue: '1'
+      description: The page number of results to return (1-based).
+      name: page
+    - defaultValue: '50'
+      description: The number of results per page (max 100).
+      name: per_page
+    - description: The full Git ref to filter caches by (e.g., refs/heads/main).
+      name: ref
+    - description: The cache key or prefix to filter by.
+      name: key
+    - auto: PREDEFINED
+      description: The property to sort the results by.
+      name: sort
+      predefined:
+      - created_at
+      - last_accessed_at
+      - size_in_bytes
+    - auto: PREDEFINED
+      description: The sort direction (asc or desc).
+      name: direction
+      predefined:
+      - asc
+      - desc
+    description: Lists GitHub Actions caches for a repository.
+    name: github-list-actions-caches
+    outputs:
+    - contextPath: GitHub.ActionsCache.id
+      description: The cache ID.
+      type: Number
+    - contextPath: GitHub.ActionsCache.key
+      description: The cache key.
+      type: String
+    - contextPath: GitHub.ActionsCache.ref
+      description: The Git ref the cache belongs to.
+      type: String
+    - contextPath: GitHub.ActionsCache.version
+      description: The cache version.
+      type: String
+    - contextPath: GitHub.ActionsCache.size_in_bytes
+      description: The size of the cache in bytes.
+      type: Number
+    - contextPath: GitHub.ActionsCache.last_accessed_at
+      description: The date the cache was last accessed, in ISO 8601 format (e.g., 2024-05-01T12:00:00Z).
+      type: Date
+    - contextPath: GitHub.ActionsCache.created_at
+      description: The date the cache was created, in ISO 8601 format (e.g., 2024-05-01T12:00:00Z).
+      type: Date
+  - arguments:
+    - description: The owner (organization or username) of the repository. Defaults to the instance configured owner if not given.
+      name: owner
+    - description: The repository name. Defaults to the instance configured repository if not given.
+      name: repository
+    - description: The ID of the cache to delete.
+      name: cache_id
+      required: true
+    description: Deletes a GitHub Actions cache entry.
+    name: github-delete-actions-cache
+  - arguments:
+    - description: The owner (organization or username) of the repository. Defaults to the instance configured owner if not given.
+      name: owner
+    - description: The repository name. Defaults to the instance configured repository if not given.
+      name: repository
+    - defaultValue: '1'
+      description: The page number of results to return (1-based).
+      name: page
+    - defaultValue: '50'
+      description: The number of results per page (max 100).
+      name: per_page
+    - description: The exact artifact name to filter by.
+      name: name
+    description: Lists GitHub Actions artifacts for a repository.
+    name: github-list-actions-artifacts
+    outputs:
+    - contextPath: GitHub.ActionsArtifact.id
+      description: The artifact ID.
+      type: Number
+    - contextPath: GitHub.ActionsArtifact.name
+      description: The artifact name.
+      type: String
+    - contextPath: GitHub.ActionsArtifact.size_in_bytes
+      description: The size of the artifact in bytes.
+      type: Number
+    - contextPath: GitHub.ActionsArtifact.expired
+      description: Whether the artifact has expired.
+      type: Boolean
+    - contextPath: GitHub.ActionsArtifact.created_at
+      description: The date the artifact was created, in ISO 8601 format (e.g., 2024-05-01T12:00:00Z).
+      type: Date
+    - contextPath: GitHub.ActionsArtifact.expires_at
+      description: The date the artifact expires, in ISO 8601 format (e.g., 2024-05-01T12:00:00Z).
+      type: Date
+  - arguments:
+    - description: The owner (organization or username) of the repository. Defaults to the instance configured owner if not given.
+      name: owner
+    - description: The repository name. Defaults to the instance configured repository if not given.
+      name: repository
+    - description: The ID of the artifact to delete.
+      name: artifact_id
+      required: true
+    description: Deletes a GitHub Actions artifact.
+    name: github-delete-actions-artifact
   dockerimage: demisto/auth-utils:1.0.0.7837600
   isfetch: true
   runonce: false

--- a/Packs/GitHub/Integrations/GitHub/GitHub_test.py
+++ b/Packs/GitHub/Integrations/GitHub/GitHub_test.py
@@ -10,6 +10,11 @@ from GitHub import (
     get_branch_command,
     get_path_data,
     github_releases_list_command,
+    github_list_organization_repositories_command,
+    github_list_actions_caches_command,
+    github_delete_actions_cache_command,
+    github_list_actions_artifacts_command,
+    github_delete_actions_artifact_command,
     http_request,
     list_all_projects_command,
     list_branch_pull_requests,
@@ -690,3 +695,151 @@ def test_github_revoke_credentials_too_many(mocker):
 
     with pytest.raises(DemistoException, match="maximum of 1000 credentials"):
         GitHub.github_revoke_credentials_command()
+
+
+def test_list_organization_repositories_command(requests_mock, mocker):
+    """
+    Given:
+        Organization name and default args.
+    When:
+        Calling github-list-organization-repositories.
+    Then:
+        Ensure expected CommandResults are returned with GitHub.Repository prefix.
+    """
+    mocker.patch.object(demisto, "args", return_value={"organization": "my-org"})
+    GitHub.TOKEN, GitHub.USE_SSL = "", ""
+    GitHub.HEADERS = {}
+    GitHub.BASE_URL = REGULAR_BASE_URL
+    GitHub.USER = "test"
+
+    test_data = load_test_data("./test_data/list_org_repos_response.json")
+    requests_mock.get(
+        f"{REGULAR_BASE_URL}/orgs/my-org/repos",
+        json=test_data,
+    )
+    mocker_results = mocker.patch("GitHub.return_results")
+    github_list_organization_repositories_command()
+
+    command_results: CommandResults = mocker_results.call_args[0][0]
+    assert command_results.outputs_prefix == "GitHub.Repository"
+    assert command_results.outputs_key_field == "id"
+    assert len(command_results.outputs) == 2
+    assert command_results.outputs[0]["name"] == "repo-alpha"
+
+
+def test_list_actions_caches_command(requests_mock, mocker):
+    """
+    Given:
+        Owner, repository, and default args.
+    When:
+        Calling github-list-actions-caches.
+    Then:
+        Ensure expected CommandResults are returned with GitHub.ActionsCache prefix.
+    """
+    mocker.patch.object(demisto, "args", return_value={"owner": "my-org", "repository": "my-repo"})
+    GitHub.TOKEN, GitHub.USE_SSL = "", ""
+    GitHub.HEADERS = {}
+    GitHub.BASE_URL = REGULAR_BASE_URL
+    GitHub.USER = "test"
+    GitHub.REPOSITORY = "hello-world"
+
+    test_data = load_test_data("./test_data/list_actions_caches_response.json")
+    requests_mock.get(
+        f"{REGULAR_BASE_URL}/repos/my-org/my-repo/actions/caches",
+        json=test_data,
+    )
+    mocker_results = mocker.patch("GitHub.return_results")
+    github_list_actions_caches_command()
+
+    command_results: CommandResults = mocker_results.call_args[0][0]
+    assert command_results.outputs_prefix == "GitHub.ActionsCache"
+    assert command_results.outputs_key_field == "id"
+    assert len(command_results.outputs) == 2
+    assert command_results.outputs[0]["key"] == "npm-cache-linux-abc123"
+
+
+def test_delete_actions_cache_command(requests_mock, mocker):
+    """
+    Given:
+        Owner, repository, and cache_id.
+    When:
+        Calling github-delete-actions-cache.
+    Then:
+        Ensure DELETE request is sent and success message is returned.
+    """
+    mocker.patch.object(demisto, "args", return_value={"owner": "my-org", "repository": "my-repo", "cache_id": "501"})
+    GitHub.TOKEN, GitHub.USE_SSL = "", ""
+    GitHub.HEADERS = {}
+    GitHub.BASE_URL = REGULAR_BASE_URL
+    GitHub.USER = "test"
+    GitHub.REPOSITORY = "hello-world"
+
+    requests_mock.delete(
+        f"{REGULAR_BASE_URL}/repos/my-org/my-repo/actions/caches/501",
+        status_code=204,
+    )
+    mocker_results = mocker.patch("GitHub.return_results")
+    github_delete_actions_cache_command()
+
+    result = mocker_results.call_args[0][0]
+    assert "501" in result
+    assert "deleted successfully" in result
+
+
+def test_list_actions_artifacts_command(requests_mock, mocker):
+    """
+    Given:
+        Owner, repository, and default args.
+    When:
+        Calling github-list-actions-artifacts.
+    Then:
+        Ensure expected CommandResults are returned with GitHub.ActionsArtifact prefix.
+    """
+    mocker.patch.object(demisto, "args", return_value={"owner": "my-org", "repository": "my-repo"})
+    GitHub.TOKEN, GitHub.USE_SSL = "", ""
+    GitHub.HEADERS = {}
+    GitHub.BASE_URL = REGULAR_BASE_URL
+    GitHub.USER = "test"
+    GitHub.REPOSITORY = "hello-world"
+
+    test_data = load_test_data("./test_data/list_actions_artifacts_response.json")
+    requests_mock.get(
+        f"{REGULAR_BASE_URL}/repos/my-org/my-repo/actions/artifacts",
+        json=test_data,
+    )
+    mocker_results = mocker.patch("GitHub.return_results")
+    github_list_actions_artifacts_command()
+
+    command_results: CommandResults = mocker_results.call_args[0][0]
+    assert command_results.outputs_prefix == "GitHub.ActionsArtifact"
+    assert command_results.outputs_key_field == "id"
+    assert len(command_results.outputs) == 2
+    assert command_results.outputs[0]["name"] == "build-output"
+
+
+def test_delete_actions_artifact_command(requests_mock, mocker):
+    """
+    Given:
+        Owner, repository, and artifact_id.
+    When:
+        Calling github-delete-actions-artifact.
+    Then:
+        Ensure DELETE request is sent and success message is returned.
+    """
+    mocker.patch.object(demisto, "args", return_value={"owner": "my-org", "repository": "my-repo", "artifact_id": "801"})
+    GitHub.TOKEN, GitHub.USE_SSL = "", ""
+    GitHub.HEADERS = {}
+    GitHub.BASE_URL = REGULAR_BASE_URL
+    GitHub.USER = "test"
+    GitHub.REPOSITORY = "hello-world"
+
+    requests_mock.delete(
+        f"{REGULAR_BASE_URL}/repos/my-org/my-repo/actions/artifacts/801",
+        status_code=204,
+    )
+    mocker_results = mocker.patch("GitHub.return_results")
+    github_delete_actions_artifact_command()
+
+    result = mocker_results.call_args[0][0]
+    assert "801" in result
+    assert "deleted successfully" in result

--- a/Packs/GitHub/Integrations/GitHub/README.md
+++ b/Packs/GitHub/Integrations/GitHub/README.md
@@ -5213,3 +5213,138 @@ Revoke exposed GitHub credentials (tokens) via the GitHub credential revocation 
 #### Context Output
 
 There is no context output for this command.
+
+### github-list-organization-repositories
+
+***
+Lists repositories for the specified organization.
+
+#### Base Command
+
+`github-list-organization-repositories`
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| organization | The name of the organization. Defaults to the instance configured owner if not given. | Optional |
+| type | The type of repositories to list. Possible values are: all, public, private, forks, sources, member, internal. Default is all. | Optional |
+| page | The page number of results to return \(1-based\). Default is 1. | Optional |
+| per_page | The number of results per page \(max 100\). Default is 50. | Optional |
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| GitHub.Repository.id | Number | The repository ID. |
+| GitHub.Repository.name | String | The repository name. |
+| GitHub.Repository.full_name | String | The full repository name \(org/repo\). |
+| GitHub.Repository.private | Boolean | Whether the repository is private. |
+| GitHub.Repository.default_branch | String | The default branch name. |
+| GitHub.Repository.updated_at | Date | The date the repository was last updated, in ISO 8601 format \(e.g., 2024-05-01T12:00:00Z\). |
+
+### github-list-actions-caches
+
+***
+Lists GitHub Actions caches for a repository.
+
+#### Base Command
+
+`github-list-actions-caches`
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| owner | The owner \(organization or username\) of the repository. Defaults to the instance configured owner if not given. | Optional |
+| repository | The repository name. Defaults to the instance configured repository if not given. | Optional |
+| page | The page number of results to return \(1-based\). Default is 1. | Optional |
+| per_page | The number of results per page \(max 100\). Default is 50. | Optional |
+| ref | The full Git ref to filter caches by \(e.g., refs/heads/main\). | Optional |
+| key | The cache key or prefix to filter by. | Optional |
+| sort | The property to sort the results by. Possible values are: created_at, last_accessed_at, size_in_bytes. | Optional |
+| direction | The sort direction. Possible values are: asc, desc. | Optional |
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| GitHub.ActionsCache.id | Number | The cache ID. |
+| GitHub.ActionsCache.key | String | The cache key. |
+| GitHub.ActionsCache.ref | String | The Git ref the cache belongs to. |
+| GitHub.ActionsCache.version | String | The cache version. |
+| GitHub.ActionsCache.size_in_bytes | Number | The size of the cache in bytes. |
+| GitHub.ActionsCache.last_accessed_at | Date | The date the cache was last accessed, in ISO 8601 format \(e.g., 2024-05-01T12:00:00Z\). |
+| GitHub.ActionsCache.created_at | Date | The date the cache was created, in ISO 8601 format \(e.g., 2024-05-01T12:00:00Z\). |
+
+### github-delete-actions-cache
+
+***
+Deletes a GitHub Actions cache entry.
+
+#### Base Command
+
+`github-delete-actions-cache`
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| owner | The owner \(organization or username\) of the repository. Defaults to the instance configured owner if not given. | Optional |
+| repository | The repository name. Defaults to the instance configured repository if not given. | Optional |
+| cache_id | The ID of the cache to delete. | Required |
+
+#### Context Output
+
+There is no context output for this command.
+
+### github-list-actions-artifacts
+
+***
+Lists GitHub Actions artifacts for a repository.
+
+#### Base Command
+
+`github-list-actions-artifacts`
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| owner | The owner \(organization or username\) of the repository. Defaults to the instance configured owner if not given. | Optional |
+| repository | The repository name. Defaults to the instance configured repository if not given. | Optional |
+| page | The page number of results to return \(1-based\). Default is 1. | Optional |
+| per_page | The number of results per page \(max 100\). Default is 50. | Optional |
+| name | The exact artifact name to filter by. | Optional |
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| GitHub.ActionsArtifact.id | Number | The artifact ID. |
+| GitHub.ActionsArtifact.name | String | The artifact name. |
+| GitHub.ActionsArtifact.size_in_bytes | Number | The size of the artifact in bytes. |
+| GitHub.ActionsArtifact.expired | Boolean | Whether the artifact has expired. |
+| GitHub.ActionsArtifact.created_at | Date | The date the artifact was created, in ISO 8601 format \(e.g., 2024-05-01T12:00:00Z\). |
+| GitHub.ActionsArtifact.expires_at | Date | The date the artifact expires, in ISO 8601 format \(e.g., 2024-05-01T12:00:00Z\). |
+
+### github-delete-actions-artifact
+
+***
+Deletes a GitHub Actions artifact.
+
+#### Base Command
+
+`github-delete-actions-artifact`
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| owner | The owner \(organization or username\) of the repository. Defaults to the instance configured owner if not given. | Optional |
+| repository | The repository name. Defaults to the instance configured repository if not given. | Optional |
+| artifact_id | The ID of the artifact to delete. | Required |
+
+#### Context Output
+
+There is no context output for this command.

--- a/Packs/GitHub/Integrations/GitHub/test_data/list_actions_artifacts_response.json
+++ b/Packs/GitHub/Integrations/GitHub/test_data/list_actions_artifacts_response.json
@@ -1,0 +1,21 @@
+{
+    "total_count": 2,
+    "artifacts": [
+        {
+            "id": 801,
+            "name": "build-output",
+            "size_in_bytes": 2097152,
+            "expired": false,
+            "created_at": "2025-06-01T06:00:00Z",
+            "expires_at": "2025-07-01T06:00:00Z"
+        },
+        {
+            "id": 802,
+            "name": "test-results",
+            "size_in_bytes": 65536,
+            "expired": true,
+            "created_at": "2025-04-01T10:00:00Z",
+            "expires_at": "2025-05-01T10:00:00Z"
+        }
+    ]
+}

--- a/Packs/GitHub/Integrations/GitHub/test_data/list_actions_caches_response.json
+++ b/Packs/GitHub/Integrations/GitHub/test_data/list_actions_caches_response.json
@@ -1,0 +1,23 @@
+{
+    "total_count": 2,
+    "actions_caches": [
+        {
+            "id": 501,
+            "key": "npm-cache-linux-abc123",
+            "ref": "refs/heads/main",
+            "version": "v1",
+            "size_in_bytes": 1048576,
+            "last_accessed_at": "2025-06-01T09:00:00Z",
+            "created_at": "2025-05-15T12:00:00Z"
+        },
+        {
+            "id": 502,
+            "key": "pip-cache-linux-def456",
+            "ref": "refs/heads/develop",
+            "version": "v1",
+            "size_in_bytes": 524288,
+            "last_accessed_at": "2025-05-30T14:00:00Z",
+            "created_at": "2025-05-10T08:00:00Z"
+        }
+    ]
+}

--- a/Packs/GitHub/Integrations/GitHub/test_data/list_org_repos_response.json
+++ b/Packs/GitHub/Integrations/GitHub/test_data/list_org_repos_response.json
@@ -1,0 +1,18 @@
+[
+    {
+        "id": 100001,
+        "name": "repo-alpha",
+        "full_name": "my-org/repo-alpha",
+        "private": false,
+        "default_branch": "main",
+        "updated_at": "2025-06-01T10:00:00Z"
+    },
+    {
+        "id": 100002,
+        "name": "repo-beta",
+        "full_name": "my-org/repo-beta",
+        "private": true,
+        "default_branch": "develop",
+        "updated_at": "2025-05-20T08:30:00Z"
+    }
+]

--- a/Packs/GitHub/ReleaseNotes/2_3_0.md
+++ b/Packs/GitHub/ReleaseNotes/2_3_0.md
@@ -1,0 +1,10 @@
+
+#### Integrations
+
+##### GitHub
+
+- Added support for the ***github-list-organization-repositories*** command to list repositories in an organization.
+- Added support for the ***github-list-actions-caches*** command to list GitHub Actions caches for a repository.
+- Added support for the ***github-delete-actions-cache*** command to delete a GitHub Actions cache entry.
+- Added support for the ***github-list-actions-artifacts*** command to list GitHub Actions artifacts for a repository.
+- Added support for the ***github-delete-actions-artifact*** command to delete a GitHub Actions artifact.

--- a/Packs/GitHub/pack_metadata.json
+++ b/Packs/GitHub/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "GitHub",
     "description": "Manage GitHub issues and pull requests directly from Cortex XSOAR",
     "support": "xsoar",
-    "currentVersion": "2.2.12",
+    "currentVersion": "2.3.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
Adds github-list-organization-repositories, github-list-actions-caches, github-delete-actions-cache, github-list-actions-artifacts, and github-delete-actions-artifact commands with tests and release notes (2.2.13)


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-16988