### PR TITLE
Update documentation, improve alert fetching

### DIFF
--- a/Packs/Code42/Integrations/Code42/Code42.py
+++ b/Packs/Code42/Integrations/Code42/Code42.py
@@ -321,13 +321,13 @@ class Code42Client(BaseClient):
         # This helper method does this for incoming sessions.
         alert.riskSeverity = SESSION_SEVERITY_LIST[max(alert.scores, key=lambda x: x.severity).severity]
         alert.state = max(alert.states, key=lambda x: x.source_timestamp).state_v2
-        alert.actor = self.incydr_sdk.actors.v1.get_actor_by_id(alert.actor_id).name
+        alert.actor = alert.actor_name or self.incydr_sdk.actors.v1.get_actor_by_id(alert.actor_id).name
         rule_name_list = []
         # It is possible for a session to trigger an alert rule that no longer exists.
         # We need to handle the 404 case.
         for rule in alert.triggered_alerts:
             try:
-                rule_name_list.append(self.incydr_sdk.alert_rules.v2.get_rule(rule.rule_id).name)
+                rule_name_list.append(rule.rule_name or self.incydr_sdk.alert_rules.v2.get_rule(rule.rule_id).name)
             except HTTPError:
                 pass
         alert.rule_names = ", ".join(rule_name_list)

--- a/Packs/Code42/Integrations/Code42/Code42.yml
+++ b/Packs/Code42/Integrations/Code42/Code42.yml
@@ -494,7 +494,7 @@ script:
       - all
       - incident
       - searches
-  dockerimage: demisto/py42:1.0.0.6978288
+  dockerimage: demisto/py42:1.0.0.10404775
   isfetch: true
   runonce: false
   script: '-'

--- a/Packs/Code42/Integrations/Code42/Code42.yml
+++ b/Packs/Code42/Integrations/Code42/Code42.yml
@@ -494,7 +494,7 @@ script:
       - all
       - incident
       - searches
-  dockerimage: demisto/py42:1.0.0.10404775
+  dockerimage: demisto/py42:1.0.0.10758190
   isfetch: true
   runonce: false
   script: '-'

