### PR TITLE
fix(AbnormalSecurity): self-healing per-stream fetch checkpoints [INT-1959]

### DIFF
--- a/Packs/AbnormalSecurity/Integrations/AbnormalSecurity/AbnormalSecurity.py
+++ b/Packs/AbnormalSecurity/Integrations/AbnormalSecurity/AbnormalSecurity.py
@@ -65,6 +65,56 @@ def get_current_datetime() -> datetime:
     return datetime.utcnow().astimezone(timezone.utc)
 
 
+# Per-stream watermark keys persisted in last_run (see fetch_incidents).
+THREATS_LAST_FETCH = "threats_last_fetch"
+CAMPAIGNS_LAST_FETCH = "campaigns_last_fetch"
+CASES_LAST_FETCH = "cases_last_fetch"
+
+
+def _resolve_stream_watermark(last_run: dict[str, Any], stream_key: str, first_fetch_time: str) -> datetime:
+    """Resolve a stream's start watermark from last_run.
+
+    Precedence: the per-stream key, then the legacy ``last_fetch`` scalar (for instances
+    deployed before per-stream checkpoints existed), then ``first_fetch_time``.
+
+    Args:
+        last_run: The integration's last_run dict.
+        stream_key: One of THREATS_LAST_FETCH / CAMPAIGNS_LAST_FETCH / CASES_LAST_FETCH.
+        first_fetch_time: ISO-8601 fallback used on the very first fetch.
+
+    Returns:
+        The watermark as a tz-aware UTC datetime.
+    """
+    raw = last_run.get(stream_key) or last_run.get("last_fetch") or first_fetch_time
+    return _parse_iso_utc(raw)
+
+
+def _parse_iso_utc(value: str) -> datetime:
+    """Parse a trailing-``Z`` ISO-8601 string as a true UTC instant.
+
+    Watermarks are stored and re-read through this function so the serialize -> resolve
+    round-trip is stable (no local-timezone drift), keeping per-stream windows consistent
+    across fetch cycles.
+    """
+    text = value[:-1] if value.endswith("Z") else value
+    return datetime.fromisoformat(text).replace(tzinfo=timezone.utc)
+
+
+def _item_sort_key(item: dict[str, Any], timestamp_field: str) -> datetime:
+    """Return an item's sort timestamp, treating missing/unparseable values as oldest.
+
+    A watermark is only safe if items are processed oldest->newest, so we sort
+    defensively rather than trusting API ordering.
+    """
+    value = item.get(timestamp_field)
+    if not value:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    try:
+        return _parse_iso_utc(value)
+    except Exception:
+        return datetime.min.replace(tzinfo=timezone.utc)
+
+
 class FetchIncidentsError(Exception):
     """Raised when there's an error in fetching incidents."""
 
@@ -1306,7 +1356,18 @@ def download_message_eml_command(client, args):
     return results
 
 
-def generate_threat_incidents(client, threats, max_page_number, start_datetime, end_datetime):
+def generate_threat_incidents(client, threats, max_page_number, start_datetime, end_datetime, watermark=None):
+    """Generate threat incidents, advancing a per-stream watermark as items succeed.
+
+    Threats are processed in the order given (callers sort ascending by
+    ``latestTimeRemediated`` first). After each threat is fully processed the
+    watermark advances to that threat's ``latestTimeRemediated``. A skippable 4xx
+    skips the entity; a non-skippable error stops the stream WITHOUT advancing past
+    the failed item and WITHOUT raising, so already-processed progress is preserved.
+
+    Returns:
+        (incidents, watermark): incidents emitted and the latest safe watermark.
+    """
     incidents = []
     for threat in threats:
         page_number = 1
