### PR TITLE
Fix category name in PAN_DB_URL_FILTERING_CATEGORIES

### DIFF
--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -204,7 +204,7 @@ PAN_DB_URL_FILTERING_CATEGORIES = {
     "home-and-garden",
     "hunting-and-fishing",
     "insufficient-content",
-    "internet-Communications-and-telephony",
+    "internet-communications-and-telephony",
     "internet-portals",
     "job-search",
     "legal",

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
@@ -10661,7 +10661,7 @@ script:
     - contextPath: Panorama.Certificate.devices_using_certificate
       type: Unknown
       description: List of devices using this certificate if it was pushed from Panorama.
-  dockerimage: demisto/pan-os-python:1.0.0.6975992
+  dockerimage: demisto/pan-os-python:1.0.0.10133006
   isfetch: true
   runonce: false
   script: ''

--- a/Packs/PAN-OS/ReleaseNotes/2_6_35.md
+++ b/Packs/PAN-OS/ReleaseNotes/2_6_35.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Palo Alto Networks PAN-OS
+
+- Fixed an issue where ***pan-os-get-url-category*** failed to recognize URL categories due to a case-sensitivity mismatch.

--- a/Packs/PAN-OS/ReleaseNotes/2_6_35.md
+++ b/Packs/PAN-OS/ReleaseNotes/2_6_35.md
@@ -4,3 +4,4 @@
 ##### Palo Alto Networks PAN-OS
 
 - Fixed an issue where ***pan-os-get-url-category*** failed to recognize URL categories due to a case-sensitivity mismatch.
+- Updated the Docker image to: *demisto/pan-os-python:1.0.0.10133006*.

--- a/Packs/PAN-OS/pack_metadata.json
+++ b/Packs/PAN-OS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "PAN-OS by Palo Alto Networks",
     "description": "Manage Palo Alto Networks Firewall and Panorama. Use this pack to manage Prisma Access through Panorama. For more information see Panorama documentation.",
     "support": "xsoar",
-    "currentVersion": "2.6.34",
+    "currentVersion": "2.6.35",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-70858

## Description
Fixed an issue where the pan-os-get-url-category command failed to recognize certain URL categories due to a case-sensitivity mismatch.