### PR TITLE
Remove Unit 42 Intel (deprecated) from platform core packs

### DIFF
--- a/Config/core_packs_platform_list.json
+++ b/Config/core_packs_platform_list.json
@@ -198,13 +198,6 @@
             ]
         },
         {
-            "id": "Unit42Intel",
-            "supportedModules": [
-                "agentix",
-                "xsiam"
-            ]
-        },
-        {
             "id": "VirusTotal",
             "supportedModules": [
                 "agentix",


### PR DESCRIPTION


## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues


## Description
Removed Unit 42 Intel (deprecated) from platform core packs

## Must have
- [ ] Tests
- [ ] Documentation
