### PR TITLE
SentinelOne V2 - 3.3.11: Bug fix where fetch-handler maps incorrect timestamp for switching fetch types with in an active instance configuration.

### DIFF
--- a/Packs/SentinelOne/Integrations/SentinelOne-V2/SentinelOne-V2.py
+++ b/Packs/SentinelOne/Integrations/SentinelOne-V2/SentinelOne-V2.py
@@ -5357,17 +5357,31 @@ def fetch_handler(client: Client, args):
     last_fetch = last_run.get("time")
     uam_last_fetch = last_run.get("uam_time")
 
-    if last_fetch is None:
-        last_fetch = dateparser.parse(args.get("first_fetch_time"), settings={"TIMEZONE": "UTC"})
-        if not last_fetch:
-            raise DemistoException("Please provide an initial First fetch timestamp")
-        last_fetch = int(last_fetch.timestamp() * 1000)
+    fetch_type = args.get("fetch_type")
+    fetch_uam = args.get("fetch_uam_alert_type")
 
-    if uam_last_fetch is None:
-        uam_last_fetch = dateparser.parse(args.get("first_fetch_time"), settings={"TIMEZONE": "UTC"})
+    # Only initialize time-based timestamps for active fetch types.
+    # This avoids freezing a stale timestamp for a fetch type that isn't enabled yet.
+    # if the user enables it later, it will start fresh from first_fetch_time at that point.
+    if fetch_type in ("Both", "Alerts", "Threats"):
+        if not last_fetch:
+            last_fetch = dateparser.parse(args.get("first_fetch_time"), settings={"TIMEZONE": "UTC"})
+            if not last_fetch:
+                raise DemistoException("Please provide an initial First fetch timestamp")
+            last_fetch = int(last_fetch.timestamp() * 1000)
+    else:
+        # fetch_type not active — preserve existing timestamp or default to 0
+        last_fetch = last_fetch or 0
+
+    if fetch_uam:
         if not uam_last_fetch:
-            raise DemistoException("Please provide an initial First fetch timestamp")
-        uam_last_fetch = int(uam_last_fetch.timestamp() * 1000)
+            uam_last_fetch = dateparser.parse(args.get("first_fetch_time"), settings={"TIMEZONE": "UTC"})
+            if not uam_last_fetch:
+                raise DemistoException("Please provide an initial First fetch timestamp")
+            uam_last_fetch = int(uam_last_fetch.timestamp() * 1000)
+    else:
+        # UAM not active — preserve existing timestamp or default to 0
+        uam_last_fetch = uam_last_fetch or 0
 
     current_fetch = last_fetch
     uam_current_fetch = uam_last_fetch
@@ -5380,9 +5394,7 @@ def fetch_handler(client: Client, args):
     args["uam_current_fetch"] = uam_current_fetch
 
     incidents = []
-    current_fetch = 0
-    uam_current_fetch = 0
-    if args.get("fetch_type") == "Both":
+    if fetch_type == "Both":
         alert_incidents, alert_current_fetch = fetch_alerts(client, args)
         threat_incidents, threat_current_fetch = fetch_threats(client, args)
 
@@ -5390,19 +5402,19 @@ def fetch_handler(client: Client, args):
 
         incidents = alert_incidents + threat_incidents
 
-    elif args.get("fetch_type") == "Alerts":
+    elif fetch_type == "Alerts":
         incidents, current_fetch = fetch_alerts(client, args)
-    elif args.get("fetch_type") == "Threats":
+    elif fetch_type == "Threats":
         incidents, current_fetch = fetch_threats(client, args)
 
     # Fetch UAM alerts independently
-    if args.get("fetch_uam_alert_type"):
+    if fetch_uam:
         uam_incidents, uam_current_fetch = fetch_uam_alerts(client, args)
         incidents += uam_incidents
     # Debug log if no incidents
     if not incidents:
         demisto.debug(
-            f"{args.get('fetch_type')=}, {args.get('fetch_uam_alert_type')=} -> "
+            f"{fetch_type=}, {fetch_uam=} -> "
             f"{incidents=} {current_fetch=} {uam_current_fetch=}"
         )
 

--- a/Packs/SentinelOne/Integrations/SentinelOne-V2/SentinelOne-V2.py
+++ b/Packs/SentinelOne/Integrations/SentinelOne-V2/SentinelOne-V2.py
@@ -5413,10 +5413,7 @@ def fetch_handler(client: Client, args):
         incidents += uam_incidents
     # Debug log if no incidents
     if not incidents:
-        demisto.debug(
-            f"{fetch_type=}, {fetch_uam=} -> "
-            f"{incidents=} {current_fetch=} {uam_current_fetch=}"
-        )
+        demisto.debug(f"{fetch_type=}, {fetch_uam=} -> " f"{incidents=} {current_fetch=} {uam_current_fetch=}")
 
     demisto.setLastRun({"time": current_fetch, "uam_time": uam_current_fetch})
     demisto.incidents(incidents)

--- a/Packs/SentinelOne/ReleaseNotes/3_3_11.md
+++ b/Packs/SentinelOne/ReleaseNotes/3_3_11.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### SentinelOne v2
+
+- Fixed an issue in the fetch incidents flow where switching between fetch types (Threats, Alerts, UAM Alerts) could cause the integration to fetch from an incorrect timestamp. Each fetch type now maintains its own independent timestamp, and enabling a fetch type for the first time will correctly bootstrap from the configured *First fetch timestamp* parameter.

--- a/Packs/SentinelOne/ReleaseNotes/3_3_11.md
+++ b/Packs/SentinelOne/ReleaseNotes/3_3_11.md
@@ -3,4 +3,4 @@
 
 ##### SentinelOne v2
 
-- Fixed an issue in the fetch incidents flow where switching between fetch types (Threats, Alerts, UAM Alerts) could cause the integration to fetch from an incorrect timestamp. Each fetch type now maintains its own independent timestamp, and enabling a fetch type for the first time will correctly bootstrap from the configured *First fetch timestamp* parameter.
+- Fixed an issue in the fetch incidents flow where switching between fetch_type and fetch_uam_alert_type could cause the integration to fetch from an incorrect timestamp when either parameter was updated after a successful installation or after the integration had been running for some time. The First fetch timestamp is now assigned separately based on the use case. This ensures that enabling a fetch type for the first time correctly bootstraps the proper timestamp for fetch_type and fetch_uam_alert_type individually.

--- a/Packs/SentinelOne/pack_metadata.json
+++ b/Packs/SentinelOne/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "SentinelOne",
     "description": "Endpoint protection",
     "support": "partner",
-    "currentVersion": "3.3.10",
+    "currentVersion": "3.3.11",
     "author": "SentinelOne",
     "url": "https://www.sentinelone.com/support/",
     "email": "support@sentinelone.com",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Description
Fixed an issue in the fetch incidents flow where switching between `fetch_type` and `fetch_uam_alert_type` could cause the integration to fetch from an incorrect timestamp when either parameter was updated after a successful installation or after the integration had been running for some time. The First fetch timestamp is now assigned separately based on the use case. This ensures that enabling a fetch type for the first time correctly bootstraps the proper timestamp for fetch_type and fetch_uam_alert_type individually.

## Must have
- [ ] Tests
- [ ] Documentation


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-17055