--- a/Packs/Code42/Integrations/Code42/Code42_description.md
+++ b/Packs/Code42/Integrations/Code42/Code42_description.md
@@ -6,7 +6,8 @@ To configure this integration, you will need to [create an API Client](https://s
 
 * Users (Read/Write)
 * Detection Lists (Read/Write)
-* Alerts (Read/Write)
+* Alerts and Sessions (Read/Write)
+* Alert Rules (Read)
 * File Events (Read)
 * Device (Read)
 

--- a/Packs/Code42/Integrations/Code42/Code42_test.py
+++ b/Packs/Code42/Integrations/Code42/Code42_test.py
@@ -169,22 +169,11 @@ with open("test_data/alert_details_response.json") as f:
 MOCK_V2_FILE_EVENTS_RESPONSE = FileEventsPage.parse_file("test_data/v2_file_event_response.json")
 
 
-def _ensure_session_has_actor_and_rule_names(session: Session) -> Session:
-    """Backfill actor_name and rule_name when the installed SDK model omits these fields."""
-    session_dict = json.loads(session.json())
-    if not hasattr(session, "actor_name") and session_dict.get("actorName"):
-        session.actor_name = session_dict["actorName"]
-    for triggered_alert, rule_dict in zip(session.triggered_alerts, session_dict.get("triggeredAlerts", [])):
-        if not hasattr(triggered_alert, "rule_name") and rule_dict.get("ruleName"):
-            triggered_alert.rule_name = rule_dict["ruleName"]
-    return session
+MOCK_SESSION_RESPONSE = Session.parse_file("test_data/session_response.json")
 
+MOCK_SESSION_RESPONSE_2 = Session.parse_file("test_data/session_response_2.json")
 
-MOCK_SESSION_RESPONSE = _ensure_session_has_actor_and_rule_names(Session.parse_file("test_data/session_response.json"))
-
-MOCK_SESSION_RESPONSE_2 = _ensure_session_has_actor_and_rule_names(Session.parse_file("test_data/session_response_2.json"))
-
-MOCK_SESSION_RESPONSE_3 = _ensure_session_has_actor_and_rule_names(Session.parse_file("test_data/session_response_3.json"))
+MOCK_SESSION_RESPONSE_3 = Session.parse_file("test_data/session_response_3.json")
 
 MOCK_ACTOR_RESPONSE = Actor.parse_file("test_data/actor_response.json")
 

--- a/Packs/Code42/Integrations/Code42/Code42_test.py
+++ b/Packs/Code42/Integrations/Code42/Code42_test.py
@@ -1,4 +1,5 @@
 import json
+from copy import deepcopy
 
 import pytest
 from incydr import Client as incydrClient
@@ -167,11 +168,23 @@ with open("test_data/alert_details_response.json") as f:
 
 MOCK_V2_FILE_EVENTS_RESPONSE = FileEventsPage.parse_file("test_data/v2_file_event_response.json")
 
-MOCK_SESSION_RESPONSE = Session.parse_file("test_data/session_response.json")
 
-MOCK_SESSION_RESPONSE_2 = Session.parse_file("test_data/session_response_2.json")
+def _ensure_session_has_actor_and_rule_names(session: Session) -> Session:
+    """Backfill actor_name and rule_name when the installed SDK model omits these fields."""
+    session_dict = json.loads(session.json())
+    if not hasattr(session, "actor_name") and session_dict.get("actorName"):
+        session.actor_name = session_dict["actorName"]
+    for triggered_alert, rule_dict in zip(session.triggered_alerts, session_dict.get("triggeredAlerts", [])):
+        if not hasattr(triggered_alert, "rule_name") and rule_dict.get("ruleName"):
+            triggered_alert.rule_name = rule_dict["ruleName"]
+    return session
 
-MOCK_SESSION_RESPONSE_3 = Session.parse_file("test_data/session_response_3.json")
+
+MOCK_SESSION_RESPONSE = _ensure_session_has_actor_and_rule_names(Session.parse_file("test_data/session_response.json"))
+
+MOCK_SESSION_RESPONSE_2 = _ensure_session_has_actor_and_rule_names(Session.parse_file("test_data/session_response_2.json"))
+
+MOCK_SESSION_RESPONSE_3 = _ensure_session_has_actor_and_rule_names(Session.parse_file("test_data/session_response_3.json"))
 
 MOCK_ACTOR_RESPONSE = Actor.parse_file("test_data/actor_response.json")
 
@@ -522,6 +535,31 @@ def test_client_when_no_alert_found_returns(mocker, incydr_sdk_mock):
         client.get_alert_details("mock-id")
 
 
+def test_client_uses_actor_and_rule_names_from_session(incydr_sessions_mock):
+    client = _create_incydr_client(incydr_sessions_mock)
+    alert = client.get_alert_details("sessionid-abc-1")
+    assert alert.actor == "someactor@domain.com"
+    assert alert.rule_names == "example rule name"
+    incydr_sessions_mock.actors.v1.get_actor_by_id.assert_not_called()
+    incydr_sessions_mock.alert_rules.v2.get_rule.assert_not_called()
+
+
+def test_client_falls_back_to_actor_and_rule_lookup_when_names_missing(incydr_sdk_mock):
+    session = deepcopy(MOCK_SESSION_RESPONSE)
+    session.actor_name = None
+    for triggered_alert in session.triggered_alerts:
+        triggered_alert.rule_name = None
+    incydr_sdk_mock.sessions.v1.get_session_details.return_value = session
+    incydr_sdk_mock.actors.v1.get_actor_by_id.return_value = MOCK_ACTOR_RESPONSE
+    incydr_sdk_mock.alert_rules.v2.get_rule.return_value = MOCK_RULE_RESPONSE
+    client = _create_incydr_client(incydr_sdk_mock)
+    alert = client.get_alert_details("sessionid-abc-1")
+    assert alert.actor == "someactor@domain.com"
+    assert alert.rule_names == "example rule name"
+    incydr_sdk_mock.actors.v1.get_actor_by_id.assert_called_once_with("someactorid")
+    incydr_sdk_mock.alert_rules.v2.get_rule.assert_called_once_with("rule-id-abc-123")
+
+
 def test_client_when_no_user_found_raises_user_not_found(mocker, incydr_sdk_mock):
     incydr_sdk_mock.users.v1.get_user.side_effect = ValueError
     client = _create_incydr_client(incydr_sdk_mock)
@@ -575,6 +613,8 @@ def test_alert_get_command(incydr_sessions_mock):
     assert cmd_res.outputs == [MOCK_CODE42_ALERT_CONTEXT[0]]
     assert cmd_res.outputs_prefix == "Code42.SecurityAlert"
     assert cmd_res.outputs_key_field == "ID"
+    incydr_sessions_mock.actors.v1.get_actor_by_id.assert_not_called()
+    incydr_sessions_mock.alert_rules.v2.get_rule.assert_not_called()
 
 
 def test_alert_get_command_when_no_alert_found(mocker, incydr_sdk_mock):
@@ -593,6 +633,8 @@ def test_alert_update_state_command(incydr_sessions_mock):
     assert cmd_res.outputs == [MOCK_CODE42_ALERT_CONTEXT[0]]
     assert cmd_res.outputs_prefix == "Code42.SecurityAlert"
     assert cmd_res.outputs_key_field == "ID"
+    incydr_sessions_mock.actors.v1.get_actor_by_id.assert_not_called()
+    incydr_sessions_mock.alert_rules.v2.get_rule.assert_not_called()
 
 
 def test_alert_resolve_command(incydr_sessions_mock):
@@ -978,6 +1020,8 @@ def test_fetch_incidents_first_run(incydr_sessions_mock):
     )
     assert len(incidents) == 3
     assert next_run["last_fetch"]
