### PR TITLE
XSUP-72364 - fix microsoft_windows_raw event_type task mapping

### DIFF
--- a/Packs/MicrosoftWindowsEvents/ModelingRules/MicrosoftWindowsEvents_1_3/MicrosoftWindowsEvents_1_3.xif
+++ b/Packs/MicrosoftWindowsEvents/ModelingRules/MicrosoftWindowsEvents_1_3/MicrosoftWindowsEvents_1_3.xif
@@ -64,7 +64,33 @@ filter channel in ("System", "Application","Directory Service") or provider_name
         user_name = coalesce(user -> name, event_data -> User, event_data -> SubjectUserName, user_data -> SubjectUserName, arrayindex(regextract(message, "User:\s*(?:[^\\]+\\)*(\S+)"), 0), arrayindex(regextract(message, "User \"([^\"]+)\""), 0), if(channel="Application" and event_data -> param3 contains "*\\*", event_data -> param3),event_data -> ["Detection User"],event_data -> ["Requester"]), 
         user_sid = coalesce(event_data -> SID, event_data -> SubjectUserSid, user -> identifier, user -> SubjectUserSid, event_data -> UserSid, if(provider_name = "Microsoft-Windows-Windows Firewall With Advanced Security", arrayindex(regextract(message, "Modifying\s*User\:\s+(.*)\b\s+Modifying\s+Application:"), 0))),
         user_type = user -> type,
-        check_task_string = if(task_str ~= "\d+", null, task_str)
+        check_task_string = if(task_str ~= "\d+", null, task_str),
+        // XSUP-72364: the raw `task` (TaskCategory) column from the XDR Collector / Winlogbeat
+        // profile is unreliable (a single event_id can carry multiple wrong task names, e.g. a
+        // 4624 logon tagged "Process Creation"/"Detailed File Share"). Re-derive the canonical
+        // TaskCategory from event_id for the standard Security-Auditing events so xdm.event.type
+        // is correct regardless of the corrupted raw value.
+        canonical_task = if(provider_name contains "Microsoft-Windows-Security-",
+            if(event_id_string in ("4624","4625","4648"), "Logon",
+               event_id_string in ("4634","4647"), "Logoff",
+               event_id_string in ("4778","4779","4800","4801","4802","4803","4825"), "Other Logon/Logoff Events",
+               event_id_string = "4672", "Special Logon",
+               event_id_string in ("4688"), "Process Creation",
+               event_id_string in ("4689"), "Process Termination",
+               event_id_string in ("4673","4674"), "Sensitive Privilege Use",
+               event_id_string in ("4662"), "Directory Service Access",
+               event_id_string in ("4768","4771"), "Kerberos Authentication Service",
+               event_id_string in ("4769","4770"), "Kerberos Service Ticket Operations",
+               event_id_string in ("4776"), "Credential Validation",
+               event_id_string in ("4663"), "Removable Storage",
+               event_id_string in ("4670","4703","4704","4705","4911"), "Authorization Policy Change",
+               event_id_string in ("4719"), "Audit Policy Change",
+               event_id_string in ("4720","4722","4723","4724","4725","4726","4738","4740","4767","4780","4781","4798"), "User Account Management",
+               event_id_string in ("4741","4742","4743"), "Computer Account Management",
+               event_id_string in ("4727","4728","4729","4730","4731","4732","4733","4734","4737","4754","4755","4756","4757","4758","4799"), "Security Group Management",
+               event_id_string in ("4697"), "Security System Extension",
+               null),
+            null)
 | alter // post-extraction processing & validations
         check_rule_name1 = if(rule_name1 ~= "\S", rule_name1, null),
     	check_rule_name2 = if(rule_name2 ~= "\S", rule_name2, null),
@@ -79,7 +105,7 @@ filter channel in ("System", "Application","Directory Service") or provider_name
         check_fw_process_name = if(provider_name = "Microsoft-Windows-Windows Firewall With Advanced Security", arraystring(regextract(message, "Modifying\s*Application:\s+\S+\\([^\.]+\.exe)"), ""), null),
         get_message_instance_exe_path = if(message_instance ~= "exe", message_instance, null),
         get_message_instance_exe_process = if(message_instance ~= "exe", arrayindex(regextract(message_instance, "\\([a-zA-Z0-9]+\.exe)$"), 0), null)
-| alter event_type = coalesce(event_action, to_string(task), check_message_task, event_name) // set event type
+| alter event_type = coalesce(event_action, canonical_task, to_string(task), check_message_task, event_name) // set event type (XSUP-72364: canonical_task first so a corrupted raw task does not poison xdm.event.type)
 | alter // XDM mappings 
         xdm.alert.category = threat_category,
         xdm.alert.description = coalesce(if(channel="System", error_code, check_fw_description != null, check_fw_description, error_message), if(event_id_string in ("4886", "4887", "4888","4897","4898"), object_create("FW_link", event_fwlink, "Disposition", event_data -> Disposition, "cdc", arrayindex(regextract(event_attributes, "cdc:([^\n]+)") ,0), "rmd", arrayindex(regextract(event_attributes, "rmd:([^\n]+)") ,0), "ccm", arrayindex(regextract(event_attributes, "ccm:([^\n]+)") ,0), "error_code", event_data -> Status, "sub_error_code", event_data -> SubStatus))),

