### PR TITLE
Fix DBotFindSimilarIncidents TypeError

### DIFF
--- a/Packs/Base/ReleaseNotes/1_41_98.md
+++ b/Packs/Base/ReleaseNotes/1_41_98.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### DBotFindSimilarIncidents
+
+Fixed an issue where the script failed with a `TypeError` when processing historical alerts that contained numeric field values (such as port lists) in the *commandline* field.

--- a/Packs/Base/ReleaseNotes/1_41_99.md
+++ b/Packs/Base/ReleaseNotes/1_41_99.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### DBotFindSimilarIncidents
+
+Fixed an issue where the script failed with a `TypeError` when processing historical alerts that contained numeric field values (such as port lists) in the *commandline* field.

--- a/Packs/Base/Scripts/DBotFindSimilarIncidents/DBotFindSimilarIncidents.py
+++ b/Packs/Base/Scripts/DBotFindSimilarIncidents/DBotFindSimilarIncidents.py
@@ -235,7 +235,7 @@ def normalize_command_line(command: str) -> str:
     """
 
     if command and isinstance(command, list):
-        command = " ".join(set(command))
+        command = " ".join(str(item) for item in set(command))
     if command and isinstance(command, str):
         my_string = command.lower()
         my_string = "".join([REPLACE_COMMAND_LINE.get(c, c) for c in my_string])

--- a/Packs/Base/Scripts/DBotFindSimilarIncidents/DBotFindSimilarIncidents_test.py
+++ b/Packs/Base/Scripts/DBotFindSimilarIncidents/DBotFindSimilarIncidents_test.py
@@ -124,11 +124,28 @@ def test_match_one_regex():
     assert match_one_regex(1, [REGEX_IP]) is False
 
 
-def test_normalize_command_line():
+@pytest.mark.parametrize(
+    "command, expected",
+    [
+        pytest.param("cmd -k IP=1.1.1.1 [1.1.1.1]", "cmd -k ip = IP IP", id="string_with_ip_and_brackets"),
+        pytest.param('powershell "remove_quotes"', "powershell remove_quotes", id="string_with_quotes"),
+        pytest.param(["GET", "POST"], {"get", "post"}, id="list_of_strings"),
+        pytest.param([80, 443, 8080], {"80", "443", "8080"}, id="list_of_integers_regression"),
+        pytest.param(["http", 443], {"http", "443"}, id="mixed_list_str_and_int"),
+        pytest.param("", "", id="empty_string"),
+        pytest.param(None, "", id="none_input"),
+        pytest.param([], "", id="empty_list"),
+    ],
+)
+def test_normalize_command_line(command, expected):
     from DBotFindSimilarIncidents import normalize_command_line
 
-    assert normalize_command_line("cmd -k IP=1.1.1.1 [1.1.1.1]") == "cmd -k ip = IP IP"
-    assert normalize_command_line('powershell "remove_quotes"') == "powershell remove_quotes"
+    result = normalize_command_line(command)
+    # For list inputs the join order is non-deterministic (set), so compare token sets
+    if isinstance(expected, set):
+        assert set(result.split()) == expected
+    else:
+        assert result == expected
 
 
 def test_euclidian_similarity_capped():

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.41.97",
+    "currentVersion": "1.41.98",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.41.98",
+    "currentVersion": "1.41.99",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
## Related Issues
fixes: [XSUP-70988](https://jira-dc.paloaltonetworks.com/browse/XSUP-70988)

## Description
Fixed an issue where the script failed with a `TypeError` when processing historical alerts that contained numeric field values (such as port lists) in the *commandline* field.
