### PR TITLE
Remove TestIPQualityScorePlaybook

### DIFF
--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -5064,13 +5064,6 @@
             ]
         },
         {
-            "playbookID": "TestIPQualityScorePlaybook",
-            "fromversion": "5.0.0",
-            "integrations": [
-                "IPQualityScore"
-            ]
-        },
-        {
             "integrations": "CrowdStrike Falcon Sandbox V2",
             "playbookID": "CrowdstrikeFalconSandbox2 Test",
             "timeout": 500


### PR DESCRIPTION
## Related Issues
fixes: [CIAC-17150](https://jira-dc.paloaltonetworks.com/browse/CIAC-17150)

## Description
The test playbook was removed here from the partner-supported pack: https://github.com/demisto/content/pull/44735

_No internal instance_

