### PR TITLE
Set fromversion to 6.8.0; add Palo Alto tag

### DIFF
--- a/Packs/Koi/CONTRIBUTORS.json
+++ b/Packs/Koi/CONTRIBUTORS.json
@@ -1,0 +1,3 @@
+[
+  "Eric Partington"
+]

--- a/Packs/Koi/Integrations/Koi/Koi.yml
+++ b/Packs/Koi/Integrations/Koi/Koi.yml
@@ -990,7 +990,7 @@ script:
   isfetchevents: true
   isfetchevents:xsoar: false
   dockerimage: demisto/fastapi:0.125.0.9094740
-fromversion: 6.8.0
+fromversion: 6.10.0
 tests:
 - No tests (auto formatted)
 marketplaces:

--- a/Packs/Koi/Integrations/Koi/Koi.yml
+++ b/Packs/Koi/Integrations/Koi/Koi.yml
@@ -990,7 +990,7 @@ script:
   isfetchevents: true
   isfetchevents:xsoar: false
   dockerimage: demisto/fastapi:0.125.0.9094740
-fromversion: 8.2.0
+fromversion: 6.8.0
 tests:
 - No tests (auto formatted)
 marketplaces:

--- a/Packs/Koi/ReleaseNotes/1_2_2.md
+++ b/Packs/Koi/ReleaseNotes/1_2_2.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### KOI
+
+- Lowered the minimum supported version to 6.8.0 and added the *Palo Alto Networks Products* tag.

--- a/Packs/Koi/pack_metadata.json
+++ b/Packs/Koi/pack_metadata.json
@@ -10,7 +10,9 @@
     "categories": [
         "Endpoint"
     ],
-    "tags": [],
+    "tags": [
+        "Palo Alto Networks Products"
+    ],
     "useCases": [],
     "keywords": [
         "KOI",

--- a/Packs/Koi/pack_metadata.json
+++ b/Packs/Koi/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "KOI",
     "description": "KOI is an endpoint security platform that provides visibility and control over browser extensions, SaaS applications, and web-based threats.",
     "support": "xsoar",
-    "currentVersion": "1.2.1",
+    "currentVersion": "1.2.2",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
Lower Koi integration minimum fromversion from 8.2.0 to 6.8.0 to support older XSOAR instances. Add the "Palo Alto Networks Products" tag to pack metadata for better categorization. Files updated: Packs/Koi/Integrations/Koi/Koi.yml, Packs/Koi/pack_metadata.json.

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues


## Description
Lower Koi integration minimum fromversion from 8.2.0 to 6.8.0 to support older XSOAR instances. Add the "Palo Alto Networks Products" tag to pack metadata for better categorization. Files updated: Packs/Koi/Integrations/Koi/Koi.yml, Packs/Koi/pack_metadata.json.

## Must have
- [ ] Tests
- [ ] Documentation


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-17112