### PR TITLE
Cisco Umbrella Cloud Security: map AD Users identity to username (XSUP-71055)

### DIFF
--- a/Packs/Cisco-umbrella-cloud-security/ModelingRules/Cisco-umbrella-cloud-security/Cisco-umbrella-cloud-security.xif
+++ b/Packs/Cisco-umbrella-cloud-security/ModelingRules/Cisco-umbrella-cloud-security/Cisco-umbrella-cloud-security.xif
@@ -12,7 +12,8 @@ call Cisco_Umbrella_Cloud_Security_Log_Type
         Response_Code = arrayindex(Log_Fields, 7)
 | alter
         xdm.event.type = logType,
-        xdm.source.host.hostname = arrayindex(Log_Fields, 1),
+        xdm.source.user.username = if(arrayindex(Log_Fields, 10) = "AD Users", arrayindex(Log_Fields, 1), null),
+        xdm.source.host.hostname = if(arrayindex(Log_Fields, 10) = "AD Users", null, arrayindex(Log_Fields, 1)),
         xdm.source.ipv4 = if(arrayindex(Log_Fields, 3) ~= "\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}", arrayindex(Log_Fields, 3), null),
         xdm.source.ipv6 = if(arrayindex(Log_Fields, 3) ~= "[a-fA-F0-9\:]{1,5}[a-fA-F0-9\:]{1,5}[a-fA-F0-9\:]{1,5}[a-fA-F0-9\:]{1,5}[a-fA-F0-9\:]{1,5}[a-fA-F0-9\:]{1,5}[a-fA-F0-9\:]{1,5}[a-fA-F0-9\:]{1,5}", arrayindex(Log_Fields, 3), null),
         xdm.intermediate.ipv4 = if(arrayindex(Log_Fields, 4) ~= "\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}", arrayindex(Log_Fields, 4), null),

--- a/Packs/Cisco-umbrella-cloud-security/ReleaseNotes/2_0_20.md
+++ b/Packs/Cisco-umbrella-cloud-security/ReleaseNotes/2_0_20.md
@@ -1,0 +1,6 @@
+
+#### Modeling Rules
+
+##### Cisco Umbrella Cloud Security Modeling Rule
+
+- Updated the DNS log mapping to map the most granular identity to **xdm.source.user.username** when the most granular identity type is *AD Users*, and to **xdm.source.host.hostname** otherwise.

--- a/Packs/Cisco-umbrella-cloud-security/pack_metadata.json
+++ b/Packs/Cisco-umbrella-cloud-security/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cisco Umbrella cloud security",
     "description": "Basic integration with Cisco Umbrella that allows you to add domains to destination lists (e.g. global block / allow)",
     "support": "xsoar",
-    "currentVersion": "2.0.19",
+    "currentVersion": "2.0.20",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
XSUP-71055 (and duplicate XSUP-71068)

## Description
The Cisco Umbrella Cloud Security DNS modeling rule mapped the most granular identity (DNS log field index 1) unconditionally to `xdm.source.host.hostname`. Per the Cisco Umbrella DNS log spec, when the most granular identity type (field index 10) is `AD Users`, that value is a user identity, not a hostname.

### Change
In the DNS `[MODEL: dataset = cisco_umbrella_raw]` block:
- Map field 1 to `xdm.source.user.username` when field 10 == `AD Users`.
- Keep mapping field 1 to `xdm.source.host.hostname` otherwise (preserves existing behavior for non-AD-Users identities such as roaming clients / network devices).

Proxy and Admin Audit blocks are unchanged.

### Files
- `ModelingRules/.../Cisco-umbrella-cloud-security.xif` - conditional mapping
- `pack_metadata.json` - version bump 2.0.19 -> 2.0.20
- `ReleaseNotes/2_0_20.md` - release note
