### PR TITLE
XSUP-72438 - Zscaler map xdm.event.type for zscalernss-fw

### DIFF
--- a/Packs/Zscaler/ModelingRules/ZscalerModelingRule_1_3/ZscalerModelingRule_1_3.xif
+++ b/Packs/Zscaler/ModelingRules/ZscalerModelingRule_1_3/ZscalerModelingRule_1_3.xif
@@ -287,6 +287,7 @@ filter sourcetype ="zscalernss-fw"
         os = lowercase(_raw_log -> deviceostype),
         user = coalesce(_raw_log -> user,_raw_log -> login)
 | alter 
+        xdm.event.type = sourcetype,
         xdm.source.user.upn = user,
         xdm.source.user.domain = arrayindex(split(user, "@"),-1),
         xdm.target.port = to_integer(_raw_log -> cdport),

--- a/Packs/Zscaler/ReleaseNotes/1_5_9.md
+++ b/Packs/Zscaler/ReleaseNotes/1_5_9.md
@@ -1,0 +1,6 @@
+
+#### Modeling Rules
+
+##### Zscaler Internet Access Modeling Rule
+
+Mapped **xdm.event.type** for **zscalernss-fw** (Cloud NSS Firewall) logs so firewall events can be distinguished from web events in the modeled data. Previously only the web, DNS, and audit sourcetypes set this field.

--- a/Packs/Zscaler/pack_metadata.json
+++ b/Packs/Zscaler/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Zscaler Internet Access",
     "description": "Zscaler is a cloud security solution built for performance and flexible scalability.",
     "support": "xsoar",
-    "currentVersion": "1.5.8",
+    "currentVersion": "1.5.9",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues

https://jira-dc.paloaltonetworks.com/browse/XSUP-72438

## Description

The Zscaler Internet Access modeling rule (`ZscalerModelingRule_1_3`) maps `xdm.event.type = sourcetype` for the `zscalernss-dns`, `zscalernss-audit`, and `zscalernss-web` sourcetypes within the `zscaler_cloudnss_raw` dataset, but the `zscalernss-fw` (Cloud NSS Firewall) branch was missing this assignment. As a result, firewall events had a NULL `xdm.event.type` in the modeled data, so customers could not distinguish Zscaler web from firewall logs in investigation and correlation.

This PR adds `xdm.event.type = sourcetype` to the `zscalernss-fw` branch, matching the other Cloud NSS sourcetypes.

Verified on a customer tenant (BigQuery): in the content-provided (MARKETPLACE) modeled view, `zscalernss-web` rows had `xdm.event.type='zscalernss-web'` while `zscalernss-fw` rows were NULL; the customer's own USER-level modeling override already sets `xdm.event.type=sourcetype` for both, confirming the intended value.

### Release Note

Mapped `xdm.event.type` for `zscalernss-fw` (Cloud NSS Firewall) logs.

> Note: modeling-rule testdata for this pack lives in `content-private`; a matching `zscalernss-fw` test case asserting `xdm.event.type == "zscalernss-fw"` should be added there.
