### PR TITLE
Skyhigh Security - Handle Undocumented Severities

### DIFF
--- a/Packs/SkyhighSecurity/Integrations/SkyhighSecurity/SkyhighSecurity.py
+++ b/Packs/SkyhighSecurity/Integrations/SkyhighSecurity/SkyhighSecurity.py
@@ -103,23 +103,29 @@ def calculate_offset_and_limit(**kwargs) -> tuple[int, int]:
 
 
 def convert_to_xsoar_severity(severity: str) -> float:
-    """Maps Skyhigh Security severity to Cortex XSOAR severity
+    """Maps a Skyhigh Security incident severity to a Cortex XSOAR severity.
 
-    Converts the Skyhigh Security incident severity level to Cortex XSOAR incident severity (1 to 4)
-    for mapping.
+    Known documented values ('low', 'medium', 'high'), as well as 'info', map to their
+    XSOAR equivalents. The lookup is case-insensitive. Any unrecognized or missing value
+    is mapped to IncidentSeverity.UNKNOWN.
 
     :type severity: ``str``
-    :param severity: severity as returned from the Skyhigh Security API ('info', 'low', 'medium', 'high')
+    :param severity: severity as returned from the Skyhigh Security API.
 
-    :return: Cortex XSOAR Severity (int: 1 to 4)
+    :return: Cortex XSOAR Severity.
     :rtype: ``float``
     """
-    return {
+    severity_map = {
         "info": IncidentSeverity.INFO,
         "low": IncidentSeverity.LOW,
         "medium": IncidentSeverity.MEDIUM,
         "high": IncidentSeverity.HIGH,
-    }[severity]
+    }
+    normalized = (severity or "").lower()
+    if normalized not in severity_map:
+        demisto.debug(f"Unmapped Skyhigh incidentRiskSeverity '{severity}' received; defaulting to UNKNOWN severity.")
+        return IncidentSeverity.UNKNOWN
+    return severity_map[normalized]
 
 
 """ COMMAND FUNCTIONS """

--- a/Packs/SkyhighSecurity/Integrations/SkyhighSecurity/SkyhighSecurity.yml
+++ b/Packs/SkyhighSecurity/Integrations/SkyhighSecurity/SkyhighSecurity.yml
@@ -282,7 +282,7 @@ script:
       required: true
     description: Adds new content to an existing policy dictionary.
     name: skyhigh-security-policy-dictionary-update
-  dockerimage: demisto/python3:3.12.8.3296088
+  dockerimage: demisto/python3:3.12.13.10404775
   isfetch: true
   runonce: false
   script: '-'

--- a/Packs/SkyhighSecurity/Integrations/SkyhighSecurity/SkyhighSecurity_test.py
+++ b/Packs/SkyhighSecurity/Integrations/SkyhighSecurity/SkyhighSecurity_test.py
@@ -241,6 +241,8 @@ def test_fetch_incidents(mocker):
         ("warn", 0),
         ("unknown", 0),
         ("TEST", 0),
+        ("", 0),
+        (None, 0),
     ],
 )
 def test_convert_to_xsoar_severity(severity, expected):

--- a/Packs/SkyhighSecurity/Integrations/SkyhighSecurity/SkyhighSecurity_test.py
+++ b/Packs/SkyhighSecurity/Integrations/SkyhighSecurity/SkyhighSecurity_test.py
@@ -1,6 +1,7 @@
 import json
 
 import demistomock as demisto
+import pytest
 import requests_mock
 from freezegun import freeze_time
 from SkyhighSecurity import main
@@ -227,3 +228,31 @@ def test_fetch_incidents(mocker):
     last_run, incidents = fetch_incidents(client, params)
 
     assert len(incidents) == 0
+
+
+@pytest.mark.parametrize(
+    "severity, expected",
+    [
+        ("info", 0.5),
+        ("low", 1),
+        ("medium", 2),
+        ("high", 3),
+        ("HIGH", 3),
+        ("warn", 0),
+        ("unknown", 0),
+        ("TEST", 0),
+    ],
+)
+def test_convert_to_xsoar_severity(severity, expected):
+    """
+    Given:
+        - A severity value returned from the Skyhigh Security API (known, case variant, or unmapped)
+    When:
+        - convert_to_xsoar_severity is called
+    Then:
+        - Ensure known values map to their XSOAR equivalent (case-insensitive) and unmapped
+          values fall back to UNKNOWN without raising
+    """
+    from SkyhighSecurity import convert_to_xsoar_severity
+
+    assert convert_to_xsoar_severity(severity) == expected

--- a/Packs/SkyhighSecurity/ReleaseNotes/1_0_23.md
+++ b/Packs/SkyhighSecurity/ReleaseNotes/1_0_23.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Skyhigh Security
+
+- Fixed an issue where **fetch-incidents** failed when an incident returned an undocumented risk severity value. Unknown severities are now mapped to *Unknown*.

--- a/Packs/SkyhighSecurity/ReleaseNotes/1_0_23.md
+++ b/Packs/SkyhighSecurity/ReleaseNotes/1_0_23.md
@@ -4,3 +4,4 @@
 ##### Skyhigh Security
 
 - Fixed an issue where ***fetch-incidents*** failed when an incident returned an undocumented risk severity value. Unknown severities are now mapped to *Unknown*.
+- Updated the Docker image to: *demisto/python3:3.12.13.10404775*.

--- a/Packs/SkyhighSecurity/ReleaseNotes/1_0_23.md
+++ b/Packs/SkyhighSecurity/ReleaseNotes/1_0_23.md
@@ -3,4 +3,4 @@
 
 ##### Skyhigh Security
 
-- Fixed an issue where **fetch-incidents** failed when an incident returned an undocumented risk severity value. Unknown severities are now mapped to *Unknown*.
+- Fixed an issue where ***fetch-incidents*** failed when an incident returned an undocumented risk severity value. Unknown severities are now mapped to *Unknown*.

--- a/Packs/SkyhighSecurity/pack_metadata.json
+++ b/Packs/SkyhighSecurity/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Skyhigh Security SSE",
     "description": "Skyhigh Security is a cloud-based, multi-tenant service that enables Cloud Discovery and Risk Monitoring, Cloud Usage Analytics, Cloud Access and Control.",
     "support": "xsoar",
-    "currentVersion": "1.0.22",
+    "currentVersion": "1.0.23",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "itemPrefix": [


### PR DESCRIPTION

## Related Issues
fixes: [XSUP-72302](https://jira-dc.paloaltonetworks.com/browse/XSUP-72302)

## Description
Fixed an issue where **fetch-incidents** failed when an incident returned an undocumented risk severity value. Unknown severities are now mapped to *Unknown*.
