### PR TITLE
CRTX-254956: Update XDM to Auth mapping for CyberArk ISP

### DIFF
--- a/Packs/CyberArkPAS/ModelingRules/CyberArkISP/CyberArkISP.xif
+++ b/Packs/CyberArkPAS/ModelingRules/CyberArkISP/CyberArkISP.xif
@@ -52,10 +52,14 @@ alter
     get_latitude = json_extract_scalar(customData, "$.geoip_latitude"),
     get_longitude = json_extract_scalar(customData, "$.geoip_longitude")
 | alter
+    get_mfa_result = json_extract_scalar(customData, "$.mfa_result")
+| alter
     get_outcome = if(
         get_success = "True", XDM_CONST.OUTCOME_SUCCESS,
         auditCode = "IDP2005" and get_cookie_session != null, XDM_CONST.OUTCOME_SUCCESS,
         auditCode = "IDP2009", XDM_CONST.OUTCOME_SUCCESS,
+        lowercase(message) = "cloud.core.mfasummary" and get_mfa_result = "Success", XDM_CONST.OUTCOME_SUCCESS,
+        lowercase(message) = "cloud.core.login.multifactorchallenge", XDM_CONST.OUTCOME_PARTIAL,
         XDM_CONST.OUTCOME_FAILED
     )
 | alter
@@ -76,13 +80,7 @@ alter
         "password"
     ),
     xdm.event.outcome = get_outcome,
-    xdm.event.outcome_reason = if(
-        get_outcome = XDM_CONST.OUTCOME_SUCCESS, null,
-        get_failure_reason contains "abandoned", "mfa_expired",
-        get_failure_reason contains "Internal error", "OTHER",
-        get_denied_by_user = "True", "user_reject",
-        "failed_login"
-    ),
+    xdm.event.outcome_reason = get_failure_reason,
     xdm.source.ipv4 = get_source_ip,
     xdm.source.port = to_integer(0),
     xdm.source.user_agent = get_user_agent,
@@ -111,7 +109,7 @@ alter
     xdm.target.port = to_integer(0),
     xdm.target.resource.name = get_entity_name,
     xdm.network.ip_protocol = XDM_CONST.IP_PROTOCOL_TCP,
-    xdm.network.session_id = get_session_id,
+    xdm.network.session_id = customData,
     xdm.session_context_id = coalesce(get_session_id, get_session_guid),
     xdm.logon.type = if(message = "Cloud.Core.O365WsTrustLogin", XDM_CONST.LOGON_TYPE_SERVICE, XDM_CONST.LOGON_TYPE_INTERACTIVE),
     xdm.auth.service = if(
@@ -120,6 +118,7 @@ alter
         "IDP"
     ),
     xdm.auth.privilege_level = if(
+        username = "SYSTEM$", XDM_CONST.PRIVILEGE_LEVEL_SYSTEM,
         get_roles contains "sysadmin", XDM_CONST.PRIVILEGE_LEVEL_ADMIN,
         get_roles contains "Admin", XDM_CONST.PRIVILEGE_LEVEL_ADMIN,
         XDM_CONST.PRIVILEGE_LEVEL_USER

--- a/Packs/CyberArkPAS/ReleaseNotes/1_2_1.md
+++ b/Packs/CyberArkPAS/ReleaseNotes/1_2_1.md
@@ -1,0 +1,12 @@
+
+#### Modeling Rules
+
+##### CyberArk ISP Modeling Rule
+
+- Updated the **CyberArk ISP Modeling Rule** (`cyberark_isp_raw`) with the following fixes:
+  - Added `PARTIAL` outcome for `cloud.core.login.multifactorchallenge` events (`xdm.event.outcome`).
+  - Added `SUCCESS` outcome for `cloud.core.mfasummary` events when `mfa_result = "Success"` (`xdm.event.outcome`).
+  - Updated `xdm.event.outcome_reason` to map directly from `JSON_VALUE(customData, '$.failure_reason')`.
+  - Updated `xdm.network.session_id` to map from `customData` (`sso_debug_data`).
+  - Added conditional `SYSTEM` privilege level when `username = "SYSTEM$"` (`xdm.auth.privilege_level`).
+<~XSIAM> (Available from Cortex XSIAM 8.4.0).</~XSIAM>

--- a/Packs/CyberArkPAS/pack_metadata.json
+++ b/Packs/CyberArkPAS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CyberArk",
     "description": "Provides a Safe Haven, where all your administrative passwords can be securely archived, transferred and shared by authorized users.",
     "support": "partner",
-    "currentVersion": "1.2.0",
+    "currentVersion": "1.2.1",
     "author": "CyberArk",
     "url": "https://www.cyberark.com/services-support/technical-support-contact/",
     "email": "support@cyberark.com",


### PR DESCRIPTION
- Add PARTIAL outcome for cloud.core.login.multifactorchallenge events
- Add SUCCESS outcome for cloud.core.mfasummary when mfa_result=Success
- Map xdm.event.outcome_reason directly from customData.failure_reason
- Map xdm.network.session_id from customData (sso_debug_data)
- Add SYSTEM privilege level when username = SYSTEM$

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
<!-- To link a Jira ticket use fixes/related: link to the issue, for example fixes: CIAC-XXXX -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

## Must have
- [ ] Tests
- [ ] Documentation
