### PR TITLE
Add use_streaming_send feature flag to send_data_to_xsiam (default off)

### DIFF
--- a/Packs/Base/ReleaseNotes/1_41_93.md
+++ b/Packs/Base/ReleaseNotes/1_41_93.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### CommonServerPython
+
+- Internal code improvements.

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -12863,7 +12863,8 @@ def split_data_to_chunks(data, target_chunk_size):
 
 def send_events_to_xsiam(events, vendor, product, data_format=None, url_key='url', num_of_attempts=3,
                          chunk_size=XSIAM_EVENT_CHUNK_SIZE, should_update_health_module=True,
-                         add_proxy_to_request=False, multiple_threads=False, client_class=None):
+                         add_proxy_to_request=False, multiple_threads=False, client_class=None,
+                         use_streaming_send=False):
     """
     Send the fetched events into the XDR data-collector private api.
 
@@ -12903,6 +12904,12 @@ def send_events_to_xsiam(events, vendor, product, data_format=None, url_key='url
     :type client_class: ``BaseClient``
     :param client_class: The client class to use for the request.
 
+    :type use_streaming_send: ``bool``
+    :param use_streaming_send: Feature flag (default False). When True, serializes+gzips the events one at a time
+        (streaming, free-as-you-go) instead of building intermediate full copies of the batch, drastically lowering
+        peak memory for large batches. The bytes sent to XSIAM are identical. Opt-in per integration during rollout
+        (CIAC-16981). Falls back to the legacy path when multiple_threads=True.
+
     :return: Either None if running in a single thread or a list of future objects if running in multiple threads.
     In case of running with multiple threads, the list of futures will hold the number of events sent and can be accessed by:
     for future in concurrent.futures.as_completed(futures):
@@ -12921,7 +12928,8 @@ def send_events_to_xsiam(events, vendor, product, data_format=None, url_key='url
         should_update_health_module=should_update_health_module,
         add_proxy_to_request=add_proxy_to_request,
         multiple_threads=multiple_threads,
-        client_class=client_class if client_class else BaseClient
+        client_class=client_class if client_class else BaseClient,
+        use_streaming_send=use_streaming_send,
     )
 
 
@@ -13035,7 +13043,7 @@ def has_passed_time_threshold(timestamp_str, seconds_threshold):
 def send_data_to_xsiam(data, vendor, product, data_format=None, url_key='url', num_of_attempts=3,
                        chunk_size=XSIAM_EVENT_CHUNK_SIZE, data_type=EVENTS, should_update_health_module=True,
                        add_proxy_to_request=False, snapshot_id='', items_count=None, multiple_threads=False,
-                       client_class=None):
+                       client_class=None, use_streaming_send=False):
     """
     Send the supported fetched data types into the XDR data-collector private api.
 
