### PR TITLE
[Slack - mirror-investigation] Preserve existing mirror autoclose and…

### DIFF
--- a/Packs/Slack/Integrations/SlackV3/SlackV3.py
+++ b/Packs/Slack/Integrations/SlackV3/SlackV3.py
@@ -1206,15 +1206,16 @@ def mirror_investigation():
             "Mirroring is enabled, however long running is disabled. For mirrors to work correctly,"
             " long running must be enabled."
         )
-    demisto.debug(f"SlackV3 integration: This is the arguments for the mirror-investigation command: {demisto.args()}")
-    mirror_type = demisto.args().get("type", "all")
-    auto_close = demisto.args().get("autoclose", "true")
-    mirror_direction = demisto.args().get("direction", "both")
-    mirror_to = demisto.args().get("mirrorTo", "group")
-    channel_name = demisto.args().get("channelName", "")
-    channel_topic = demisto.args().get("channelTopic", "")
-    kick_admin = argToBoolean(demisto.args().get("kickAdmin", "false"))
-    private = argToBoolean(demisto.args().get("private", "false"))
+    args = demisto.args()
+    demisto.debug(f"SlackV3 integration: This is the arguments for the mirror-investigation command: {args}")
+    mirror_type = args.get("type", "all")
+    auto_close = args.get("autoclose", "true")
+    mirror_direction = args.get("direction", "both")
+    mirror_to = args.get("mirrorTo", "group")
+    channel_name = args.get("channelName", "")
+    channel_topic = args.get("channelTopic", "")
+    kick_admin = argToBoolean(args.get("kickAdmin", "false"))
+    private = argToBoolean(args.get("private", "false"))
 
     investigation = demisto.investigation()
     demisto.debug(f"SlackV3 integration: This is the investigation - {investigation}")
@@ -1287,10 +1288,10 @@ def mirror_investigation():
         # Special case (XSUP-70395): `type` is the only provided argument, combined as
         # "<mirror_type>:<mirror_direction>" (e.g. "all:ToDemisto"). Split it and keep the other values
         # from the existing mirror context instead of overriding them with defaults.
-        if list(demisto.args()) == ["type"] and ":" in mirror_type:
+        if len(args) == 1 and "type" in args and ":" in mirror_type:
             mirror_type, mirror_direction = mirror_type.split(":", 1)
