### PR TITLE
CIAC-17199: Fix PR creation for internal contributions with mixed XSOAR and XSIAM content

### DIFF
--- a/.github/github_workflow_scripts/create_internal_pr.py
+++ b/.github/github_workflow_scripts/create_internal_pr.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import functools
 import json
 from pathlib import Path
 import subprocess
@@ -41,6 +42,7 @@ RELEASE_NOTES_ITEMS = ["ReleaseNotes", "pack_metadata.json"]
 # -----------------------------
 # Git utilities
 # -----------------------------
+@functools.lru_cache(maxsize=1)
 def get_repo_root() -> str:
     """Get the git repository root directory.
 
@@ -49,11 +51,11 @@ def get_repo_root() -> str:
     must execute from the repository root. Without this, git rm --ignore-unmatch
     silently does nothing because the paths don't exist relative to the cwd.
     """
-    result = subprocess.run(["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True)
+    result = subprocess.run(["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True, check=True)
     return result.stdout.strip()
 
 
-def run_git_command(cmd, github_token, raise_on_error=True):
+def run_git_command(cmd: list[str], github_token: str, raise_on_error: bool = True) -> subprocess.CompletedProcess:
     log_cmd = [c.replace(github_token, "***") for c in cmd]
     print(f"Running: {' '.join(log_cmd)}")
     result = subprocess.run(cmd, capture_output=True, text=True, cwd=get_repo_root())

--- a/.github/github_workflow_scripts/create_internal_pr.py
+++ b/.github/github_workflow_scripts/create_internal_pr.py
@@ -49,9 +49,7 @@ def get_repo_root() -> str:
     must execute from the repository root. Without this, git rm --ignore-unmatch
     silently does nothing because the paths don't exist relative to the cwd.
     """
-    result = subprocess.run(
-        ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True
-    )
+    result = subprocess.run(["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True)
     return result.stdout.strip()
 
 

--- a/.github/github_workflow_scripts/create_internal_pr.py
+++ b/.github/github_workflow_scripts/create_internal_pr.py
@@ -41,10 +41,24 @@ RELEASE_NOTES_ITEMS = ["ReleaseNotes", "pack_metadata.json"]
 # -----------------------------
 # Git utilities
 # -----------------------------
+def get_repo_root() -> str:
+    """Get the git repository root directory.
+
+    The workflow runs this script from .github/github_workflow_scripts/,
+    but git commands operating on repo-relative file paths (e.g. Packs/...)
+    must execute from the repository root. Without this, git rm --ignore-unmatch
+    silently does nothing because the paths don't exist relative to the cwd.
+    """
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
 def run_git_command(cmd, github_token, raise_on_error=True):
     log_cmd = [c.replace(github_token, "***") for c in cmd]
     print(f"Running: {' '.join(log_cmd)}")
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = subprocess.run(cmd, capture_output=True, text=True, cwd=get_repo_root())
 
     if result.returncode != 0 and raise_on_error:
         print(f"Error: {result.stderr}")


### PR DESCRIPTION

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-17199

## Description

**Root cause:**
(create_internal_pr.py:61): The GitHub Actions workflow does cd .github/github_workflow_scripts before running the script. All git commands (git rm, git checkout origin/master -- <file>) received repo-relative paths like Packs/AbnormalSecurity/..., but executed from the subdirectory. --ignore-unmatch silently swallowed the errors, so both branches stayed identical.

**Fix:** Added get_repo_root() helper and cwd=get_repo_root() to subprocess.run in run_git_command so all git commands run from the repo root.