@@ -13086,6 +13094,13 @@ def send_data_to_xsiam(data, vendor, product, data_format=None, url_key='url', n
     :type client_class: ``BaseClient``
     :param client_class: The client class to use for the request.
 
+    :type use_streaming_send: ``bool``
+    :param use_streaming_send: Feature flag (default False). When True, the data is serialized and gzipped one item at a
+        time (streaming, free-as-you-go) instead of materializing intermediate full copies of the whole batch (a list of
+        JSON strings, then one big joined string). This keeps peak memory ~flat regardless of batch size; the gzipped
+        bytes sent to XSIAM are equivalent to the legacy path. Opt-in per integration during the CIAC-16981 rollout.
+        Ignored (legacy path used) when multiple_threads=True or when data is already a raw string.
+
     :return: Either None if running in a single thread or a list of future objects if running in multiple threads.
     In case of running with multiple threads, the list of futures will hold the number of events sent and can be accessed by:
     for future in concurrent.futures.as_completed(futures):
@@ -13110,9 +13125,19 @@ def send_data_to_xsiam(data, vendor, product, data_format=None, url_key='url', n
         demisto.updateModuleHealth({'{data_type}Pulled'.format(data_type=data_type): data_size})
         return
 
+    # Feature flag (CIAC-16981): stream-serialize the batch one item at a time instead of building
+    # intermediate full copies (a list of JSON strings + one giant joined string). Only applies to the
+    # list-of-items, single-thread path; the bytes sent to XSIAM are equivalent to the legacy path.
+    streaming_send = bool(use_streaming_send) and isinstance(data, list) and not multiple_threads
+    if streaming_send and data and isinstance(data[0], dict):
+        data_format = 'json'
+
     # only in case we have data to send to XSIAM we continue with this flow.
     # Correspond to case 1: List of strings or dicts where each string or dict represents an one event or asset or snapshot.
-    if isinstance(data, list):
+    if streaming_send:
+        # Keep `data` as the list; it will be serialized+gzipped item-by-item below (no full-batch copies).
+        demisto.debug("Sending {size} {data_type} to XSIAM (streaming send)".format(size=len(data), data_type=data_type))
+    elif isinstance(data, list):
         # In case we have list of dicts we set the data_format to json and parse each dict to a stringify each dict.
         demisto.debug("Sending {size} {data_type} to XSIAM".format(size=len(data), data_type=data_type))
         if isinstance(data[0], dict):
@@ -13181,6 +13206,54 @@ def send_data_to_xsiam(data, vendor, product, data_format=None, url_key='url', n
     if client_class is None:
         client_class = BaseClient
     client = client_class(base_url=xsiam_url, proxy=add_proxy_to_request)
+
+    if streaming_send:
+        # Streaming path (CIAC-16981, "Method F" - streaming + free-as-you-go): serialize each item and write it
+        # STRAIGHT INTO the gzip stream one at a time, freeing the source item immediately. We never build a second
+        # full list of JSON strings nor one giant joined string - at any moment only a single event is uncompressed
+        # (plus the small, growing compressed buffer). When a chunk reaches ~chunk_size (uncompressed bytes), we
+        # close that gzip stream, POST it, and open a fresh one. `data` (the source list) is drained as we go.
+        target_chunk_size = min(chunk_size, XSIAM_EVENT_CHUNK_SIZE_LIMIT)
+        demisto.info("Sending events to xsiam with a single thread (streaming, free-as-you-go).")
+
+        def _post_zipped(zipped_data):
+            xsiam_api_call_with_retries(client=client, events_error_handler=data_error_handler,
+                                        error_msg=header_msg, headers=headers,
+                                        num_of_attempts=num_of_attempts, xsiam_url=xsiam_url,
+                                        zipped_data=zipped_data, is_json_response=True, data_type=data_type)
+
+        buf = _io.BytesIO()
+        gz = gzip.GzipFile(fileobj=buf, mode='wb')
+        chunk_uncompressed = 0   # uncompressed bytes written into the current gzip stream
+        chunk_items = 0          # items written into the current gzip stream
+        total_items = len(data)
+        for index in range(total_items):
+            item = data[index]
+            line = (json.dumps(item) if isinstance(item, dict) else item).encode('utf-8')
+            data[index] = None  # free the source item the moment it is serialized (keeps peak ~one event)
+            # newline-separate items, matching the legacy payload ('\n'.join(...))
+            gz.write((b'\n' if chunk_items else b'') + line)
+            chunk_uncompressed += len(line) + (1 if chunk_items else 0)
+            chunk_items += 1
+            if chunk_uncompressed >= target_chunk_size:
+                # finalize this chunk, send it, and start a fresh gzip stream
+                gz.close()
+                _post_zipped(buf.getvalue())
+                data_size += chunk_items
+                buf = _io.BytesIO()
+                gz = gzip.GzipFile(fileobj=buf, mode='wb')
+                chunk_uncompressed = 0
+                chunk_items = 0
+        # flush the final (partial) chunk
+        gz.close()
+        if chunk_items:
+            _post_zipped(buf.getvalue())
+            data_size += chunk_items
+
+        if should_update_health_module:
+            demisto.updateModuleHealth({'{data_type}Pulled'.format(data_type=data_type): data_size})
+        return
+
     data_chunks = split_data_to_chunks(data, chunk_size)
 
     def send_events(data_chunk):

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -13204,7 +13204,7 @@ def send_data_to_xsiam(data, vendor, product, data_format=None, url_key='url', n
     client = client_class(base_url=xsiam_url, proxy=add_proxy_to_request)
 
     if streaming_send:
-        # Streaming path (CIAC-16981, "Method F"): serialize+gzip one event at a time, freeing each as we go, so peak
+        # Streaming path: serialize+gzip one event at a time, freeing each as we go, so peak
         # memory stays ~flat. At the target chunk size we close the stream, POST it, and open a fresh one.
         target_chunk_size = min(chunk_size, XSIAM_EVENT_CHUNK_SIZE_LIMIT)
         demisto.info("Sending events to xsiam with a single thread (streaming, free-as-you-go).")

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -13129,7 +13129,10 @@ def send_data_to_xsiam(data, vendor, product, data_format=None, url_key='url', n
     # intermediate full copies (a list of JSON strings + one giant joined string). Only applies to the
     # list-of-items, single-thread path; the bytes sent to XSIAM are equivalent to the legacy path.
     streaming_send = bool(use_streaming_send) and isinstance(data, list) and not multiple_threads
-    if streaming_send and data and isinstance(data[0], dict):
+    # Decide JSON-encoding once based on the first item, exactly like the legacy list path, so the streaming
+    # payload is identical (the legacy path json.dumps every item iff data[0] is a dict).
+    streaming_items_are_json = streaming_send and bool(data) and isinstance(data[0], dict)
+    if streaming_items_are_json:
         data_format = 'json'
 
     # only in case we have data to send to XSIAM we continue with this flow.
@@ -13208,11 +13211,11 @@ def send_data_to_xsiam(data, vendor, product, data_format=None, url_key='url', n
     client = client_class(base_url=xsiam_url, proxy=add_proxy_to_request)
 
     if streaming_send:
-        # Streaming path (CIAC-16981, "Method F" - streaming + free-as-you-go): serialize each item and write it
-        # STRAIGHT INTO the gzip stream one at a time, freeing the source item immediately. We never build a second
+        # Streaming path (CIAC-16981, "Method F"): serialize each event and write it straight into the gzip stream
+        # one at a time, freeing the source item immediately. Unlike the legacy path this never materializes a second
         # full list of JSON strings nor one giant joined string - at any moment only a single event is uncompressed
-        # (plus the small, growing compressed buffer). When a chunk reaches ~chunk_size (uncompressed bytes), we
-        # close that gzip stream, POST it, and open a fresh one. `data` (the source list) is drained as we go.
+        # (plus the growing compressed buffer), so peak memory stays ~flat regardless of batch size. When a chunk
+        # reaches the target size we close the stream, POST it, and start a fresh one; the wire payload is equivalent.
         target_chunk_size = min(chunk_size, XSIAM_EVENT_CHUNK_SIZE_LIMIT)
         demisto.info("Sending events to xsiam with a single thread (streaming, free-as-you-go).")
 
@@ -13224,19 +13227,27 @@ def send_data_to_xsiam(data, vendor, product, data_format=None, url_key='url', n
 
         buf = _io.BytesIO()
         gz = gzip.GzipFile(fileobj=buf, mode='wb')
-        chunk_uncompressed = 0   # uncompressed bytes written into the current gzip stream
-        chunk_items = 0          # items written into the current gzip stream
-        total_items = len(data)
-        for index in range(total_items):
-            item = data[index]
-            line = (json.dumps(item) if isinstance(item, dict) else item).encode('utf-8')
-            data[index] = None  # free the source item the moment it is serialized (keeps peak ~one event)
-            # newline-separate items, matching the legacy payload ('\n'.join(...))
-            gz.write((b'\n' if chunk_items else b'') + line)
+        chunk_uncompressed = 0  # uncompressed bytes written into the current gzip stream
+        chunk_items = 0         # items written into the current gzip stream
+
+        for index in range(len(data)):
+            serialized = json.dumps(data[index]) if streaming_items_are_json else data[index]
+            data[index] = None  # free the source item as soon as it is serialized (keeps peak ~one event)
+
+            # Match legacy split_data_to_chunks: skip and log any single entry larger than the allowed size,
+            # measuring with sys.getsizeof on the serialized string exactly as the legacy path does.
+            entry_size = sys.getsizeof(serialized)
+            if entry_size >= MAX_ALLOWED_ENTRY_SIZE:
+                demisto.error("entry size {size} is larger than the maximum allowed entry size {max_size}, "
+                              "skipping this entry".format(size=entry_size, max_size=MAX_ALLOWED_ENTRY_SIZE))
+                continue
+
+            line = serialized.encode('utf-8')
+            gz.write((b'\n' if chunk_items else b'') + line)  # newline-separate items, like legacy '\n'.join(...)
             chunk_uncompressed += len(line) + (1 if chunk_items else 0)
             chunk_items += 1
+
             if chunk_uncompressed >= target_chunk_size:
-                # finalize this chunk, send it, and start a fresh gzip stream
                 gz.close()
                 _post_zipped(buf.getvalue())
                 data_size += chunk_items
@@ -13244,6 +13255,7 @@ def send_data_to_xsiam(data, vendor, product, data_format=None, url_key='url', n
                 gz = gzip.GzipFile(fileobj=buf, mode='wb')
                 chunk_uncompressed = 0
                 chunk_items = 0
+
         # flush the final (partial) chunk
         gz.close()
         if chunk_items:

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -12905,10 +12905,9 @@ def send_events_to_xsiam(events, vendor, product, data_format=None, url_key='url
     :param client_class: The client class to use for the request.
 
     :type use_streaming_send: ``bool``
-    :param use_streaming_send: Feature flag (default False). When True, serializes+gzips the events one at a time
-        (streaming, free-as-you-go) instead of building intermediate full copies of the batch, drastically lowering
-        peak memory for large batches. The bytes sent to XSIAM are identical. Opt-in per integration during rollout
-        (CIAC-16981). Falls back to the legacy path when multiple_threads=True.
+    :param use_streaming_send: Feature flag (default False). When True, serializes and gzips the data one item at a time
+        (streaming) instead of building full copies of the whole batch, keeping peak memory ~flat; the bytes sent to
+        XSIAM are equivalent to the legacy path. Ignored when multiple_threads=True or when data is already a raw string.
 
     :return: Either None if running in a single thread or a list of future objects if running in multiple threads.
     In case of running with multiple threads, the list of futures will hold the number of events sent and can be accessed by:
@@ -13095,11 +13094,9 @@ def send_data_to_xsiam(data, vendor, product, data_format=None, url_key='url', n
     :param client_class: The client class to use for the request.
 
     :type use_streaming_send: ``bool``
-    :param use_streaming_send: Feature flag (default False). When True, the data is serialized and gzipped one item at a
-        time (streaming, free-as-you-go) instead of materializing intermediate full copies of the whole batch (a list of
-        JSON strings, then one big joined string). This keeps peak memory ~flat regardless of batch size; the gzipped
-        bytes sent to XSIAM are equivalent to the legacy path. Opt-in per integration during the CIAC-16981 rollout.
-        Ignored (legacy path used) when multiple_threads=True or when data is already a raw string.
+    :param use_streaming_send: Feature flag (default False). When True, serializes and gzips the data one item at a time
+        (streaming) instead of building full copies of the whole batch, keeping peak memory ~flat; the bytes sent to
+        XSIAM are equivalent to the legacy path. Ignored when multiple_threads=True or when data is already a raw string.
 
     :return: Either None if running in a single thread or a list of future objects if running in multiple threads.
     In case of running with multiple threads, the list of futures will hold the number of events sent and can be accessed by:
@@ -13125,12 +13122,9 @@ def send_data_to_xsiam(data, vendor, product, data_format=None, url_key='url', n
         demisto.updateModuleHealth({'{data_type}Pulled'.format(data_type=data_type): data_size})
         return
 
-    # Feature flag (CIAC-16981): stream-serialize the batch one item at a time instead of building
-    # intermediate full copies (a list of JSON strings + one giant joined string). Only applies to the
-    # list-of-items, single-thread path; the bytes sent to XSIAM are equivalent to the legacy path.
+    # Feature flag (CIAC-16981): stream-serialize one item at a time (list-of-items, single-thread path only).
     streaming_send = bool(use_streaming_send) and isinstance(data, list) and not multiple_threads
-    # Decide JSON-encoding once based on the first item, exactly like the legacy list path, so the streaming
-    # payload is identical (the legacy path json.dumps every item iff data[0] is a dict).
+    # Decide JSON-encoding once on the first item, like the legacy list path, so the payload is identical.
     streaming_items_are_json = streaming_send and bool(data) and isinstance(data[0], dict)
     if streaming_items_are_json:
         data_format = 'json'
@@ -13138,7 +13132,6 @@ def send_data_to_xsiam(data, vendor, product, data_format=None, url_key='url', n
     # only in case we have data to send to XSIAM we continue with this flow.
     # Correspond to case 1: List of strings or dicts where each string or dict represents an one event or asset or snapshot.
     if streaming_send:
-        # Keep `data` as the list; it will be serialized+gzipped item-by-item below (no full-batch copies).
         demisto.debug("Sending {size} {data_type} to XSIAM (streaming send)".format(size=len(data), data_type=data_type))
     elif isinstance(data, list):
         # In case we have list of dicts we set the data_format to json and parse each dict to a stringify each dict.
@@ -13211,11 +13204,8 @@ def send_data_to_xsiam(data, vendor, product, data_format=None, url_key='url', n
     client = client_class(base_url=xsiam_url, proxy=add_proxy_to_request)
 
     if streaming_send:
-        # Streaming path (CIAC-16981, "Method F"): serialize each event and write it straight into the gzip stream
-        # one at a time, freeing the source item immediately. Unlike the legacy path this never materializes a second
-        # full list of JSON strings nor one giant joined string - at any moment only a single event is uncompressed
-        # (plus the growing compressed buffer), so peak memory stays ~flat regardless of batch size. When a chunk
-        # reaches the target size we close the stream, POST it, and start a fresh one; the wire payload is equivalent.
+        # Streaming path (CIAC-16981, "Method F"): serialize+gzip one event at a time, freeing each as we go, so peak
+        # memory stays ~flat. At the target chunk size we close the stream, POST it, and open a fresh one.
         target_chunk_size = min(chunk_size, XSIAM_EVENT_CHUNK_SIZE_LIMIT)
         demisto.info("Sending events to xsiam with a single thread (streaming, free-as-you-go).")
 

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -9558,6 +9558,50 @@ class TestSendEventsToXSIAMTest:
         send_data_to_xsiam(data=[], vendor='v', product='p', data_type='events', use_streaming_send=True)
         assert http_mock.call_count == 0
 
+    def test_send_data_to_xsiam_streaming_skips_oversized_entry_like_legacy(self, mocker):
+        """
+        Given: a list of events where one single entry exceeds MAX_ALLOWED_ENTRY_SIZE.
+        When:  calling send_data_to_xsiam with use_streaming_send=False (legacy) and True (streaming).
+        Then:  both paths skip the oversized entry and send exactly the same remaining lines, so the
+               streaming path is as safe/reliable as the legacy path for this edge case.
+        """
+        if not IS_PY3:
+            return
+        from CommonServerPython import BaseClient, MAX_ALLOWED_ENTRY_SIZE
+        from requests import Response
+
+        mocker.patch.object(demisto, 'getLicenseCustomField', side_effect=self.get_license_custom_field_mock)
+        mocker.patch.object(demisto, 'updateModuleHealth')
+        mocker.patch.object(demisto, 'params', return_value={'url': 'some-url'})
+        mocker.patch.object(demisto, 'error')
+
+        api_response = Response()
+        api_response.status_code = 200
+        api_response._content = json.dumps({'error': 'false'}).encode('utf-8')
+
+        # One oversized entry (a long string > MAX_ALLOWED_ENTRY_SIZE) surrounded by normal events.
+        oversized = 'x' * (MAX_ALLOWED_ENTRY_SIZE + 1000)
+        events = [{'id': 0, 'msg': 'first'}, oversized, {'id': 1, 'msg': 'second'}]
+
+        legacy_mock = mocker.patch.object(BaseClient, '_http_request', return_value=api_response)
+        send_data_to_xsiam(data=list(events), vendor='v', product='p',
+                           data_type='events', use_streaming_send=False)
+        legacy_lines = []
+        for call in legacy_mock.call_args_list:
+            legacy_lines.extend(gzip.decompress(call[1]['data']).decode('utf-8').split('\n'))
+
+        streaming_mock = mocker.patch.object(BaseClient, '_http_request', return_value=api_response)
+        send_data_to_xsiam(data=list(events), vendor='v', product='p',
+                           data_type='events', use_streaming_send=True)
+        streaming_lines = []
+        for call in streaming_mock.call_args_list:
+            streaming_lines.extend(gzip.decompress(call[1]['data']).decode('utf-8').split('\n'))
+
+        # Both paths drop the oversized entry and keep the two normal events, identically.
+        assert sorted(streaming_lines) == sorted(legacy_lines)
+        assert oversized not in streaming_lines
+        assert len(streaming_lines) == 2
+
     @pytest.mark.parametrize('data_type, snapshot_id, items_count, expected', [
         ('assets', None, None, {'snapshot_id': '123000', 'items_count': '2'}),
         ('assets', '12345', 25, {'snapshot_id': '12345', 'items_count': '25'})

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -9579,9 +9579,12 @@ class TestSendEventsToXSIAMTest:
         api_response.status_code = 200
         api_response._content = json.dumps({'error': 'false'}).encode('utf-8')
 
-        # One oversized entry (a long string > MAX_ALLOWED_ENTRY_SIZE) surrounded by normal events.
-        oversized = 'x' * (MAX_ALLOWED_ENTRY_SIZE + 1000)
-        events = [{'id': 0, 'msg': 'first'}, oversized, {'id': 1, 'msg': 'second'}]
+        # One oversized event (its serialized form exceeds MAX_ALLOWED_ENTRY_SIZE) between two normal events.
+        events = [
+            {'id': 0, 'msg': 'first'},
+            {'id': 1, 'blob': 'x' * (MAX_ALLOWED_ENTRY_SIZE + 1000)},
+            {'id': 2, 'msg': 'second'},
+        ]
 
         legacy_mock = mocker.patch.object(BaseClient, '_http_request', return_value=api_response)
         send_data_to_xsiam(data=list(events), vendor='v', product='p',
@@ -9597,10 +9600,10 @@ class TestSendEventsToXSIAMTest:
         for call in streaming_mock.call_args_list:
             streaming_lines.extend(gzip.decompress(call[1]['data']).decode('utf-8').split('\n'))
 
-        # Both paths drop the oversized entry and keep the two normal events, identically.
+        # Both paths drop the oversized event and keep the two normal events, identically.
         assert sorted(streaming_lines) == sorted(legacy_lines)
-        assert oversized not in streaming_lines
         assert len(streaming_lines) == 2
+        assert all('blob' not in line for line in streaming_lines)
 
     @pytest.mark.parametrize('data_type, snapshot_id, items_count, expected', [
         ('assets', None, None, {'snapshot_id': '123000', 'items_count': '2'}),

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -9500,6 +9500,64 @@ class TestSendEventsToXSIAMTest:
             assert arguments_called['headers']['snapshot-id'] == '123000'
             assert arguments_called['headers']['total-items-count'] == '2'
 
+    @pytest.mark.parametrize('chunk_size', [2 ** 20, 50])
+    def test_send_data_to_xsiam_streaming_matches_legacy(self, mocker, chunk_size):
+        """
+        Given: a list of dict events.
+        When:  calling send_data_to_xsiam with use_streaming_send=False (legacy) and True (streaming),
+               including a small chunk_size to force multiple chunks.
+        Then:  the union of decompressed lines sent to XSIAM is identical between the two paths
+               (same events, same JSON, same newline separation), and the reported count matches.
+        """
+        if not IS_PY3:
+            return
+        from CommonServerPython import BaseClient
+        from requests import Response
+
+        mocker.patch.object(demisto, 'getLicenseCustomField', side_effect=self.get_license_custom_field_mock)
+        mocker.patch.object(demisto, 'updateModuleHealth')
+        mocker.patch.object(demisto, 'params', return_value={'url': 'some-url'})
+
+        api_response = Response()
+        api_response.status_code = 200
+        api_response._content = json.dumps({'error': 'false'}).encode('utf-8')
+
+        events = [{'id': i, 'msg': 'event number {}'.format(i)} for i in range(25)]
+
+        # legacy path
+        legacy_mock = mocker.patch.object(BaseClient, '_http_request', return_value=api_response)
+        send_data_to_xsiam(data=list(events), vendor='v', product='p', chunk_size=chunk_size,
+                           data_type='events', use_streaming_send=False)
+        legacy_lines = []
+        for call in legacy_mock.call_args_list:
+            legacy_lines.extend(gzip.decompress(call[1]['data']).decode('utf-8').split('\n'))
+
+        # streaming path
+        streaming_mock = mocker.patch.object(BaseClient, '_http_request', return_value=api_response)
+        send_data_to_xsiam(data=list(events), vendor='v', product='p', chunk_size=chunk_size,
+                           data_type='events', use_streaming_send=True)
+        streaming_lines = []
+        for call in streaming_mock.call_args_list:
+            streaming_lines.extend(gzip.decompress(call[1]['data']).decode('utf-8').split('\n'))
+
+        # same content (order-independent: same set of serialized events)
+        assert sorted(streaming_lines) == sorted(legacy_lines)
+        assert len(streaming_lines) == len(events)
+        # streaming reports the same total count to the health module
+        demisto.updateModuleHealth.assert_called_with({'eventsPulled': len(events)})
+
+    def test_send_data_to_xsiam_streaming_empty(self, mocker):
+        """Streaming path with an empty list makes no HTTP call and reports 0."""
+        if not IS_PY3:
+            return
+        from CommonServerPython import BaseClient
+        mocker.patch.object(demisto, 'getLicenseCustomField', side_effect=self.get_license_custom_field_mock)
+        mocker.patch.object(demisto, 'updateModuleHealth')
+        mocker.patch.object(demisto, 'params', return_value={'url': 'some-url'})
+        http_mock = mocker.patch.object(BaseClient, '_http_request')
+        send_data_to_xsiam(data=[], vendor='v', product='p', data_type='events', use_streaming_send=True)
+        assert http_mock.call_count == 0
+
     @pytest.mark.parametrize('data_type, snapshot_id, items_count, expected', [
         ('assets', None, None, {'snapshot_id': '123000', 'items_count': '2'}),
         ('assets', '12345', 25, {'snapshot_id': '12345', 'items_count': '25'})

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.41.92",
+    "currentVersion": "1.41.93",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
Streams serialize+gzip one event at a time (free-as-you-go) instead of building full in-memory copies of the batch, lowering peak memory for large batches. Bytes sent to XSIAM are equivalent. Off by default; opt-in per integration via the use_streaming_send flag during rollout. Adds unit tests proving the streaming path sends the same content as the legacy path. Bumps Base to 1.41.93.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
<!-- To link a Jira ticket use fixes/related: link to the issue, for example fixes: CIAC-XXXX -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

## Must have
- [ ] Tests
- [ ] Documentation
