### PR TITLE
MISP Feed - Fix LastRun Reset

### DIFF
--- a/Packs/FeedMISP/Integrations/FeedMISP/FeedMISP.py
+++ b/Packs/FeedMISP/Integrations/FeedMISP/FeedMISP.py
@@ -653,9 +653,14 @@ def fetch_attributes_command(client: Client, params: Dict[str, str]):
 
     if error_message := search_query_per_page.get("Error"):
         raise DemistoException(f"Error in API call - check the input parameters and the API Key. Error: {error_message}")
-    demisto.setLastRun(
-        {"last_indicator_timestamp": last_run.get("candidate_timestamp"), "last_indicator_value": last_run.get("candidate_value")}
-    )
+
+    candidate_timestamp = last_run.get("candidate_timestamp")
+    candidate_value = last_run.get("candidate_value")
+    if candidate_timestamp is None:
+        # No candidate was produced this run.
+        demisto.debug("No candidate produced this run; leaving existing lastRun unchanged")
+        return
+    demisto.setLastRun({"last_indicator_timestamp": candidate_timestamp, "last_indicator_value": candidate_value})
 
 
 def main():  # pragma: no cover

--- a/Packs/FeedMISP/Integrations/FeedMISP/FeedMISP.py
+++ b/Packs/FeedMISP/Integrations/FeedMISP/FeedMISP.py
@@ -583,10 +583,6 @@ def update_candidate(
     if not candidate_timestamp or (latest_indicator_timestamp and latest_indicator_timestamp > candidate_timestamp):
         last_run["candidate_timestamp"] = latest_indicator_timestamp
         last_run["candidate_value"] = latest_indicator_value
-    demisto.debug(
-        f"[FeedMISP update_candidate] latest_ts={latest_indicator_timestamp}, prior_candidate={candidate_timestamp}, "
-        f"new_candidate={last_run.get('candidate_timestamp')}"
-    )
 
 
 def fetch_attributes_command(client: Client, params: Dict[str, str]):
@@ -610,14 +606,6 @@ def fetch_attributes_command(client: Client, params: Dict[str, str]):
     last_run_timestamp = arg_to_number(last_run.get("last_indicator_timestamp"))
     last_run_page = last_run.get("page") or 1
     last_run_value = last_run.get("last_indicator_value") or ""
-    # Seed the candidate from the previously stored watermark so that a run which fetches no new indicators
-    # (e.g. an empty incremental page) does not reset last_indicator_* to None on the final setLastRun.
-    last_run.setdefault("candidate_timestamp", last_run_timestamp)  # type: ignore[arg-type]
-    last_run.setdefault("candidate_value", last_run_value or None)  # type: ignore[arg-type]
-    demisto.debug(
-        f"[FeedMISP fetch] entry: getLastRun={last_run}, last_run_timestamp={last_run_timestamp}, "
-        f"last_run_value={last_run_value!r}, page={last_run_page}"
-    )
     params_dict = (
         parsing_user_query(query, fetch_limit, from_timestamp=last_run_timestamp, page=last_run_page)
         if query
@@ -630,12 +618,6 @@ def fetch_attributes_command(client: Client, params: Dict[str, str]):
     demisto.debug(f"params_dict: {params_dict}")
 
     attributes = get_attributes_from_response(search_query_per_page)
-    demisto.debug(f"[FeedMISP fetch] first page returned {len(attributes)} attributes (page={params_dict['page']})")
-    if not attributes:
-        demisto.debug(
-            "[FeedMISP fetch] first page empty -> loop skipped; candidate_* not populated this run, "
-            "final setLastRun may reset last_indicator_*"
-        )
     while attributes:
         demisto.debug(f"search_query_per_page number of attributes: {len(attributes)} page: {params_dict['page']}")
         attributes.sort(key=lambda x: x["timestamp"], reverse=False)
@@ -647,17 +629,10 @@ def fetch_attributes_command(client: Client, params: Dict[str, str]):
         latest_indicator = attributes
         latest_indicator_timestamp = arg_to_number(latest_indicator[-1]["timestamp"])
         latest_indicator_value = latest_indicator[-1]["value"]
-        demisto.debug(
-            f"[FeedMISP fetch] page={params_dict['page']} latest_indicator_timestamp={latest_indicator_timestamp}, "
-            f"latest_indicator_value={latest_indicator_value!r}"
-        )
 
         if last_run_timestamp == latest_indicator_timestamp and latest_indicator_value == last_run_value:
             # No new indicators since last run, no need to fetch again
-            demisto.debug(
-                f"[FeedMISP fetch] no new indicators since last run (last_run_timestamp={last_run_timestamp}, "
-                f"last_run_value={last_run_value!r}); returning without modifying lastRun"
-            )
+            demisto.debug("No new indicators found since last run")
             return
 
         for iter_ in batch(indicators, batch_size=2000):
@@ -667,12 +642,6 @@ def fetch_attributes_command(client: Client, params: Dict[str, str]):
         # Note: The limit is applied after indicators are created,
         # so the total number of indicators may slightly exceed the limit due to page size constraints.
         if fetch_limit and fetch_limit <= total_fetched_indicators:
-            demisto.debug(
-                f"[FeedMISP fetch] fetch limit reached (total_fetched_indicators={total_fetched_indicators}); "
-                f"persisting lastRun={last_run | {'page': params_dict['page']}} "
-                f"candidate_timestamp={last_run.get('candidate_timestamp')} "
-                f"candidate_value={last_run.get('candidate_value')!r}"
-            )
             demisto.setLastRun(last_run | {"page": params_dict["page"]})
             demisto.debug(
                 f"Reached the limit of indicators to fetch. The number of indicators fetched is: {total_fetched_indicators}"
@@ -684,21 +653,9 @@ def fetch_attributes_command(client: Client, params: Dict[str, str]):
 
     if error_message := search_query_per_page.get("Error"):
         raise DemistoException(f"Error in API call - check the input parameters and the API Key. Error: {error_message}")
-    candidate_timestamp = last_run.get("candidate_timestamp")
-    candidate_value = last_run.get("candidate_value")
-    if candidate_timestamp is None:
-        # No candidate was produced this run (e.g. an empty incremental page) and no prior watermark exists.
-        # Do not overwrite lastRun with nulls - leave the existing lastRun untouched to avoid resetting the cursor.
-        demisto.debug(
-            "[FeedMISP fetch] final: no candidate produced and no prior watermark; "
-            "leaving lastRun unchanged to avoid wiping last_indicator_*"
-        )
-        return
-    demisto.debug(
-        f"[FeedMISP fetch] final setLastRun: candidate_timestamp={candidate_timestamp}, "
-        f"candidate_value={candidate_value!r} -> writing last_indicator_timestamp/value"
+    demisto.setLastRun(
+        {"last_indicator_timestamp": last_run.get("candidate_timestamp"), "last_indicator_value": last_run.get("candidate_value")}
     )
-    demisto.setLastRun({"last_indicator_timestamp": candidate_timestamp, "last_indicator_value": candidate_value})
 
 
 def main():  # pragma: no cover

--- a/Packs/FeedMISP/Integrations/FeedMISP/FeedMISP.py
+++ b/Packs/FeedMISP/Integrations/FeedMISP/FeedMISP.py
@@ -583,6 +583,10 @@ def update_candidate(
     if not candidate_timestamp or (latest_indicator_timestamp and latest_indicator_timestamp > candidate_timestamp):
         last_run["candidate_timestamp"] = latest_indicator_timestamp
         last_run["candidate_value"] = latest_indicator_value
+    demisto.debug(
+        f"[FeedMISP update_candidate] latest_ts={latest_indicator_timestamp}, prior_candidate={candidate_timestamp}, "
+        f"new_candidate={last_run.get('candidate_timestamp')}"
+    )
 
 
 def fetch_attributes_command(client: Client, params: Dict[str, str]):
@@ -606,6 +610,14 @@ def fetch_attributes_command(client: Client, params: Dict[str, str]):
     last_run_timestamp = arg_to_number(last_run.get("last_indicator_timestamp"))
     last_run_page = last_run.get("page") or 1
     last_run_value = last_run.get("last_indicator_value") or ""
+    # Seed the candidate from the previously stored watermark so that a run which fetches no new indicators
+    # (e.g. an empty incremental page) does not reset last_indicator_* to None on the final setLastRun.
+    last_run.setdefault("candidate_timestamp", last_run_timestamp)  # type: ignore[arg-type]
+    last_run.setdefault("candidate_value", last_run_value or None)  # type: ignore[arg-type]
+    demisto.debug(
+        f"[FeedMISP fetch] entry: getLastRun={last_run}, last_run_timestamp={last_run_timestamp}, "
+        f"last_run_value={last_run_value!r}, page={last_run_page}"
+    )
     params_dict = (
         parsing_user_query(query, fetch_limit, from_timestamp=last_run_timestamp, page=last_run_page)
         if query
@@ -618,6 +630,12 @@ def fetch_attributes_command(client: Client, params: Dict[str, str]):
     demisto.debug(f"params_dict: {params_dict}")
 
     attributes = get_attributes_from_response(search_query_per_page)
+    demisto.debug(f"[FeedMISP fetch] first page returned {len(attributes)} attributes (page={params_dict['page']})")
+    if not attributes:
+        demisto.debug(
+            "[FeedMISP fetch] first page empty -> loop skipped; candidate_* not populated this run, "
+            "final setLastRun may reset last_indicator_*"
+        )
     while attributes:
         demisto.debug(f"search_query_per_page number of attributes: {len(attributes)} page: {params_dict['page']}")
         attributes.sort(key=lambda x: x["timestamp"], reverse=False)
@@ -629,10 +647,17 @@ def fetch_attributes_command(client: Client, params: Dict[str, str]):
         latest_indicator = attributes
         latest_indicator_timestamp = arg_to_number(latest_indicator[-1]["timestamp"])
         latest_indicator_value = latest_indicator[-1]["value"]
+        demisto.debug(
+            f"[FeedMISP fetch] page={params_dict['page']} latest_indicator_timestamp={latest_indicator_timestamp}, "
+            f"latest_indicator_value={latest_indicator_value!r}"
+        )
 
         if last_run_timestamp == latest_indicator_timestamp and latest_indicator_value == last_run_value:
             # No new indicators since last run, no need to fetch again
-            demisto.debug("No new indicators found since last run")
+            demisto.debug(
+                f"[FeedMISP fetch] no new indicators since last run (last_run_timestamp={last_run_timestamp}, "
+                f"last_run_value={last_run_value!r}); returning without modifying lastRun"
+            )
             return
 
         for iter_ in batch(indicators, batch_size=2000):
@@ -642,6 +667,12 @@ def fetch_attributes_command(client: Client, params: Dict[str, str]):
         # Note: The limit is applied after indicators are created,
         # so the total number of indicators may slightly exceed the limit due to page size constraints.
         if fetch_limit and fetch_limit <= total_fetched_indicators:
+            demisto.debug(
+                f"[FeedMISP fetch] fetch limit reached (total_fetched_indicators={total_fetched_indicators}); "
+                f"persisting lastRun={last_run | {'page': params_dict['page']}} "
+                f"candidate_timestamp={last_run.get('candidate_timestamp')} "
+                f"candidate_value={last_run.get('candidate_value')!r}"
+            )
             demisto.setLastRun(last_run | {"page": params_dict["page"]})
             demisto.debug(
                 f"Reached the limit of indicators to fetch. The number of indicators fetched is: {total_fetched_indicators}"
@@ -653,9 +684,21 @@ def fetch_attributes_command(client: Client, params: Dict[str, str]):
 
     if error_message := search_query_per_page.get("Error"):
         raise DemistoException(f"Error in API call - check the input parameters and the API Key. Error: {error_message}")
-    demisto.setLastRun(
-        {"last_indicator_timestamp": last_run.get("candidate_timestamp"), "last_indicator_value": last_run.get("candidate_value")}
+    candidate_timestamp = last_run.get("candidate_timestamp")
+    candidate_value = last_run.get("candidate_value")
+    if candidate_timestamp is None:
+        # No candidate was produced this run (e.g. an empty incremental page) and no prior watermark exists.
+        # Do not overwrite lastRun with nulls - leave the existing lastRun untouched to avoid resetting the cursor.
+        demisto.debug(
+            "[FeedMISP fetch] final: no candidate produced and no prior watermark; "
+            "leaving lastRun unchanged to avoid wiping last_indicator_*"
+        )
+        return
+    demisto.debug(
+        f"[FeedMISP fetch] final setLastRun: candidate_timestamp={candidate_timestamp}, "
+        f"candidate_value={candidate_value!r} -> writing last_indicator_timestamp/value"
     )
+    demisto.setLastRun({"last_indicator_timestamp": candidate_timestamp, "last_indicator_value": candidate_value})
 
 
 def main():  # pragma: no cover

--- a/Packs/FeedMISP/Integrations/FeedMISP/FeedMISP.py
+++ b/Packs/FeedMISP/Integrations/FeedMISP/FeedMISP.py
@@ -293,6 +293,16 @@ def parsing_user_query(query: str, limit: int, page: int = 1, from_timestamp: Op
     return params
 
 
+def get_attributes_from_response(response: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """
+    Safely extracts the list of attributes from a MISP search response.
+    Args:
+        response: The raw response returned from client.search_query.
+    Returns: The list of attribute dicts, or an empty list if none are present.
+    """
+    return response.get("response", {}).get("Attribute", [])
+
+
 def get_ip_type(ip_attribute: Dict[str, Any]) -> str:
     """
     Returns the correct FeedIndicatorType for attributes of type ip
@@ -607,16 +617,16 @@ def fetch_attributes_command(client: Client, params: Dict[str, str]):
     search_query_per_page = client.search_query(params_dict)
     demisto.debug(f"params_dict: {params_dict}")
 
-    while len(search_query_per_page.get("response", {}).get("Attribute", [])):
-        demisto.debug(f'search_query_per_page number of attributes:\
-                      {len(search_query_per_page.get("response", {}).get("Attribute", []))} page: {params_dict["page"]}')
-        search_query_per_page.get("response", {}).get("Attribute", []).sort(key=lambda x: x["timestamp"], reverse=False)
+    attributes = get_attributes_from_response(search_query_per_page)
+    while attributes:
+        demisto.debug(f"search_query_per_page number of attributes: {len(attributes)} page: {params_dict['page']}")
+        attributes.sort(key=lambda x: x["timestamp"], reverse=False)
         indicators = build_indicators(
             client, search_query_per_page, attribute_types, tlp_color, params.get("url"), reputation, feed_tags
         )
 
         total_fetched_indicators += len(indicators)
-        latest_indicator = search_query_per_page["response"]["Attribute"]
+        latest_indicator = attributes
         latest_indicator_timestamp = arg_to_number(latest_indicator[-1]["timestamp"])
         latest_indicator_value = latest_indicator[-1]["value"]
 
@@ -639,6 +649,8 @@ def fetch_attributes_command(client: Client, params: Dict[str, str]):
             return
 
         search_query_per_page = client.search_query(params_dict)
+        attributes = get_attributes_from_response(search_query_per_page)
+
     if error_message := search_query_per_page.get("Error"):
         raise DemistoException(f"Error in API call - check the input parameters and the API Key. Error: {error_message}")
     demisto.setLastRun(

--- a/Packs/FeedMISP/Integrations/FeedMISP/FeedMISP_test.py
+++ b/Packs/FeedMISP/Integrations/FeedMISP/FeedMISP_test.py
@@ -763,3 +763,36 @@ def test_build_indicators_propagates_inherited_event_tag():
     tags = indicators[0]["fields"]["Tags"]
     assert "tlp:white" in tags
     assert "attribute-tag" in tags
+
+
+def test_fetch_empty_response_preserves_last_run(mocker):
+    """
+    Given:
+        - A previously stored watermark (last_indicator_timestamp/value) from an earlier fetch.
+    When:
+        - The next fetch returns an empty response (no new attributes), so no candidate is produced.
+    Then:
+        - setLastRun must NOT be called (the existing watermark is left untouched), instead of being
+          overwritten with nulls which would reset the incremental cursor and cause a full re-fetch.
+    """
+    client = Client(
+        base_url="example",
+        authorization="auth",
+        verify=False,
+        proxy=False,
+        timeout=60,
+        performance=False,
+        max_indicator_to_fetch=2000,
+    )
+    # Empty MISP response -> the while loop never runs, no candidate is produced.
+    mocker.patch.object(Client, "_http_request", side_effect=[{"response": {"Attribute": []}}])
+    mocked_last_run = {"last_indicator_timestamp": "1607517728", "last_indicator_value": "test"}
+    mocker.patch.object(demisto, "getLastRun", return_value=mocked_last_run)
+    set_last_run = mocker.patch.object(demisto, "setLastRun")
+    create_indicators = mocker.patch.object(demisto, "createIndicators")
+
+    fetch_attributes_command(client, {})
+
+    # No new indicators should be created, and the watermark must be preserved (setLastRun not called).
+    assert not create_indicators.called
+    assert not set_last_run.called

--- a/Packs/FeedMISP/ReleaseNotes/1_1_3.md
+++ b/Packs/FeedMISP/ReleaseNotes/1_1_3.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### MISP Feed
+
+- Fixed an issue where the feed's last run state (**last_indicator_timestamp** and **last_indicator_value**) was reset when a fetch returned no new indicators.

--- a/Packs/FeedMISP/pack_metadata.json
+++ b/Packs/FeedMISP/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "MISP Feed",
     "description": "Indicators feed from MISP",
     "support": "xsoar",
-    "currentVersion": "1.1.2",
+    "currentVersion": "1.1.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Related Issues
fixes: [XSUP-71868](https://jira-dc.paloaltonetworks.com/browse/XSUP-71868)

## Description
Fixed an issue where the feed's last run state (**last_indicator_timestamp** and **last_indicator_value**) was reset when a fetch returned no new indicators.