+    incydr_sessions_mock.actors.v1.get_actor_by_id.assert_not_called()
+    incydr_sessions_mock.alert_rules.v2.get_rule.assert_not_called()
 
 
 def test_fetch_incidents_next_run(incydr_sessions_mock):

--- a/Packs/Code42/Integrations/Code42/test_data/session_response.json
+++ b/Packs/Code42/Integrations/Code42/test_data/session_response.json
@@ -2,6 +2,7 @@
   "sessionId": "sessionid-abc-1",
   "tenantId": "sometenantid",
   "actorId": "someactorid",
+  "actorName": "someactor@domain.com",
   "beginTime": 1726082760680,
   "endTime": 1726082762722,
   "firstObserved": 1726083300017,
@@ -31,6 +32,7 @@
     {
       "alertId": "alert-id-abc-123",
       "ruleId": "rule-id-abc-123",
+      "ruleName": "example rule name",
       "lessonId": null
     }
   ],

--- a/Packs/Code42/Integrations/Code42/test_data/session_response_2.json
+++ b/Packs/Code42/Integrations/Code42/test_data/session_response_2.json
@@ -2,6 +2,7 @@
   "sessionId": "sessionid-abc-2",
   "tenantId": "sometenantid",
   "actorId": "someactorid",
+  "actorName": "someactor@domain.com",
   "beginTime": 1726082760680,
   "endTime": 1726082762722,
   "firstObserved": 1726083300018,
@@ -31,6 +32,7 @@
     {
       "alertId": "alert-id-abc-123",
       "ruleId": "rule-id-abc-123",
+      "ruleName": "example rule name",
       "lessonId": null
     }
   ],

--- a/Packs/Code42/Integrations/Code42/test_data/session_response_3.json
+++ b/Packs/Code42/Integrations/Code42/test_data/session_response_3.json
@@ -2,6 +2,7 @@
   "sessionId": "sessionid-abc-3",
   "tenantId": "sometenantid",
   "actorId": "someactorid",
+  "actorName": "someactor@domain.com",
   "beginTime": 1726082760680,
   "endTime": 1726082762722,
   "firstObserved": 1726083300018,
@@ -31,6 +32,7 @@
     {
       "alertId": "alert-id-abc-123",
       "ruleId": "rule-id-abc-123",
+      "ruleName": "example rule name",
       "lessonId": null
     }
   ],

--- a/Packs/Code42/ReleaseNotes/6_1_14.md
+++ b/Packs/Code42/ReleaseNotes/6_1_14.md
@@ -3,4 +3,4 @@
 
 ##### Code42
 - Documentation and metadata improvements.
-- Updated the Docker image to: *demisto/py42:1.0.0.6978288*.
+- Updated the Docker image to: *demisto/py42:1.0.0.10758190*.

--- a/Packs/Code42/ReleaseNotes/6_1_14.md
+++ b/Packs/Code42/ReleaseNotes/6_1_14.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Code42
+- Documentation and metadata improvements.
+- Updated the Docker image to: *demisto/py42:1.0.0.6978288*.

--- a/Packs/Code42/pack_metadata.json
+++ b/Packs/Code42/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Code42",
     "description": "The Code42 INCYDR integration accelerates insider threat incident response and remediation procedures for potential data exfiltration across computers, email, cloud and SaaS apps.",
     "support": "partner",
-    "currentVersion": "6.1.13",
+    "currentVersion": "6.1.14",
     "author": "Code42",
     "url": "https://support.code42.com/Administrator/Cloud/Monitoring_and_managing/Install_and_manage_the_Code42_app_for_Cortex_XSOAR",
     "email": "gethelp@code42.com",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (reason)

## Description
Updates some documentation on the Code42 integration, updates the docker image to the latest version, and improves the efficiency of alert fetching by preferring to use data on the alert response itself, falling back to additional API calls only if that isn't present.

## Must have
- [x] Tests
- [x] Documentation


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-17224