@@ -1329,7 +1390,10 @@ def generate_threat_incidents(client, threats, max_page_number, start_datetime, 
             if _is_skippable_error(e):
                 demisto.debug(f"Threat {threat['threatId']} returned a skippable error, skipping: {e}")
                 continue
-            raise
+            # Non-skippable (5xx / connection reset / 401/403/429): stop this stream,
+            # keep watermark at last good item, do not raise so progress persists.
+            demisto.error(f"Threat {threat['threatId']} returned a non-skippable error, stopping stream: {e}")
+            break
 
         # Skip if we didn't get any threat details (shouldn't happen but defensive)
         if threat_details is None:
@@ -1348,10 +1412,16 @@ def generate_threat_incidents(client, threats, max_page_number, start_datetime, 
             "rawJSON": json.dumps(threat_details) if threat_details else {},
         }
         incidents.append(incident)
-    return incidents
+        watermark = _advance_watermark(watermark, threat, "latestTimeRemediated")
+    return incidents, watermark
 
 
-def generate_abuse_campaign_incidents(client, campaigns):
+def generate_abuse_campaign_incidents(client, campaigns, watermark=None):
+    """Generate abuse-campaign incidents, advancing a per-stream watermark as items succeed.
+
+    See ``generate_threat_incidents`` for the watermark / non-skippable-error contract.
+    The watermark advances to each campaign's ``lastReportedTime``.
+    """
     incidents = []
     for campaign in campaigns:
         try:
@@ -1360,7 +1430,8 @@ def generate_abuse_campaign_incidents(client, campaigns):
             if _is_skippable_error(e):
                 demisto.debug(f"Campaign {campaign['campaignId']} returned a skippable error, skipping: {e}")
                 continue
-            raise
+            demisto.error(f"Campaign {campaign['campaignId']} returned a non-skippable error, stopping stream: {e}")
+            break
         first_reported = campaign_details.get("firstReported", "")
         incident = {
             "dbotMirrorId": str(campaign.get("campaignId", "")),
@@ -1370,10 +1441,16 @@ def generate_abuse_campaign_incidents(client, campaigns):
             "rawJSON": json.dumps(campaign_details) if campaign_details else {},
         }
         incidents.append(incident)
-    return incidents
+        watermark = _advance_watermark(watermark, campaign, "lastReportedTime")
+    return incidents, watermark
 
 
-def generate_account_takeover_cases_incidents(client, cases):
+def generate_account_takeover_cases_incidents(client, cases, watermark=None):
+    """Generate account-takeover-case incidents, advancing a per-stream watermark as items succeed.
+
+    See ``generate_threat_incidents`` for the watermark / non-skippable-error contract.
+    The watermark advances to each case's ``lastModifiedTime``.
+    """
     incidents = []
     for case in cases:
         try:
@@ -1382,7 +1459,8 @@ def generate_account_takeover_cases_incidents(client, cases):
             if _is_skippable_error(e):
                 demisto.debug(f"Case {case['caseId']} returned a skippable error, skipping: {e}")
                 continue
-            raise
+            demisto.error(f"Case {case['caseId']} returned a non-skippable error, stopping stream: {e}")
+            break
         incident = {
             "dbotMirrorId": str(case["caseId"]),
             "name": "Account Takeover Case",
@@ -1392,7 +1470,21 @@ def generate_account_takeover_cases_incidents(client, cases):
             "rawJSON": json.dumps(case_details) if case_details else {},
         }
         incidents.append(incident)
-    return incidents
+        watermark = _advance_watermark(watermark, case, "lastModifiedTime")
+    return incidents, watermark
+
+
+def _advance_watermark(current: datetime | None, item: dict[str, Any], timestamp_field: str) -> datetime | None:
+    """Advance a watermark to ``item[timestamp_field]`` if it is newer (never backwards).
+
+    If the item has no parseable timestamp the watermark is left unchanged.
+    """
+    item_time = _item_sort_key(item, timestamp_field)
+    if item_time == datetime.min.replace(tzinfo=timezone.utc):
+        return current
+    if current is None or item_time > current:
+        return item_time
+    return current
 
 
 def fetch_incidents(
@@ -1409,6 +1501,14 @@ def fetch_incidents(
     """
     Fetch incidents from various sources (threats, abuse campaigns, and account takeovers).
 
+    Each stream keeps its own watermark in ``last_run`` (``threats_last_fetch`` /
+    ``campaigns_last_fetch`` / ``cases_last_fetch``) so a transient (non-skippable)
+    failure in one stream mid-cycle does not force a full-window retry of the others
+    and never loses progress. A watermark advances only to the last successfully
+    processed item, so on the next run only un-processed items are re-queried.
+    Backward compatible: a missing per-stream key falls back to the legacy
+    ``last_fetch`` scalar, then to ``first_fetch_time``.
+
     Parameters:
     - client (Client): Client object to interact with the API.
     - last_run (Dict[str, Any]): Dictionary containing details about the last time incidents were fetched.
@@ -1418,52 +1518,68 @@ def fetch_incidents(
     - polling_lag (int, optional): Time in minutes to subtract from polling time window for data consistency. Defaults to 0.
 
     Returns:
-    - Tuple[Dict[str, str], List[Dict]]: Tuple containing a dictionary with the `last_fetch` time and a list of fetched incidents.
+    - Tuple[Dict[str, str], List[Dict]]: (next_run with per-stream watermarks, fetched incidents). Returned even on
+      partial failure so main() can persist progress via demisto.setLastRun.
     """
     try:
-        last_fetch = last_run.get("last_fetch", first_fetch_time)
-        last_fetch = datetime.fromisoformat(last_fetch[:-1]).astimezone(timezone.utc)
+        # Resolve each stream's start watermark independently (per-stream key, then legacy
+        # last_fetch, then first_fetch_time). These seed the returned next_run so a stream
+        # that fetches nothing keeps its prior watermark rather than skipping a window.
+        threats_wm = _resolve_stream_watermark(last_run, THREATS_LAST_FETCH, first_fetch_time)
+        campaigns_wm = _resolve_stream_watermark(last_run, CAMPAIGNS_LAST_FETCH, first_fetch_time)
+        cases_wm = _resolve_stream_watermark(last_run, CASES_LAST_FETCH, first_fetch_time)
 
-        current_datetime = get_current_datetime()
-        start_time = last_fetch + timedelta(milliseconds=1)  # Not to overlap with previous polling window
-        end_time = get_current_datetime()
-
-        if polling_lag is not None:
-            start_time = start_time - polling_lag
-            end_time = end_time - polling_lag
-
-        start_timestamp = start_time.strftime(ISO_8601_FORMAT)
+        if polling_lag is None:
+            polling_lag = timedelta(minutes=0)
+        end_time = get_current_datetime() - polling_lag
         end_timestamp = end_time.strftime(ISO_8601_FORMAT)
 
-        all_incidents = []
+        def _window(watermark: datetime) -> tuple[datetime, str]:
+            # start = watermark + 1ms (minus lag) so the boundary item is not re-emitted.
+            start = watermark + timedelta(milliseconds=1) - polling_lag
+            return start, start.strftime(ISO_8601_FORMAT)
+
+        all_incidents: list[dict] = []
         current_pending_incidents_to_fetch = max_incidents_to_fetch
         threat_incidents, abuse_campaign_incidents, account_takeover_cases_incidents = [], [], []
 
         if fetch_threats and current_pending_incidents_to_fetch > 0:
+            start_time, start_timestamp = _window(threats_wm)
             threats_filter = f"latestTimeRemediated gte {start_timestamp} and latestTimeRemediated lte {end_timestamp}"
             threats_response = client.get_paginated_threats_list(
                 filter_=threats_filter, max_incidents_to_fetch=current_pending_incidents_to_fetch
             )
-            threat_incidents = generate_threat_incidents(
-                client, threats_response.get("threats", []), max_page_number, start_time, end_time
+            threats = sorted(threats_response.get("threats", []), key=lambda t: _item_sort_key(t, "latestTimeRemediated"))
+            threat_incidents, threats_wm = generate_threat_incidents(
+                client, threats, max_page_number, start_time, end_time, watermark=threats_wm
             )
         current_pending_incidents_to_fetch -= len(threat_incidents)
 
         if fetch_abuse_campaigns and current_pending_incidents_to_fetch > 0:
+            _, start_timestamp = _window(campaigns_wm)
             abuse_campaigns_filter = f"lastReportedTime gte {start_timestamp} and lastReportedTime lte {end_timestamp}"
             abuse_campaigns_response = client.get_paginated_abusecampaigns_list(
                 filter_=abuse_campaigns_filter, max_incidents_to_fetch=current_pending_incidents_to_fetch
             )
-            abuse_campaign_incidents = generate_abuse_campaign_incidents(client, abuse_campaigns_response.get("campaigns", []))
+            campaigns = sorted(
+                abuse_campaigns_response.get("campaigns", []), key=lambda c: _item_sort_key(c, "lastReportedTime")
+            )
+            abuse_campaign_incidents, campaigns_wm = generate_abuse_campaign_incidents(
+                client, campaigns, watermark=campaigns_wm
+            )
         current_pending_incidents_to_fetch -= len(abuse_campaign_incidents)
 
         if fetch_account_takeover_cases and current_pending_incidents_to_fetch > 0:
+            _, start_timestamp = _window(cases_wm)
             account_takeover_cases_filter = f"lastModifiedTime gte {start_timestamp} and lastModifiedTime lte {end_timestamp}"
             account_takeover_cases_response = client.get_paginated_cases_list(
                 filter_=account_takeover_cases_filter, max_incidents_to_fetch=current_pending_incidents_to_fetch
             )
-            account_takeover_cases_incidents = generate_account_takeover_cases_incidents(
-                client, account_takeover_cases_response.get("cases", [])
+            cases = sorted(
+                account_takeover_cases_response.get("cases", []), key=lambda c: _item_sort_key(c, "lastModifiedTime")
+            )
+            account_takeover_cases_incidents, cases_wm = generate_account_takeover_cases_incidents(
+                client, cases, watermark=cases_wm
             )
 
         all_incidents = threat_incidents + abuse_campaign_incidents + account_takeover_cases_incidents
@@ -1471,7 +1587,11 @@ def fetch_incidents(
         logging.error(f"Failed fetching incidents: {e}")
         raise FetchIncidentsError(f"Error while fetching incidents: {e}")
 
-    next_run = {"last_fetch": current_datetime.strftime(ISO_8601_FORMAT)}
+    next_run = {
+        THREATS_LAST_FETCH: threats_wm.strftime(ISO_8601_FORMAT),
+        CAMPAIGNS_LAST_FETCH: campaigns_wm.strftime(ISO_8601_FORMAT),
+        CASES_LAST_FETCH: cases_wm.strftime(ISO_8601_FORMAT),
+    }
 
     return next_run, all_incidents[:max_incidents_to_fetch]
 

--- a/Packs/AbnormalSecurity/Integrations/AbnormalSecurity/AbnormalSecurity_test.py
+++ b/Packs/AbnormalSecurity/Integrations/AbnormalSecurity/AbnormalSecurity_test.py
@@ -545,7 +545,7 @@ def test_get_details_of_a_threat_request_two_pages(mocker):
     start_datetime = datetime(2023, 9, 17, 14, 43, 9, tzinfo=UTC)
     end_datetime = datetime(2023, 9, 18, 14, 43, 9, tzinfo=UTC)
 
-    incidents = generate_threat_incidents(client, [{"threatId": "asdf097sdf907"}], 2, start_datetime, end_datetime)
+    incidents, _ = generate_threat_incidents(client, [{"threatId": "asdf097sdf907"}], 2, start_datetime, end_datetime)
     assert len(incidents) == 1
     assert len(json.loads(incidents[0].get("rawJSON")).get("messages")) == 2
 
@@ -558,7 +558,7 @@ def test_get_details_of_a_threat_request_single_page(mocker):
     start_datetime = datetime(2023, 9, 17, 14, 43, 9, tzinfo=UTC)
     end_datetime = datetime(2023, 9, 18, 14, 43, 9, tzinfo=UTC)
 
-    incidents = generate_threat_incidents(client, [{"threatId": "asdf097sdf907"}], 1, start_datetime, end_datetime)
+    incidents, _ = generate_threat_incidents(client, [{"threatId": "asdf097sdf907"}], 1, start_datetime, end_datetime)
     assert len(incidents) == 1
 
 
@@ -664,7 +664,7 @@ def test_get_details_of_a_threat_request_time_window_filtering(mocker):
     start_datetime = datetime(2023, 9, 17, 14, 0, 0, tzinfo=UTC)
     end_datetime = datetime(2023, 9, 17, 17, 0, 0, tzinfo=UTC)
 
-    incidents = generate_threat_incidents(client, [{"threatId": "test-threat-id"}], 1, start_datetime, end_datetime)
+    incidents, _ = generate_threat_incidents(client, [{"threatId": "test-threat-id"}], 1, start_datetime, end_datetime)
 
     # Verify we get one incident
     assert len(incidents) == 1
@@ -727,7 +727,7 @@ def test_get_details_of_a_threat_request_early_exit(mocker):
     start_datetime = datetime(2023, 9, 17, 14, 0, 0, tzinfo=UTC)
     end_datetime = datetime(2023, 9, 17, 17, 0, 0, tzinfo=UTC)
 
-    incidents = generate_threat_incidents(client, [{"threatId": "test-threat-id"}], 3, start_datetime, end_datetime)
+    incidents, _ = generate_threat_incidents(client, [{"threatId": "test-threat-id"}], 3, start_datetime, end_datetime)
 
     # Verify we get one incident
     assert len(incidents) == 1
@@ -887,9 +887,12 @@ def test_pagination_methods_in_fetch_incidents(mocker):
     assert len(case_incidents) == len(case_ids)
     assert len(campaign_incidents) == len(campaign_ids)
 
-    # Verify next_run contains updated last_fetch timestamp
-    assert next_run.get("last_fetch", None) is not None
-    assert next_run.get("last_fetch") > last_run.get("last_fetch")
+    # Verify next_run carries per-stream watermarks. Cases/campaigns advance to their
+    # list-item timestamps; the threat template lacks latestTimeRemediated so its
+    # watermark holds at the resolved start (legacy last_fetch fallback) rather than skipping.
+    assert next_run.get("cases_last_fetch") > last_run.get("last_fetch")
+    assert next_run.get("campaigns_last_fetch") > last_run.get("last_fetch")
+    assert next_run.get("threats_last_fetch") == last_run.get("last_fetch")
 
 
 def test_get_paginated_threats_list(mocker):
@@ -1574,16 +1577,17 @@ def test_generate_threat_incidents_skips_4xx_error(mocker):
         {"threatId": "valid-threat-id"},
     ]
 
-    incidents = generate_threat_incidents(client, threats, 1, start_datetime, end_datetime)
+    incidents, _ = generate_threat_incidents(client, threats, 1, start_datetime, end_datetime)
 
     assert len(incidents) == 1
     assert incidents[0]["dbotMirrorId"] == "valid-threat-id"
 
 
 @pytest.mark.parametrize("status_code,reason", [(401, "Unauthorized"), (403, "Forbidden"), (429, "Too Many Requests")])
-def test_generate_threat_incidents_raises_non_skippable_errors(mocker, status_code, reason):
+def test_generate_threat_incidents_stops_on_non_skippable_errors(mocker, status_code, reason):
     """
-    Test that non-skippable errors (401, 403, 429) are re-raised.
+    Non-skippable errors (401/403/429) stop the stream WITHOUT raising, so progress on
+    already-processed items is preserved (the watermark must not advance past the failure).
     """
 
     def mock_get_details(threat_id, **kwargs):
@@ -1597,14 +1601,14 @@ def test_generate_threat_incidents_raises_non_skippable_errors(mocker, status_co
 
     threats = [{"threatId": "some-threat-id"}]
 
-    with pytest.raises(DemistoException) as exc_info:
-        generate_threat_incidents(client, threats, 1, start_datetime, end_datetime)
+    incidents, watermark = generate_threat_incidents(client, threats, 1, start_datetime, end_datetime)
 
-    assert str(status_code) in str(exc_info.value)
+    assert incidents == []
+    assert watermark is None  # never advanced past the failed item
 
 
-def test_generate_threat_incidents_raises_5xx_errors(mocker):
-    """Test that 5xx errors are re-raised."""
+def test_generate_threat_incidents_stops_on_5xx_errors(mocker):
+    """5xx errors stop the stream without raising (preserving the watermark)."""
 
     def mock_get_details(threat_id, **kwargs):
         raise DemistoException("Error in API call [500] - Internal Server Error", res=MockResponse(None, 500))
@@ -1615,10 +1619,10 @@ def test_generate_threat_incidents_raises_5xx_errors(mocker):
     start_datetime = datetime(2023, 9, 17, 14, 0, 0, tzinfo=UTC)
     end_datetime = datetime(2023, 9, 17, 17, 0, 0, tzinfo=UTC)
 
-    with pytest.raises(DemistoException) as exc_info:
-        generate_threat_incidents(client, [{"threatId": "id"}], 1, start_datetime, end_datetime)
+    incidents, watermark = generate_threat_incidents(client, [{"threatId": "id"}], 1, start_datetime, end_datetime)
 
-    assert "500" in str(exc_info.value)
+    assert incidents == []
+    assert watermark is None
 
 
 def test_generate_threat_incidents_handles_4xx_mid_pagination(mocker):
@@ -1664,7 +1668,7 @@ def test_generate_threat_incidents_handles_4xx_mid_pagination(mocker):
         {"threatId": "valid-threat-id"},
     ]
 
-    incidents = generate_threat_incidents(client, threats, 5, start_datetime, end_datetime)
+    incidents, _ = generate_threat_incidents(client, threats, 5, start_datetime, end_datetime)
 
     assert len(incidents) == 1
     assert incidents[0]["dbotMirrorId"] == "valid-threat-id"
@@ -1695,14 +1699,14 @@ def test_generate_abuse_campaign_incidents_skips_4xx_error(mocker):
         {"campaignId": "valid-campaign-id"},
     ]
 
-    incidents = generate_abuse_campaign_incidents(client, campaigns)
+    incidents, _ = generate_abuse_campaign_incidents(client, campaigns)
 
     assert len(incidents) == 1
     assert incidents[0]["dbotMirrorId"] == "valid-campaign-id"
 
 
-def test_generate_abuse_campaign_incidents_raises_non_skippable_errors(mocker):
-    """Test that non-skippable errors (401) are re-raised."""
+def test_generate_abuse_campaign_incidents_stops_on_non_skippable_errors(mocker):
+    """Non-skippable errors (401) stop the campaign stream without raising."""
 
     def mock_get_campaign(campaign_id, **kwargs):
         raise DemistoException("Error in API call [401] - Unauthorized", res=MockResponse(None, 401))
@@ -1710,10 +1714,10 @@ def test_generate_abuse_campaign_incidents_raises_non_skippable_errors(mocker):
     client = mock_client(mocker, response=None)
     mocker.patch.object(client, "get_details_of_an_abuse_mailbox_campaign_request", side_effect=mock_get_campaign)
 
-    with pytest.raises(DemistoException) as exc_info:
-        generate_abuse_campaign_incidents(client, [{"campaignId": "id"}])
+    incidents, watermark = generate_abuse_campaign_incidents(client, [{"campaignId": "id"}])
 
-    assert "401" in str(exc_info.value)
+    assert incidents == []
+    assert watermark is None
 
 
 """
@@ -1742,14 +1746,14 @@ def test_generate_account_takeover_cases_incidents_skips_4xx_error(mocker):
         {"caseId": "valid-case-id", "description": "Valid case"},
     ]
 
-    incidents = generate_account_takeover_cases_incidents(client, cases)
+    incidents, _ = generate_account_takeover_cases_incidents(client, cases)
 
     assert len(incidents) == 1
     assert incidents[0]["dbotMirrorId"] == "valid-case-id"
 
 
-def test_generate_account_takeover_cases_incidents_raises_non_skippable_errors(mocker):
-    """Test that non-skippable errors (429) are re-raised."""
+def test_generate_account_takeover_cases_incidents_stops_on_non_skippable_errors(mocker):
+    """Non-skippable errors (429) stop the case stream without raising."""
 
     def mock_get_case(case_id, **kwargs):
         raise DemistoException("Error in API call [429] - Too Many Requests", res=MockResponse(None, 429))
@@ -1757,7 +1761,180 @@ def test_generate_account_takeover_cases_incidents_raises_non_skippable_errors(m
     client = mock_client(mocker, response=None)
     mocker.patch.object(client, "get_details_of_an_abnormal_case_request", side_effect=mock_get_case)
 
-    with pytest.raises(DemistoException) as exc_info:
-        generate_account_takeover_cases_incidents(client, [{"caseId": "id", "description": "test"}])
+    incidents, watermark = generate_account_takeover_cases_incidents(client, [{"caseId": "id", "description": "test"}])
 
-    assert "429" in str(exc_info.value)
+    assert incidents == []
+    assert watermark is None
+
+
+"""
+    Per-stream watermark / self-healing checkpoint tests (INT-1959)
+"""
+
+FIXED_NOW = datetime(2023, 9, 17, 18, 0, 0, tzinfo=UTC)
+
+
+def _threat_detail(threat_id):
+    """Minimal threat-details payload whose single message is inside any wide test window."""
+    return {
+        "threatId": threat_id,
+        "messages": [{"threatId": threat_id, "receivedTime": "2023-09-17T15:00:00Z", "remediationTimestamp": "2023-09-17T15:00:00Z"}],
+    }
+
+
+def test_fetch_incidents_non_skippable_500_midstream_persists_progress(mocker):
+    """
+    (a) A non-skippable 500 on the 2nd of three threats must NOT raise: fetch_incidents
+    returns the already-processed incident(s) and advances threats_last_fetch only to the
+    last good threat (not past the failed one), while campaigns/cases still produce watermarks.
+    """
+    mocker.patch("AbnormalSecurity.get_current_datetime", return_value=FIXED_NOW)
+    client = Client(server_url=BASE_URL, verify=False, proxy=False, auth=None, headers=headers)
+
+    threats = [
+        {"threatId": "t1", "latestTimeRemediated": "2023-09-17T15:00:00Z"},
+        {"threatId": "t2", "latestTimeRemediated": "2023-09-17T16:00:00Z"},
+        {"threatId": "t3", "latestTimeRemediated": "2023-09-17T17:00:00Z"},
+    ]
+    mocker.patch.object(client, "get_paginated_threats_list", return_value={"threats": threats})
+
+    def detail(threat_id, **kwargs):
+        if threat_id == "t2":
+            raise DemistoException("Error in API call [500] - Internal Server Error", res=MockResponse(None, 500))
+        return _threat_detail(threat_id)
+
+    mocker.patch.object(client, "get_details_of_a_threat_request", side_effect=detail)
+
+    next_run, incidents = fetch_incidents(
+        client=client,
+        last_run={},
+        first_fetch_time="2023-09-17T14:00:00Z",
+        max_incidents_to_fetch=200,
+        fetch_threats=True,
+        fetch_abuse_campaigns=False,
+        fetch_account_takeover_cases=False,
+        polling_lag=timedelta(minutes=0),
+    )
+
+    # Only t1 emitted; stream stopped at t2 without raising.
+    assert [i["dbotMirrorId"] for i in incidents] == ["t1"]
+    # Watermark advanced to t1's timestamp, NOT past the failed t2.
+    assert next_run["threats_last_fetch"] == "2023-09-17T15:00:00Z"
+    # Other streams still get watermarks (fall back to first_fetch_time start).
+    assert next_run["campaigns_last_fetch"] == "2023-09-17T14:00:00Z"
+    assert next_run["cases_last_fetch"] == "2023-09-17T14:00:00Z"
+
+
+def test_fetch_incidents_legacy_last_fetch_backward_compat(mocker):
+    """(b) A last_run with only the legacy last_fetch is honored as the start for all streams."""
+    mocker.patch("AbnormalSecurity.get_current_datetime", return_value=FIXED_NOW)
+    client = Client(server_url=BASE_URL, verify=False, proxy=False, auth=None, headers=headers)
+
+    captured = {}
+
+    def paginate(filter_, **kwargs):
+        captured["threats"] = filter_
+        return {"threats": []}
+
+    mocker.patch.object(client, "get_paginated_threats_list", side_effect=paginate)
+
+    next_run, incidents = fetch_incidents(
+        client=client,
+        last_run={"last_fetch": "2023-09-17T12:00:00Z"},
+        first_fetch_time="2000-01-01T00:00:00Z",
+        max_incidents_to_fetch=200,
+        fetch_threats=True,
+        fetch_abuse_campaigns=False,
+        fetch_account_takeover_cases=False,
+        polling_lag=timedelta(minutes=0),
+    )
+
+    # Legacy last_fetch (not first_fetch_time) seeded the window start (+1ms rounds to same second).
+    assert "latestTimeRemediated gte 2023-09-17T12:00:00Z" in captured["threats"]
+    # With no items the watermark holds at the legacy value rather than skipping forward.
+    assert next_run["threats_last_fetch"] == "2023-09-17T12:00:00Z"
+
+
+def test_fetch_incidents_out_of_order_input_does_not_skip_older_item(mocker):
+    """
+    (c) Ascending-sort safety: when the API returns threats newest-first and the NEWEST one
+    fails non-skippably, the watermark must not jump to the newest item and skip the older
+    (unprocessed) one. After sorting, the older threat is processed first and the watermark
+    stays at it; the failed newer threat is re-queried next cycle.
+    """
+    mocker.patch("AbnormalSecurity.get_current_datetime", return_value=FIXED_NOW)
+    client = Client(server_url=BASE_URL, verify=False, proxy=False, auth=None, headers=headers)
+
+    # Returned out of order: newer first, older second.
+    threats = [
+        {"threatId": "newer", "latestTimeRemediated": "2023-09-17T16:00:00Z"},
+        {"threatId": "older", "latestTimeRemediated": "2023-09-17T15:00:00Z"},
+    ]
+    mocker.patch.object(client, "get_paginated_threats_list", return_value={"threats": threats})
+
+    def detail(threat_id, **kwargs):
+        if threat_id == "newer":
+            raise DemistoException("Error in API call [500] - Internal Server Error", res=MockResponse(None, 500))
+        return _threat_detail(threat_id)
+
+    mocker.patch.object(client, "get_details_of_a_threat_request", side_effect=detail)
+
+    next_run, incidents = fetch_incidents(
+        client=client,
+        last_run={},
+        first_fetch_time="2023-09-17T14:00:00Z",
+        max_incidents_to_fetch=200,
+        fetch_threats=True,
+        fetch_abuse_campaigns=False,
+        fetch_account_takeover_cases=False,
+        polling_lag=timedelta(minutes=0),
+    )
+
+    # "older" processed first (sorted asc), then "newer" fails -> watermark stays at older,
+    # so the unprocessed "newer" threat is NOT skipped on the next cycle.
+    assert [i["dbotMirrorId"] for i in incidents] == ["older"]
+    assert next_run["threats_last_fetch"] == "2023-09-17T15:00:00Z"
+
+
+def test_fetch_incidents_clean_run_advances_all_watermarks(mocker):
+    """(d) No-regression: a clean run emits every incident and advances all three watermarks."""
+    mocker.patch("AbnormalSecurity.get_current_datetime", return_value=FIXED_NOW)
+    client = Client(server_url=BASE_URL, verify=False, proxy=False, auth=None, headers=headers)
+
+    mocker.patch.object(
+        client, "get_paginated_threats_list",
+        return_value={"threats": [{"threatId": "t1", "latestTimeRemediated": "2023-09-17T15:00:00Z"}]},
+    )
+    mocker.patch.object(
+        client, "get_paginated_abusecampaigns_list",
+        return_value={"campaigns": [{"campaignId": "c1", "lastReportedTime": "2023-09-17T15:10:00Z"}]},
+    )
+    mocker.patch.object(
+        client, "get_paginated_cases_list",
+        return_value={"cases": [{"caseId": "k1", "description": "d", "lastModifiedTime": "2023-09-17T15:20:00Z"}]},
+    )
+    mocker.patch.object(client, "get_details_of_a_threat_request", side_effect=lambda threat_id, **kw: _threat_detail(threat_id))
+    mocker.patch.object(
+        client, "get_details_of_an_abuse_mailbox_campaign_request",
+        side_effect=lambda campaign_id, **kw: {"campaignId": campaign_id, "firstReported": "2023-09-17T15:10:00Z"},
+    )
+    mocker.patch.object(
+        client, "get_details_of_an_abnormal_case_request",
+        side_effect=lambda case_id, **kw: {"caseId": case_id, "firstObserved": "2023-09-17T15:20:00Z", "genai_summary": "s"},
+    )
+
+    next_run, incidents = fetch_incidents(
+        client=client,
+        last_run={},
+        first_fetch_time="2023-09-17T14:00:00Z",
+        max_incidents_to_fetch=200,
+        fetch_threats=True,
+        fetch_abuse_campaigns=True,
+        fetch_account_takeover_cases=True,
+        polling_lag=timedelta(minutes=0),
+    )
+
+    assert {i["name"] for i in incidents} == {"Threat", "Abuse Campaign", "Account Takeover Case"}
+    assert next_run["threats_last_fetch"] == "2023-09-17T15:00:00Z"
+    assert next_run["campaigns_last_fetch"] == "2023-09-17T15:10:00Z"
+    assert next_run["cases_last_fetch"] == "2023-09-17T15:20:00Z"

--- a/Packs/AbnormalSecurity/ReleaseNotes/2_4_7.md
+++ b/Packs/AbnormalSecurity/ReleaseNotes/2_4_7.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### Abnormal Security
+
+- Fixed an issue where a transient backend error (e.g., HTTP 500, connection reset, or timeout) mid-fetch would wedge **fetch-incidents** by preventing the fetch checkpoint from advancing, causing the same time window to be retried and fail indefinitely.
+- The integration now tracks an independent checkpoint per stream (threats, abuse campaigns, and account takeover cases). On a transient error the affected stream stops at its last successfully fetched incident while the other streams continue, and progress is persisted, so the next fetch resumes without re-processing or losing data.

--- a/Packs/AbnormalSecurity/pack_metadata.json
+++ b/Packs/AbnormalSecurity/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Abnormal Security",
     "description": "Abnormal Security detects and protects against the whole spectrum of email attacks",
     "support": "partner",
-    "currentVersion": "2.4.6",
+    "currentVersion": "2.4.7",
     "created": "2021-07-11T00:00:00Z",
     "author": "Abnormal Security",
     "url": "",


### PR DESCRIPTION
## Summary

Fixes INT-1959: a single transient backend error (HTTP 500 / connection reset / timeout) mid `fetch-incidents` previously propagated out, so `setLastRun` was never called, `last_fetch` never advanced, and the identical window was retried and failed every cycle — wedging the fetch until a manual reset.

## Changes

- Replaced the single `last_fetch` scalar with three independent per-stream watermarks in `last_run` (`threats_last_fetch` / `campaigns_last_fetch` / `cases_last_fetch`); a missing per-stream key falls back to legacy `last_fetch`, then `first_fetch_time`, for backward compatibility with already-deployed instances.
- Each stream now computes its own start window, sorts its items ascending by the filter timestamp (`latestTimeRemediated` / `lastReportedTime` / `lastModifiedTime`, missing values treated as oldest), and advances its watermark only to the last successfully processed item.
- A non-skippable error (5xx / connection reset / 401/403/429) now stops only the affected stream — without raising and without advancing past the failed item — so `fetch_incidents` still returns and `main()` persists progress for all streams. Existing skippable-4xx skip-and-continue behavior is unchanged.
- Added `ReleaseNotes/2_4_7.md` and bumped `pack_metadata.json` to `2.4.7`.

## Test Plan

Unit tests run under the demisto-sdk venv (CI timezone is UTC):

```
$ TZ=UTC PYTHONPATH="Tests/demistomock:Packs/Base/Scripts/CommonServerPython:Packs/ApiModules/Scripts/DemistoClassApiModule:<integration dir>" \
    python -m pytest Packs/AbnormalSecurity/Integrations/AbnormalSecurity/AbnormalSecurity_test.py -q

72 passed, 1 warning in 0.17s
```

New focused tests cover:
- A non-skippable 500 on the 2nd of three threats: `fetch_incidents` returns (does not raise), emits the first threat, and `threats_last_fetch` advances to the last good threat but not past the failed one, while campaigns/cases still get watermarks.
- Backward compat: a `last_run` with only legacy `last_fetch` seeds the start for all streams.
- Ascending-sort safety: an out-of-order input where the newest item fails does not let the watermark skip the older unprocessed item.
- Clean run: all incidents emitted and all three watermarks advanced (no regression).

## Known limitation / follow-up

`setLastRun` only persists on a graceful return. If XSOAR hard-kills the Docker container (SIGKILL on the 300s wall-clock timeout) mid-fetch, nothing returns and progress within that run is still lost. Surviving a hard kill would require incremental `demisto.setIntegrationContext()` checkpointing during processing — tracked as follow-up **INT-1960**, out of scope for this PR. This PR fixes the dominant documented failure mode (the 500/timeout exception that propagates and wedges the window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-17156