### PR TITLE
Wiz content pack v2.0.7: guard outgoing mirror resolve to Threat Detection issues only

### DIFF
--- a/Packs/Wiz/Integrations/Wiz/Wiz.py
+++ b/Packs/Wiz/Integrations/Wiz/Wiz.py
@@ -12,7 +12,7 @@ WIZ_API_LIMIT = 500  # limit number of returned records from the Wiz API
 MAX_NOTE_LENGTH = 1400  # Hard limit for issue note text length enforced by the Wiz API
 WIZ = "wiz"
 
-WIZ_VERSION = "1.6.0"
+WIZ_VERSION = "1.7.0"
 INTEGRATION_GUID = "8864e131-72db-4928-1293-e292f0ed699f"
 NOT_DEFINED = "Not Defined"
 
@@ -2460,15 +2460,11 @@ def resolve_issue(issue_id, resolution_reason, resolution_note):
     if not is_valid_id:
         return message
 
-    issue_object = _get_issue(issue_id, is_evidence=False)
-
-    nodes = (issue_object or {}).get("data", {}).get("issues", {}).get("nodes") or []
-    if not nodes:
+    issue_type = _get_issue_type(issue_id)
+    if issue_type is None:
         return f"Issue not found: {issue_id}"
 
-    issue_type = nodes[0].get("type")
-
-    if issue_type != "THREAT_DETECTION":
+    if issue_type != WizIssueType.THREAT_DETECTION:
         msg = (
             f"Only a Threat Detection Issue can be resolved.\n"
             f"Received an Issue of type {issue_type}.\n"
@@ -2574,6 +2570,42 @@ def _get_issue(issue_id, is_evidence=False):
     issue_response = checkAPIerrors(issue_query, issue_variables)
 
     return issue_response
+
+
+def _get_issue_type(issue_id):
+    """
+    Return the Wiz Issue `type` (e.g. THREAT_DETECTION, TOXIC_COMBINATION) for an
+    issue id, or None if the issue can't be found / has no type. Used to guard
+    status mutations that are only valid for certain issue types.
+    """
+    issue_object = _get_issue(issue_id, is_evidence=False)
+    if not isinstance(issue_object, dict):
+        return None
+    nodes = issue_object.get("data", {}).get("issues", {}).get("nodes") or []
+    if not nodes:
+        return None
+    return nodes[0].get("type")
+
+
+def _can_resolve_issue(issue_id):
+    """
+    Return True only when the issue may be manually set to RESOLVED in Wiz.
+
+    Only Threat Detection issues can be manually resolved; all other types
+    (Toxic Combination, Cloud Configuration, Attack Surface) auto-resolve when
+    the underlying problem is remediated, and the backend rejects an explicit
+    RESOLVED for them. The outgoing-mirror paths use this to skip the RESOLVED
+    push for non-Threat-Detection issues (letting Wiz auto-resolve) instead of
+    firing a mutation the backend will reject and silently swallowing the error.
+    """
+    issue_type = _get_issue_type(issue_id)
+    if issue_type != WizIssueType.THREAT_DETECTION:
+        demisto.info(
+            f"Skipping RESOLVED mirror for issue {issue_id}: type {issue_type} cannot be manually resolved "
+            f"(only Threat Detection issues can; other types auto-resolve when remediated)."
+        )
+        return False
+    return True
 
 
 def truncate_note(text):
@@ -3043,6 +3075,8 @@ def _mirror_status_to_wiz(issue_id, xsoar_status, delta, data=None):
 
     try:
         if status_lower in ("resolved", "done", "closed"):
+            if not _can_resolve_issue(issue_id):
+                return
             resolution_reason = _resolve_wiz_reason(delta, data) or DEFAULT_RESOLUTION_REASON
             reject_or_resolve_issue(issue_id, resolution_reason, "Status mirrored from Cortex XSOAR", "RESOLVED")
         elif status_lower in ("rejected",):
@@ -3063,6 +3097,8 @@ def _handle_incident_closed(remote_id, resolution_reason=None):
     reason = resolution_reason or DEFAULT_RESOLUTION_REASON
     demisto.debug(f"_handle_incident_closed: resolving {remote_id} with reason={reason}")
     try:
+        if not _can_resolve_issue(remote_id):
+            return
         reject_or_resolve_issue(remote_id, reason, "Resolved from Cortex XSOAR", "RESOLVED")
     except Exception as e:
         demisto.info(f"_handle_incident_closed: failed (may already be resolved): {e}")

--- a/Packs/Wiz/Integrations/Wiz/Wiz_test.py
+++ b/Packs/Wiz/Integrations/Wiz/Wiz_test.py
@@ -2370,6 +2370,27 @@ def test_mirror_status_to_wiz_resolved_non_threat_skipped_via_api(mock_check_api
 
 
 @patch("Wiz.reject_or_resolve_issue")
+@patch("Wiz._get_issue_type", return_value=None)
+def test_mirror_status_to_wiz_resolved_unknown_issue_skipped(mock_type, mock_resolve):
+    """When the issue type can't be resolved (issue not found → None), the mirror must NOT push RESOLVED."""
+    from Wiz import _mirror_status_to_wiz
+
+    _mirror_status_to_wiz("11111111-1111-1111-1111-111111111111", "resolved", {})
+
+    mock_resolve.assert_not_called()
+
+
+@patch("Wiz.checkAPIerrors")
+def test_get_issue_type_returns_none_when_not_found(mock_check_api):
+    """_get_issue_type returns None when the API responds with no matching nodes."""
+    from Wiz import _get_issue_type
+
+    mock_check_api.return_value = {"data": {"issues": {"nodes": [], "pageInfo": {"hasNextPage": False, "endCursor": ""}}}}
+
+    assert _get_issue_type("11111111-1111-1111-1111-111111111111") is None
+
+
+@patch("Wiz.reject_or_resolve_issue")
 @patch("Wiz._get_issue_type", return_value="TOXIC_COMBINATION")
 def test_mirror_status_to_wiz_rejected_non_threat_still_pushes(mock_type, mock_resolve):
     """The guard is RESOLVED-only: REJECTED is valid for any issue type and must still be pushed."""

--- a/Packs/Wiz/Integrations/Wiz/Wiz_test.py
+++ b/Packs/Wiz/Integrations/Wiz/Wiz_test.py
@@ -1866,9 +1866,10 @@ def test_mirror_limit_validation(mock_check_api, _mock_get_ctx, _mock_set_ctx, l
     assert call_variables["first"] == expected_first
 
 
+@patch("Wiz._get_issue_type", return_value="THREAT_DETECTION")
 @patch("Wiz.reject_or_resolve_issue")
-def test_handle_field_changes_status_resolved(mock_resolve):
-    """Test _handle_field_changes with resolved status"""
+def test_handle_field_changes_status_resolved(mock_resolve, _mock_type):
+    """Test _handle_field_changes with resolved status (Threat Detection issue is resolvable)"""
     from Wiz import _handle_field_changes
 
     mock_resolve.return_value = {}
@@ -1965,9 +1966,10 @@ def test_handle_field_changes_clear_due_date(mock_clear_due):
     mock_clear_due.assert_called_once_with(issue_id="11111111-1111-1111-1111-111111111111")
 
 
+@patch("Wiz._get_issue_type", return_value="THREAT_DETECTION")
 @patch("Wiz.reject_or_resolve_issue")
-def test_handle_incident_closed(mock_resolve):
-    """Test _handle_incident_closed resolves issue in Wiz"""
+def test_handle_incident_closed(mock_resolve, _mock_type):
+    """Test _handle_incident_closed resolves a Threat Detection issue in Wiz"""
     from Wiz import _handle_incident_closed
 
     mock_resolve.return_value = {}
@@ -2290,6 +2292,101 @@ def test_mirror_status_to_wiz_rejected_default_reason(mock_resolve):
     )
 
 
+# ===== Outgoing-mirror RESOLVED guard: only Threat Detection issues may be resolved =====
+
+
+def _issue_type_response(issue_type):
+    """Build a PULL_ISSUES_QUERY-shaped response carrying a single issue of the given type."""
+    return {
+        "data": {
+            "issues": {
+                "nodes": [{"id": "11111111-1111-1111-1111-111111111111", "type": issue_type}],
+                "pageInfo": {"hasNextPage": False, "endCursor": ""},
+            }
+        }
+    }
+
+
+@patch("Wiz.reject_or_resolve_issue")
+@patch("Wiz._get_issue_type", return_value="THREAT_DETECTION")
+def test_mirror_status_to_wiz_resolved_threat_detection(mock_type, mock_resolve):
+    """A mirrored 'resolved' on a Threat Detection issue DOES push RESOLVED to Wiz."""
+    from Wiz import _mirror_status_to_wiz
+
+    mock_resolve.return_value = {}
+    _mirror_status_to_wiz(
+        "11111111-1111-1111-1111-111111111111",
+        "resolved",
+        {"resolutionReason": "ISSUE_FIXED"},
+    )
+
+    mock_type.assert_called_once_with("11111111-1111-1111-1111-111111111111")
+    mock_resolve.assert_called_once_with(
+        "11111111-1111-1111-1111-111111111111", "ISSUE_FIXED", "Status mirrored from Cortex XSOAR", "RESOLVED"
+    )
+
+
+@patch("Wiz.reject_or_resolve_issue")
+@patch("Wiz._get_issue_type", return_value="TOXIC_COMBINATION")
+def test_mirror_status_to_wiz_resolved_non_threat_skipped(mock_type, mock_resolve):
+    """A mirrored 'resolved' on a non-Threat-Detection issue must NOT push RESOLVED to Wiz.
+
+    Regression for WZ-118281: previously the mirror fired RESOLVED for any type, the Wiz
+    backend rejected it ('changing to resolved status is not allowed'), and the error was
+    silently swallowed - leaving the Wiz issue open while the XSOAR incident closed.
+    """
+    from Wiz import _mirror_status_to_wiz
+
+    _mirror_status_to_wiz(
+        "11111111-1111-1111-1111-111111111111",
+        "resolved",
+        {"resolutionReason": "ISSUE_FIXED"},
+    )
+
+    mock_resolve.assert_not_called()
+
+
+@patch("Wiz.reject_or_resolve_issue")
+@patch("Wiz._get_issue_type", return_value="TOXIC_COMBINATION")
+def test_handle_incident_closed_non_threat_skipped(mock_type, mock_resolve):
+    """Closing an XSOAR incident mirrored to a non-Threat-Detection issue must NOT push RESOLVED."""
+    from Wiz import _handle_incident_closed
+
+    _handle_incident_closed("11111111-1111-1111-1111-111111111111")
+
+    mock_resolve.assert_not_called()
+
+
+@patch("Wiz.reject_or_resolve_issue")
+@patch("Wiz.checkAPIerrors")
+def test_mirror_status_to_wiz_resolved_non_threat_skipped_via_api(mock_check_api, mock_resolve):
+    """End-to-end guard through the real _get_issue_type: a TOXIC_COMBINATION lookup skips RESOLVED."""
+    from Wiz import _mirror_status_to_wiz
+
+    mock_check_api.return_value = _issue_type_response("TOXIC_COMBINATION")
+    _mirror_status_to_wiz("11111111-1111-1111-1111-111111111111", "resolved", {})
+
+    mock_resolve.assert_not_called()
+
+
+@patch("Wiz.reject_or_resolve_issue")
+@patch("Wiz._get_issue_type", return_value="TOXIC_COMBINATION")
+def test_mirror_status_to_wiz_rejected_non_threat_still_pushes(mock_type, mock_resolve):
+    """The guard is RESOLVED-only: REJECTED is valid for any issue type and must still be pushed."""
+    from Wiz import _mirror_status_to_wiz
+
+    mock_resolve.return_value = {}
+    _mirror_status_to_wiz(
+        "11111111-1111-1111-1111-111111111111",
+        "rejected",
+        {"resolutionReason": "FALSE_POSITIVE"},
+    )
+
+    mock_resolve.assert_called_once_with(
+        "11111111-1111-1111-1111-111111111111", "FALSE_POSITIVE", "Status mirrored from Cortex XSOAR", "REJECTED"
+    )
+
+
 # ===== GAP #3: _handle_field_changes with wizissueduedate key =====
 
 
@@ -2484,8 +2581,9 @@ def test_update_remote_system_close_explicit_reason_overrides_close_reason(mock_
     mock_closed.assert_called_once_with("11111111-1111-1111-1111-111111111111", resolution_reason="EXCEPTION")
 
 
+@patch("Wiz._get_issue_type", return_value="THREAT_DETECTION")
 @patch("Wiz.reject_or_resolve_issue")
-def test_mirror_status_to_wiz_resolved_uses_close_reason_fallback(mock_reject_resolve):
+def test_mirror_status_to_wiz_resolved_uses_close_reason_fallback(mock_reject_resolve, _mock_type):
     """_mirror_status_to_wiz on 'resolved' status path also respects the closeReason fallback."""
     from Wiz import _mirror_status_to_wiz
 

--- a/Packs/Wiz/ReleaseNotes/2_0_7.md
+++ b/Packs/Wiz/ReleaseNotes/2_0_7.md
@@ -2,4 +2,4 @@
 
 ##### Wiz
 
-- Fixed an issue where closing or resolving a mirrored incident in Cortex XSOAR attempted to resolve the linked Wiz Issue regardless of its type. Only Threat Detection Issues can be manually resolved; other Issue types (e.g., Toxic Combination, Cloud Configuration) auto-resolve once the underlying problem is remediated. The outgoing mirror now skips the resolve request for non-Threat-Detection Issues instead of sending a request the Wiz backend rejects.
+- Fixed an issue where closing or resolving a mirrored incident in Cortex XSOAR attempted to resolve the linked **Wiz** Issue regardless of its type. Only *Threat Detection* Issues can be manually resolved; other Issue types (e.g., *Toxic Combination*, *Cloud Configuration*) auto-resolve once the underlying problem is remediated. The outgoing mirror now skips the resolve request for non-*Threat Detection* Issues instead of sending a request the **Wiz** backend rejects.

--- a/Packs/Wiz/ReleaseNotes/2_0_7.md
+++ b/Packs/Wiz/ReleaseNotes/2_0_7.md
@@ -1,0 +1,5 @@
+#### Integrations
+
+##### Wiz
+
+- Fixed an issue where closing or resolving a mirrored incident in Cortex XSOAR attempted to resolve the linked Wiz Issue regardless of its type. Only Threat Detection Issues can be manually resolved; other Issue types (e.g., Toxic Combination, Cloud Configuration) auto-resolve once the underlying problem is remediated. The outgoing mirror now skips the resolve request for non-Threat-Detection Issues instead of sending a request the Wiz backend rejects.

--- a/Packs/Wiz/pack_metadata.json
+++ b/Packs/Wiz/pack_metadata.json
@@ -12,7 +12,9 @@
     ],
     "tags": [],
     "useCases": [],
-    "keywords": [],
+    "keywords": [
+        "Wiz"
+    ],
     "dependencies": {
         "Base": {
             "mandatory": true,
@@ -23,7 +25,9 @@
             "name": "Generic Webhook"
         }
     },
-    "githubUser": "ariel-wiz",
+    "githubUser": [
+        "ariel-wiz"
+    ],
     "defaultDataSource": "Wiz",
     "marketplaces": [
         "xsoar",

--- a/Packs/Wiz/pack_metadata.json
+++ b/Packs/Wiz/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Wiz",
     "description": "Integrate with Wiz for bidirectional Issue management, Detections investigation, and fetching of resource information. \n",
     "support": "partner",
-    "currentVersion": "2.0.6",
+    "currentVersion": "2.0.7",
     "author": "Wiz Inc.",
     "url": "https://wiz.io/",
     "email": "support@wiz.io",


### PR DESCRIPTION
## Contributor
@ariel-wiz

## Summary

Fixes a bidirectional-mirroring bug where closing or resolving a mirrored incident in Cortex XSOAR attempted to set the linked Wiz Issue to **RESOLVED** regardless of the Issue's type.

In Wiz, only **Threat Detection** Issues can be manually resolved; other types (Toxic Combination, Cloud Configuration, etc.) auto-resolve once the underlying problem is remediated, and the Wiz backend rejects an explicit RESOLVED for them (`changing to resolved status is not allowed`). The outgoing-mirror paths sent RESOLVED for any type and only debug/info-logged the resulting backend rejection — so the XSOAR incident closed while the Wiz Issue silently stayed open.

The explicit `wiz-resolve-issue` command already guarded against this; this change brings the outgoing-mirror paths to parity.

## Changes

- **`Wiz.py`**
  - New `_get_issue_type` helper (returns the Issue's `type`, or `None` if not found) and `_can_resolve_issue` guard (true only for `THREAT_DETECTION`).
  - `_mirror_status_to_wiz` and `_handle_incident_closed` now skip the RESOLVED push for non-Threat-Detection Issues (letting Wiz auto-resolve) instead of firing a mutation the backend rejects and swallowing the error. `REJECTED` is unaffected (valid for all types).
  - `resolve_issue` refactored to reuse `_get_issue_type` (no behavior change).
  - `WIZ_VERSION` 1.6.0 → 1.7.0.
- **`Wiz_test.py`** — unit tests for both mirror paths × both Issue types (Threat Detection resolves; non-Threat-Detection skips), the REJECTED-still-pushes case, and an end-to-end guard through the real `_get_issue_type`.
- **Release notes** `2_0_7.md`; pack version 2.0.6 → 2.0.7.

## Testing

- `pytest Wiz_test.py` — **259 passed**.
- `ruff check` — clean. `demisto-sdk format` / `demisto-sdk validate` — all validations passed.
- Deployed to a live XSOAR 6.14 instance; code-integrity diff confirmed deployed code == source (only SDK import-stripping).
- Cross-checked against the real Wiz API (`issuesV2`) on a live tenant, both Issue types:
  - Non-Threat-Detection (Toxic Combination): guard refuses, no `updateIssue` mutation sent — XSOAR-reported type matched API ground truth.
  - Threat Detection: guard allows; resolve succeeds and API confirms `status=RESOLVED` (restored to OPEN afterward).


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-17136
