### PR TITLE
CRTX-257340 - populate _scope for Cribl WEC-XML Windows events

### DIFF
--- a/Packs/MicrosoftWindowsEvents/ParsingRules/MicrosoftWindowsEvents/MicrosoftWindowsEvents.xif
+++ b/Packs/MicrosoftWindowsEvents/ParsingRules/MicrosoftWindowsEvents/MicrosoftWindowsEvents.xif
@@ -7,5 +7,5 @@ filter to_string(time_created) ~= ".*\d{2}:\d{2}:\d{2}.*" AND provider_name not 
 | alter
     _time = if(subtract(tmp_get_time_created, tmp_get_time) < 0, to_timestamp(tmp_get_time_created), subtract(tmp_get_insert_time, tmp_get_time) < 0, to_timestamp(tmp_get_insert_time), to_timestamp(tmp_get_time))
 | alter
-    _scope = coalesce(_scope, event_data -> _scope, event_data -> scope)
+    _scope = coalesce(_scope, event_data -> _scope, event_data -> scope, arrayindex(regextract(_raw_log, "<_scope>([^<]+)<\/_scope>"), 0))
 | fields -tmp*;

--- a/Packs/MicrosoftWindowsEvents/ReleaseNotes/1_1_30.md
+++ b/Packs/MicrosoftWindowsEvents/ReleaseNotes/1_1_30.md
@@ -2,4 +2,4 @@
 
 ##### Microsoft Windows Events Parsing Rule
 
-Updated the parsing rule to populate the **_scope** field for Windows Event Logs forwarded via Cribl in **WEC-XML** format, where the SBAC `_scope` value is appended as a trailing `<_scope>` element after the closing `</Event>` tag (CRTX-257340 / XSUP-70435).
+Updated the parsing rule to populate the **_scope** field for Windows Event Logs forwarded via Cribl in **WEC-XML** format, where the SBAC `_scope` value is appended as a trailing `<_scope>` element after the closing `</Event>` tag.

--- a/Packs/MicrosoftWindowsEvents/ReleaseNotes/1_1_30.md
+++ b/Packs/MicrosoftWindowsEvents/ReleaseNotes/1_1_30.md
@@ -1,0 +1,5 @@
+#### Parsing Rules
+
+##### Microsoft Windows Events Parsing Rule
+
+Updated the parsing rule to populate the **_scope** field for Windows Event Logs forwarded via Cribl in **WEC-XML** format, where the SBAC `_scope` value is appended as a trailing `<_scope>` element after the closing `</Event>` tag (CRTX-257340 / XSUP-70435).

--- a/Packs/MicrosoftWindowsEvents/pack_metadata.json
+++ b/Packs/MicrosoftWindowsEvents/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Windows Event Logs",
     "description": "The Windows event log is a detailed record of system, security and application notifications stored by the Windows operating system.",
     "support": "xsoar",
-    "currentVersion": "1.1.29",
+    "currentVersion": "1.1.30",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CRTX-257340

## Description
Populate the `_scope` field for Windows Event Logs forwarded via **Cribl** in **WEC-XML** format (dataset `microsoft_windows_raw`).

For JSON/CEF (and Cribl "structured" events) `_scope` is a top-level field and is already mapped. For the WEC-XML path the SBAC `_scope` value is appended by Cribl as a trailing `<_scope>...</_scope>` element **after** the closing `</Event>` tag, so it lands neither at top level nor in `event_data` — the existing `coalesce(_scope, event_data -> _scope, event_data -> scope)` resolved to NULL.

This adds a final `coalesce` fallback that extracts `<_scope>` from `_raw_log`:
```
arrayindex(regextract(_raw_log, "<_scope>([^<]+)</_scope>"), 0)
```
It is the last coalesce arm, so structured-path events (already populated) are unaffected.

Verified on a live tenant: 1,723,168 WEC-XML rows with `_scope` NULL resolve to the expected scope value via this expression.

Pack version bumped to 1.1.30 with release note.