-            auto_close = mirror["auto_close"]
-            mirror_to = mirror["mirror_to"]
+            auto_close = mirror.get("auto_close")
+            mirror_to = mirror.get("mirror_to")
             demisto.debug(
                 f"SlackV3 integration: 'type' was the only argument and contained a ':'. "
                 f"Split into mirror_type='{mirror_type}', mirror_direction='{mirror_direction}'. "

--- a/Packs/Slack/Integrations/SlackV3/SlackV3.py
+++ b/Packs/Slack/Integrations/SlackV3/SlackV3.py
@@ -1284,6 +1284,18 @@ def mirror_investigation():
     else:
         mirror = mirrors.pop(mirrors.index(current_mirror[0]))
         conversation_id = mirror["channel_id"]
+        # Special case (XSUP-70395): `type` is the only provided argument, combined as
+        # "<mirror_type>:<mirror_direction>" (e.g. "all:ToDemisto"). Split it and keep the other values
+        # from the existing mirror context instead of overriding them with defaults.
+        if list(demisto.args()) == ["type"] and ":" in mirror_type:
+            mirror_type, mirror_direction = mirror_type.split(":", 1)
+            auto_close = mirror["auto_close"]
+            mirror_to = mirror["mirror_to"]
+            demisto.debug(
+                f"SlackV3 integration: 'type' was the only argument and contained a ':'. "
+                f"Split into mirror_type='{mirror_type}', mirror_direction='{mirror_direction}'. "
+                f"Kept auto_close={auto_close}, mirror_to={mirror_to} from the existing mirror context."
+            )
         if mirror_type:
             mirror["mirror_type"] = mirror_type
         if auto_close:

--- a/Packs/Slack/Integrations/SlackV3/SlackV3_test.py
+++ b/Packs/Slack/Integrations/SlackV3/SlackV3_test.py
@@ -1115,6 +1115,64 @@ def test_mirror_investigation_existing_investigation(mocker):
     assert our_mirror == new_mirror
 
 
+def test_mirror_investigation_existing_mirror_combined_type_only(mocker):
+    """
+    Given:
+        - An existing mirror in the context with non-default values (auto_close=False).
+        - The mirror-investigation command is invoked with only the `type` argument, containing a
+          combined "<mirror_type>:<mirror_direction>" value (e.g. "all:FromDemisto") - XSUP-70395.
+    When:
+        - Running mirror_investigation.
+    Then:
+        - The `type` value is split into mirror_type and mirror_direction.
+        - The existing `auto_close` and `mirror_to` values are preserved from the context and are NOT
+          overridden with the command defaults.
+    """
+    from SlackV3 import mirror_investigation
+
+    # Set - an existing mirror with auto_close=False (differs from the "true" default)
+    mirrors = [
+        {
+            "channel_id": "GKQ86DVPH",
+            "channel_name": "incident-681",
+            "channel_topic": "incident-681",
+            "investigation_id": "681",
+            "mirror_type": "all",
+            "mirror_direction": "both",
+            "mirror_to": "channel",
+            "auto_close": False,
+            "mirrored": True,
+        }
+    ]
+    set_integration_context({"mirrors": js.dumps(mirrors), "users": USERS, "conversations": CONVERSATIONS, "bot_id": "W12345678"})
+
+    def api_call(method: str, http_verb: str = "POST", file: str = None, params=None, json=None, data=None):
+        return None
+
+    # Only the `type` argument is provided, with a combined "<type>:<direction>" value.
+    mocker.patch.object(demisto, "args", return_value={"type": "chat:FromDemisto"})
+    mocker.patch.object(demisto, "investigation", return_value={"id": "681", "users": ["spengler"]})
+    mocker.patch.object(demisto, "results")
+    mocker.patch.object(demisto, "getIntegrationContext", side_effect=get_integration_context)
+    mocker.patch.object(demisto, "setIntegrationContext", side_effect=set_integration_context)
+    mocker.patch.object(slack_sdk.WebClient, "api_call", side_effect=api_call)
+
+    # Arrange
+    mirror_investigation()
+
+    # Assert
+    new_context = demisto.setIntegrationContext.call_args[0][0]
+    new_mirrors = js.loads(new_context["mirrors"])
+    our_mirror = next(m for m in new_mirrors if m["investigation_id"] == "681")
+
+    # The combined type was split correctly
+    assert our_mirror["mirror_type"] == "chat"
+    assert our_mirror["mirror_direction"] == "FromDemisto"
+    # The existing values were preserved and NOT overridden with the defaults ("true" / "group")
+    assert our_mirror["auto_close"] is False
+    assert our_mirror["mirror_to"] == "channel"
+
+
 def test_mirror_investigation_existing_channel(mocker):
     from SlackV3 import mirror_investigation
 

--- a/Packs/Slack/ReleaseNotes/3_8_6.md
+++ b/Packs/Slack/ReleaseNotes/3_8_6.md
@@ -3,4 +3,4 @@
 
 ##### Slack v3
 
-- Fixed an issue where running the ***mirror-investigation*** command on an existing mirror changed the **autoclose** and **mirrorTo** values under certain conditions instead of preserving the values stored in the context.
+- Fixed an issue where running the ***mirror-investigation*** command on an existing mirror changed the *autoclose* and *mirrorTo* values under certain conditions instead of preserving the values stored in the context.

--- a/Packs/Slack/ReleaseNotes/3_8_6.md
+++ b/Packs/Slack/ReleaseNotes/3_8_6.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Slack v3
+
+- Fixed an issue where running the ***mirror-investigation*** command on an existing mirror changed the **autoclose** and **mirrorTo** values under certain conditions instead of preserving the values stored in the context.

--- a/Packs/Slack/pack_metadata.json
+++ b/Packs/Slack/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Slack",
     "description": "Interact with Slack API - collect logs, send messages and notifications to your Slack team.",
     "support": "xsoar",
-    "currentVersion": "3.8.5",
+    "currentVersion": "3.8.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: XSUP-70395

## Description
- Fixed an issue where running the ***mirror-investigation*** command on an existing mirror changed the **autoclose** and **mirrorTo** values under certain conditions instead of preserving the values stored in the context.

## Must have
- [ ] Tests
- [ ] Documentation
