### PR TITLE
added content-type header to REST requests

### DIFF
--- a/Packs/ClarotyXDome/Integrations/XDome/XDome.py
+++ b/Packs/ClarotyXDome/Integrations/XDome/XDome.py
@@ -729,7 +729,7 @@ def main() -> None:
 
     demisto.debug(f"Command being called is {command}")
     try:
-        headers: dict = {"Authorization": f"Bearer {api_key}"}
+        headers: dict = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
 
         client = Client(
             base_url=base_url,

--- a/Packs/ClarotyXDome/ReleaseNotes/1_0_6.md
+++ b/Packs/ClarotyXDome/ReleaseNotes/1_0_6.md
@@ -1,0 +1,1 @@
+- added content-type header to REST request

--- a/Packs/ClarotyXDome/pack_metadata.json
+++ b/Packs/ClarotyXDome/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Claroty xDome",
     "description": "Use xDome to manage assets and alerts.",
     "support": "partner",
-    "currentVersion": "1.0.5",
+    "currentVersion": "1.0.6",
     "author": "Claroty",
     "url": "",
     "email": "support@claroty.com",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
<!-- To link a Jira ticket use fixes/related: link to the issue, for example relates: link to the issue

## Description
Claroty is making a change to the xDome server, and requests which do not include content-type header will break.
This is why we introduce this change.

## Must have
- [x] Tests
- [x] Documentation


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-17236