### PR TITLE
Idira CCP fix Folder param

### DIFF
--- a/Packs/cyberark_AIM/Integrations/CyberArkAIM_v2/CyberArkAIM_v2.py
+++ b/Packs/cyberark_AIM/Integrations/CyberArkAIM_v2/CyberArkAIM_v2.py
@@ -73,9 +73,10 @@ class Client(BaseClient):
         body = {
             "AppID": self._app_id,
             "Safe": self._safe,
-            "Folder": self._folder,
             "Object": creds_object,
         }
+        if self._folder:
+            body["Folder"] = self._folder
 
         return self._http_request("POST", url_suffix, json_data=body, auth=self.auth, cert=self.crt)
 

--- a/Packs/cyberark_AIM/ReleaseNotes/1_0_30.md
+++ b/Packs/cyberark_AIM/ReleaseNotes/1_0_30.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### CyberArk AIM v2
+
+- Updated the CyberArkAIM v2 integration to add the `Folder` body param if not empty to avoid overriding the default folder value.

--- a/Packs/cyberark_AIM/pack_metadata.json
+++ b/Packs/cyberark_AIM/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CyberArk Central Credential Provider (CCP)",
     "description": "Securely pull hard-coded and embedded privileged credentials from the CyberArk Vault using CyberArk Secrets Manager.",
     "support": "partner",
-    "currentVersion": "1.0.29",
+    "currentVersion": "1.0.30",
     "author": "CyberArk",
     "url": "https://www.cyberark.com/products/secrets-management/",
     "email": "https://www.cyberark.com/services-support/technical-support-contact/",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description
Fix optional  `Folder` parameter usage in `get_credentials`

## Must have
- [x] Tests
- [x] Documentation


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-17014