--- a/Packs/MicrosoftWindowsEvents/ModelingRules/MicrosoftWindowsEvents_1_3/MicrosoftWindowsEvents_1_3.xif
+++ b/Packs/MicrosoftWindowsEvents/ModelingRules/MicrosoftWindowsEvents_1_3/MicrosoftWindowsEvents_1_3.xif
@@ -65,11 +65,6 @@ filter channel in ("System", "Application","Directory Service") or provider_name
         user_sid = coalesce(event_data -> SID, event_data -> SubjectUserSid, user -> identifier, user -> SubjectUserSid, event_data -> UserSid, if(provider_name = "Microsoft-Windows-Windows Firewall With Advanced Security", arrayindex(regextract(message, "Modifying\s*User\:\s+(.*)\b\s+Modifying\s+Application:"), 0))),
         user_type = user -> type,
         check_task_string = if(task_str ~= "\d+", null, task_str),
-        // XSUP-72364: the raw `task` (TaskCategory) column from the XDR Collector / Winlogbeat
-        // profile is unreliable (a single event_id can carry multiple wrong task names, e.g. a
-        // 4624 logon tagged "Process Creation"/"Detailed File Share"). Re-derive the canonical
-        // TaskCategory from event_id for the standard Security-Auditing events so xdm.event.type
-        // is correct regardless of the corrupted raw value.
         canonical_task = if(provider_name contains "Microsoft-Windows-Security-",
             if(event_id_string in ("4624","4625","4648"), "Logon",
                event_id_string in ("4634","4647"), "Logoff",
@@ -105,7 +100,7 @@ filter channel in ("System", "Application","Directory Service") or provider_name
         check_fw_process_name = if(provider_name = "Microsoft-Windows-Windows Firewall With Advanced Security", arraystring(regextract(message, "Modifying\s*Application:\s+\S+\\([^\.]+\.exe)"), ""), null),
         get_message_instance_exe_path = if(message_instance ~= "exe", message_instance, null),
         get_message_instance_exe_process = if(message_instance ~= "exe", arrayindex(regextract(message_instance, "\\([a-zA-Z0-9]+\.exe)$"), 0), null)
-| alter event_type = coalesce(event_action, canonical_task, to_string(task), check_message_task, event_name) // set event type (XSUP-72364: canonical_task first so a corrupted raw task does not poison xdm.event.type)
+| alter event_type = coalesce(event_action, canonical_task, to_string(task), check_message_task, event_name) // set event type
 | alter // XDM mappings 
         xdm.alert.category = threat_category,
         xdm.alert.description = coalesce(if(channel="System", error_code, check_fw_description != null, check_fw_description, error_message), if(event_id_string in ("4886", "4887", "4888","4897","4898"), object_create("FW_link", event_fwlink, "Disposition", event_data -> Disposition, "cdc", arrayindex(regextract(event_attributes, "cdc:([^\n]+)") ,0), "rmd", arrayindex(regextract(event_attributes, "rmd:([^\n]+)") ,0), "ccm", arrayindex(regextract(event_attributes, "ccm:([^\n]+)") ,0), "error_code", event_data -> Status, "sub_error_code", event_data -> SubStatus))),

--- a/Packs/MicrosoftWindowsEvents/ReleaseNotes/1_1_32.md
+++ b/Packs/MicrosoftWindowsEvents/ReleaseNotes/1_1_32.md
@@ -1,0 +1,6 @@
+
+#### Modeling Rules
+
+##### Microsoft Windows Events Modeling Rule
+
+Fixed an issue where **xdm.event.type** for `microsoft_windows_raw` could be set from an unreliable `task` (TaskCategory) value produced by the collector, causing incorrect event types (for example a `4624` logon showing as *Process Creation* or *Detailed File Share*). The rule now derives the canonical TaskCategory from `event_id` for standard Security-Auditing events.

--- a/Packs/MicrosoftWindowsEvents/pack_metadata.json
+++ b/Packs/MicrosoftWindowsEvents/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Windows Event Logs",
     "description": "The Windows event log is a detailed record of system, security and application notifications stored by the Windows operating system.",
     "support": "xsoar",
-    "currentVersion": "1.1.31",
+    "currentVersion": "1.1.32",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
https://jira-dc.paloaltonetworks.com/browse/XSUP-72364

## Description
Fixed an issue where `xdm.event.type` for the `microsoft_windows_raw` dataset could be set from an unreliable `task` (TaskCategory) value produced by the XDR Collector / Winlogbeat profile, which caused incorrect event types (for example a `4624` logon event showing as *Process Creation* or *Detailed File Share*).

Investigation on a live tenant showed the raw `task` column is wrong for a large share of Security-Auditing events (measured ~18% of `4624`, ~17% of `4634`, ~6% of `4688`), with the same generic task buckets spread across 17+ distinct event IDs. The underlying event (event_id, message, provider) is correct; only the `task` label is corrupted.

The modeling rule previously derived `event_type` via `coalesce(event_action, to_string(task), ...)`, so the corrupted `task` flowed straight into `xdm.event.type`. This change adds a `canonical_task` derived from `event_id` for standard `Microsoft-Windows-Security-*` events and prefers it in the `event_type` coalesce, so `xdm.event.type` is correct regardless of the corrupted raw value. Behavior for non-Security providers is unchanged (`canonical_task` is null and the previous coalesce order applies).

Pack `MicrosoftWindowsEvents` bumped 1.1.31 -> 1.1.32.


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-17246