### PR TITLE
Ignite Implemented truncate_message function to limit message length.

### DIFF
--- a/Packs/Flashpoint/Integrations/Ignite/Ignite.py
+++ b/Packs/Flashpoint/Integrations/Ignite/Ignite.py
@@ -2029,14 +2029,14 @@ def html_to_text(html) -> str:
     return text.strip()
 
 
-def truncate_message(message: str, max_length: int = MESSAGE_MAX_LENGTH) -> str:
+def truncate_message(message: str | None, max_length: int = MESSAGE_MAX_LENGTH) -> str | None:
     """
     Cut a free-text message down to `max_length` characters.
 
     :param message: The raw message text to truncate.
     :param max_length: Maximum number of characters to keep.
 
-    :return: The truncated message, unchanged if it was already short enough.
+    :return: The truncated message, unchanged if it was already short enough or not a non-empty string.
     """
     if not message or not isinstance(message, str) or len(message) <= max_length:
         return message
@@ -3306,26 +3306,27 @@ def ip_lookup_command(client: Client, ip: str, exact_match: bool = False) -> Com
 
             limited_indicators = []
             for indicator in indicators:
-                for enr_key, enr_val in indicator.get("enrichments", {}).items():
+                limited_indicator = deepcopy(indicator)
+
+                for enr_key, enr_val in limited_indicator.get("enrichments", {}).items():
                     if isinstance(enr_val, list) and len(enr_val) > client.reputation_enrichments_limit:
                         demisto.debug(
                             f"Community search for IP {ip}: enrichments[{enr_key}] truncated to "
                             f"{client.reputation_enrichments_limit} entries for indicator "
-                            f"{indicator.get('id', 'unknown')}. Full data available in raw_response."
+                            f"{limited_indicator.get('id', 'unknown')}. Full data available in raw_response."
                         )
-                        indicator["enrichments"][enr_key] = enr_val[: client.reputation_enrichments_limit]
+                        limited_indicator["enrichments"][enr_key] = enr_val[: client.reputation_enrichments_limit]
 
-                raw_message = indicator.get("message")
-                if isinstance(raw_message, str) and raw_message:
-                    truncated_message = truncate_message(raw_message)
-                    if truncated_message != raw_message:
-                        demisto.debug(
-                            f"Community search for IP {ip}: message truncated for indicator "
-                            f"{indicator.get('id', 'unknown')}. Full content available in raw_response."
-                        )
-                    indicator["message"] = truncated_message
+                raw_message = limited_indicator.get("message")
+                truncated_message = truncate_message(raw_message)
+                if truncated_message != raw_message:
+                    demisto.debug(
+                        f"Community search for IP {ip}: message truncated for indicator "
+                        f"{limited_indicator.get('id', 'unknown')}. Full content available in raw_response."
+                    )
+                    limited_indicator["message"] = truncated_message
 
-                limited_indicators.append(indicator)
+                limited_indicators.append(limited_indicator)
             command_results = CommandResults(
                 outputs_prefix=OUTPUT_PREFIX["IP_COMMUNITY_SEARCH"],
                 outputs_key_field="id",

--- a/Packs/Flashpoint/Integrations/Ignite/Ignite.py
+++ b/Packs/Flashpoint/Integrations/Ignite/Ignite.py
@@ -27,7 +27,7 @@ DEFAULT_LIMIT = 10
 DEFAULT_REPORT_LIMIT = 5
 DEFAULT_REPUTATION_LIMIT = 5
 DEFAULT_REPUTATION_CONTEXT_LIMIT = 50  # Default max entries for both relationships and enrichments per reputation result
-MESSAGE_MAX_LENGTH = 500  # Max characters to keep from a community search indicator's "message" field.
+DEFAULT_MESSAGE_MAX_LENGTH = 500  # Max characters to keep from a community search indicator's "message" field.
 MESSAGE_TRUNCATION_SUFFIX = "... [message truncated, full content available in raw_response]"
 MAX_PAGE_SIZE = 1000
 MAX_FETCH_LIMIT = 200
@@ -365,6 +365,7 @@ class Client(BaseClient):
         proxy,
         create_relationships,
         reputation_enrichments_limit: int = DEFAULT_REPUTATION_CONTEXT_LIMIT,
+        message_max_length: int = DEFAULT_MESSAGE_MAX_LENGTH,
     ):
         """Initialize class object.
 
@@ -386,6 +387,10 @@ class Client(BaseClient):
         :type reputation_enrichments_limit: ``int``
         :param reputation_enrichments_limit: Maximum number of enrichment entries stored per reputation
             command result. Lower values improve performance; higher values preserve more details.
+
+        :type message_max_length: ``int``
+        :param message_max_length: Maximum number of characters kept from a community search indicator's
+            "message" field. Lower values reduce context size; higher values preserve more content.
         """
         self.url = url
 
@@ -399,6 +404,7 @@ class Client(BaseClient):
         self.proxy = proxy
         self.create_relationships = create_relationships
         self.reputation_enrichments_limit = reputation_enrichments_limit
+        self.message_max_length = message_max_length
 
         super().__init__(base_url=self.url, headers=self.headers, verify=self.verify, proxy=self.proxy)
 
@@ -2029,7 +2035,7 @@ def html_to_text(html) -> str:
     return text.strip()
 
 
-def truncate_message(message: str | None, max_length: int = MESSAGE_MAX_LENGTH) -> str | None:
+def truncate_message(message: str | None, max_length: int = DEFAULT_MESSAGE_MAX_LENGTH) -> str | None:
     """
     Cut a free-text message down to `max_length` characters.
 
@@ -3318,7 +3324,7 @@ def ip_lookup_command(client: Client, ip: str, exact_match: bool = False) -> Com
                         limited_indicator["enrichments"][enr_key] = enr_val[: client.reputation_enrichments_limit]
 
                 raw_message = limited_indicator.get("message")
-                truncated_message = truncate_message(raw_message)
+                truncated_message = truncate_message(raw_message, client.message_max_length)
                 if truncated_message != raw_message:
                     demisto.debug(
                         f"Community search for IP {ip}: message truncated for indicator "
@@ -4715,6 +4721,8 @@ def main():
         or DEFAULT_REPUTATION_CONTEXT_LIMIT
     )
 
+    message_max_length = arg_to_number(params.get("message_max_length", DEFAULT_MESSAGE_MAX_LENGTH)) or DEFAULT_MESSAGE_MAX_LENGTH
+
     config_exact_match = argToBoolean(params.get("ioc_enrichment_exact_match", False))
 
     # if your Client class inherits from BaseClient, system proxy is handled
@@ -4735,7 +4743,7 @@ def main():
             "X-FP-IntegrationVersion": INTEGRATION_VERSION,
         }
         validate_params(command, params)
-        client = Client(url, headers, verify, proxy, create_relationships, reputation_enrichments_limit)
+        client = Client(url, headers, verify, proxy, create_relationships, reputation_enrichments_limit, message_max_length)
 
         COMMAND_TO_FUNCTION: dict = {
             "flashpoint-ignite-intelligence-report-search": get_reports_command,

--- a/Packs/Flashpoint/Integrations/Ignite/Ignite.py
+++ b/Packs/Flashpoint/Integrations/Ignite/Ignite.py
@@ -27,6 +27,8 @@ DEFAULT_LIMIT = 10
 DEFAULT_REPORT_LIMIT = 5
 DEFAULT_REPUTATION_LIMIT = 5
 DEFAULT_REPUTATION_CONTEXT_LIMIT = 50  # Default max entries for both relationships and enrichments per reputation result
+MESSAGE_MAX_LENGTH = 500  # Max characters to keep from a community search indicator's "message" field.
+MESSAGE_TRUNCATION_SUFFIX = "... [message truncated, full content available in raw_response]"
 MAX_PAGE_SIZE = 1000
 MAX_FETCH_LIMIT = 200
 MAX_PRODUCT = 10000
@@ -2027,6 +2029,21 @@ def html_to_text(html) -> str:
     return text.strip()
 
 
+def truncate_message(message: str, max_length: int = MESSAGE_MAX_LENGTH) -> str:
+    """
+    Cut a free-text message down to `max_length` characters.
+
+    :param message: The raw message text to truncate.
+    :param max_length: Maximum number of characters to keep.
+
+    :return: The truncated message, unchanged if it was already short enough.
+    """
+    if not message or not isinstance(message, str) or len(message) <= max_length:
+        return message
+
+    return message[:max_length].rstrip() + MESSAGE_TRUNCATION_SUFFIX
+
+
 def prepare_hr_for_vulnerability(vulnerability: dict, platform_url: str, is_reputation: bool = False) -> str:
     """
     Prepare human-readable output for vulnerability details.
@@ -3297,6 +3314,17 @@ def ip_lookup_command(client: Client, ip: str, exact_match: bool = False) -> Com
                             f"{indicator.get('id', 'unknown')}. Full data available in raw_response."
                         )
                         indicator["enrichments"][enr_key] = enr_val[: client.reputation_enrichments_limit]
+
+                raw_message = indicator.get("message")
+                if isinstance(raw_message, str) and raw_message:
+                    truncated_message = truncate_message(raw_message)
+                    if truncated_message != raw_message:
+                        demisto.debug(
+                            f"Community search for IP {ip}: message truncated for indicator "
+                            f"{indicator.get('id', 'unknown')}. Full content available in raw_response."
+                        )
+                    indicator["message"] = truncated_message
+
                 limited_indicators.append(indicator)
             command_results = CommandResults(
                 outputs_prefix=OUTPUT_PREFIX["IP_COMMUNITY_SEARCH"],

--- a/Packs/Flashpoint/Integrations/Ignite/Ignite.yml
+++ b/Packs/Flashpoint/Integrations/Ignite/Ignite.yml
@@ -215,7 +215,6 @@ configuration:
 - additionalinfo: >-
     Maximum number of characters kept from the "message" field of a community search result returned by the
     ip command. Lowering this value reduces context size. Raising it preserves more of the original content
-    at the cost of a larger context payload. Default is 500.
   defaultvalue: '500'
   display: Community search message max length
   name: message_max_length

--- a/Packs/Flashpoint/Integrations/Ignite/Ignite.yml
+++ b/Packs/Flashpoint/Integrations/Ignite/Ignite.yml
@@ -213,7 +213,7 @@ configuration:
   section: Connect
   advanced: true
 - additionalinfo: >-
-    Maximum number of characters kept from the "message" field of a community search result returned by the
+    The maximum number of characters retained from the message field of a community search result returned by the ip command. Lowering this value reduces context payload size, while raising it preserves more of the original content.
   defaultvalue: '500'
   display: Community search message max length
   name: message_max_length

--- a/Packs/Flashpoint/Integrations/Ignite/Ignite.yml
+++ b/Packs/Flashpoint/Integrations/Ignite/Ignite.yml
@@ -212,6 +212,17 @@ configuration:
   required: false
   section: Connect
   advanced: true
+- additionalinfo: >-
+    Maximum number of characters kept from the "message" field of a community search result returned by the
+    ip command. Lowering this value reduces context size. Raising it preserves more of the original content
+    at the cost of a larger context payload. Default is 500.
+  defaultvalue: '500'
+  display: Community search message max length
+  name: message_max_length
+  type: 0
+  required: false
+  section: Connect
+  advanced: true
 - display: Trust any certificate (not secure)
   name: insecure
   type: 8

--- a/Packs/Flashpoint/Integrations/Ignite/Ignite.yml
+++ b/Packs/Flashpoint/Integrations/Ignite/Ignite.yml
@@ -214,7 +214,6 @@ configuration:
   advanced: true
 - additionalinfo: >-
     Maximum number of characters kept from the "message" field of a community search result returned by the
-    ip command. Lowering this value reduces context size. Raising it preserves more of the original content
   defaultvalue: '500'
   display: Community search message max length
   name: message_max_length

--- a/Packs/Flashpoint/Integrations/Ignite/Ignite_test.py
+++ b/Packs/Flashpoint/Integrations/Ignite/Ignite_test.py
@@ -3941,3 +3941,66 @@ def test_ip_lookup_community_search_keeps_short_message_unchanged(requests_mock,
     outputs = result.outputs  # type: ignore[union-attr]
     assert isinstance(outputs, list)
     assert outputs[0].get("message") == short_message
+
+
+def test_client_default_message_max_length():
+    """
+    Test that Client uses MESSAGE_MAX_LENGTH as the default when message_max_length is not provided.
+
+    Given:
+        - A Client instantiated without the message_max_length argument.
+    When:
+        - Accessing client.message_max_length.
+    Then:
+        - The value equals MESSAGE_MAX_LENGTH.
+    """
+    client = Client(MOCK_URL, {}, False, None, False)
+    assert client.message_max_length == MESSAGE_MAX_LENGTH
+
+
+def test_ip_lookup_community_search_message_truncated_to_client_param_limit(requests_mock, mocker):
+    """
+    Test that the community-search branch of `ip_lookup_command` truncates the "message" field
+    using the configured `client.message_max_length` value, not the hardcoded constant.
+
+    Given:
+        - A client with message_max_length set to a small custom value.
+        - A community search response containing a "message" field longer than that value.
+    When:
+        - Calling `ip_lookup_command`.
+    Then:
+        - The "message" field stored in the outputs is truncated to the custom limit.
+    """
+    custom_limit = 20
+    client = Client(MOCK_URL, {}, False, None, False, message_max_length=custom_limit)
+
+    empty_ioc_response = {"items": []}
+    long_message = "a" * 100
+    community_response = {
+        "items": [
+            {
+                "id": "test-id",
+                "date": "2024-01-01T00:00:00Z",
+                "first_observed_at": "2024-01-01T00:00:00Z",
+                "last_observed_at": "2024-01-01T00:00:00Z",
+                "author": "test-author",
+                "title": "test-title",
+                "site": "test-site",
+                "message": long_message,
+                "enrichments": {},
+            }
+        ]
+    }
+
+    requests_mock.get(f'{MOCK_URL}{URL_SUFFIX["LIST_INDICATORS"]}', json=empty_ioc_response, status_code=200)
+    requests_mock.post(f'{MOCK_URL}{URL_SUFFIX["COMMUNITY_SEARCH"]}', json=community_response, status_code=200)
+    mocker.patch("Ignite.is_ip_address_internal", return_value=False)
+    mocker.patch.object(demisto, "params", return_value={**BASIC_PARAMS, "integrationReliability": "B - Usually reliable"})
+
+    result = ip_lookup_command(client, "1.2.3.4")
+
+    outputs = result.outputs  # type: ignore[union-attr]
+    assert isinstance(outputs, list)
+    stored_message = outputs[0].get("message", "")
+
+    assert stored_message == long_message[:custom_limit] + MESSAGE_TRUNCATION_SUFFIX

--- a/Packs/Flashpoint/Integrations/Ignite/Ignite_test.py
+++ b/Packs/Flashpoint/Integrations/Ignite/Ignite_test.py
@@ -37,8 +37,11 @@ from Ignite import (
     vulnerability_list_command,
     cve_command,
     DEFAULT_REPUTATION_CONTEXT_LIMIT,
+    MESSAGE_MAX_LENGTH,
+    MESSAGE_TRUNCATION_SUFFIX,
     create_relationships_list_for_community_search,
     ip_lookup_command,
+    truncate_message,
 )
 
 """ CONSTANTS """
@@ -3795,3 +3798,146 @@ def test_client_default_reputation_enrichments_limit():
     """
     client = Client(MOCK_URL, {}, False, None, False)
     assert client.reputation_enrichments_limit == DEFAULT_REPUTATION_CONTEXT_LIMIT
+
+
+def test_truncate_message_keeps_short_message_unchanged():
+    """
+    Test that a message shorter than MESSAGE_MAX_LENGTH is returned unchanged.
+
+    Given:
+        - A short message.
+    When:
+        - Calling `truncate_message`.
+    Then:
+        - The message is returned unmodified, with no truncation suffix appended.
+    """
+    message = "This IP was seen scanning. It was reported once."
+    assert truncate_message(message) == message
+
+
+def test_truncate_message_cuts_at_max_length():
+    """
+    Test that a message longer than MESSAGE_MAX_LENGTH is cut to that many characters.
+
+    Given:
+        - A message longer than MESSAGE_MAX_LENGTH characters.
+    When:
+        - Calling `truncate_message`.
+    Then:
+        - The result contains at most MESSAGE_MAX_LENGTH characters of original content,
+          followed by the truncation suffix.
+    """
+    message = "a" * (MESSAGE_MAX_LENGTH + 1000)
+
+    result = truncate_message(message)
+
+    assert result == message[:MESSAGE_MAX_LENGTH] + MESSAGE_TRUNCATION_SUFFIX
+
+
+def test_truncate_message_handles_empty_and_non_string_input():
+    """
+    Test that `truncate_message` safely handles falsy or non-string inputs.
+
+    Given:
+        - Empty string, None.
+    When:
+        - Calling `truncate_message`.
+    Then:
+        - The input is returned unchanged.
+    """
+    assert truncate_message("") == ""
+    assert truncate_message(None) is None
+
+
+def test_ip_lookup_community_search_truncates_large_message(requests_mock, mocker):
+    """
+    Test that the community-search branch of `ip_lookup_command` truncates an oversized
+    "message" field down to MESSAGE_MAX_LENGTH characters in the context output.
+
+    Given:
+        - A community search response where one indicator's "message" field contains
+          thousands of characters of raw paste content.
+    When:
+        - Calling `ip_lookup_command`.
+    Then:
+        - The "message" field stored in the outputs is reduced to at most
+          MESSAGE_MAX_LENGTH characters, not the full original content.
+    """
+    client = Client(MOCK_URL, {}, False, None, False)
+
+    empty_ioc_response = {"items": []}
+    long_message = " ".join(f"This is sentence number {i} describing observed IOC data." for i in range(200))
+    community_response = {
+        "items": [
+            {
+                "id": "test-id",
+                "date": "2024-01-01T00:00:00Z",
+                "first_observed_at": "2024-01-01T00:00:00Z",
+                "last_observed_at": "2024-01-01T00:00:00Z",
+                "author": "test-author",
+                "title": "test-title",
+                "site": "test-site",
+                "message": long_message,
+                "enrichments": {},
+            }
+        ]
+    }
+
+    requests_mock.get(f'{MOCK_URL}{URL_SUFFIX["LIST_INDICATORS"]}', json=empty_ioc_response, status_code=200)
+    requests_mock.post(f'{MOCK_URL}{URL_SUFFIX["COMMUNITY_SEARCH"]}', json=community_response, status_code=200)
+    mocker.patch("Ignite.is_ip_address_internal", return_value=False)
+    mocker.patch.object(demisto, "params", return_value={**BASIC_PARAMS, "integrationReliability": "B - Usually reliable"})
+
+    result = ip_lookup_command(client, "1.2.3.4")
+
+    outputs = result.outputs  # type: ignore[union-attr]
+    assert isinstance(outputs, list)
+    stored_message = outputs[0].get("message", "")
+
+    assert len(stored_message) < len(long_message)
+    assert stored_message.endswith(MESSAGE_TRUNCATION_SUFFIX)
+
+
+def test_ip_lookup_community_search_keeps_short_message_unchanged(requests_mock, mocker):
+    """
+    Test that a short "message" field is preserved as-is in the community-search branch
+    of `ip_lookup_command`.
+
+    Given:
+        - A community search response where the indicator's "message" field is short
+          (fewer sentences than MESSAGE_MAX_SENTENCES).
+    When:
+        - Calling `ip_lookup_command`.
+    Then:
+        - The "message" field stored in the outputs is unchanged.
+    """
+    client = Client(MOCK_URL, {}, False, None, False)
+
+    empty_ioc_response = {"items": []}
+    short_message = "This is a short message."
+    community_response = {
+        "items": [
+            {
+                "id": "test-id",
+                "date": "2024-01-01T00:00:00Z",
+                "first_observed_at": "2024-01-01T00:00:00Z",
+                "last_observed_at": "2024-01-01T00:00:00Z",
+                "author": "test-author",
+                "title": "test-title",
+                "site": "test-site",
+                "message": short_message,
+                "enrichments": {},
+            }
+        ]
+    }
+
+    requests_mock.get(f'{MOCK_URL}{URL_SUFFIX["LIST_INDICATORS"]}', json=empty_ioc_response, status_code=200)
+    requests_mock.post(f'{MOCK_URL}{URL_SUFFIX["COMMUNITY_SEARCH"]}', json=community_response, status_code=200)
+    mocker.patch("Ignite.is_ip_address_internal", return_value=False)
+    mocker.patch.object(demisto, "params", return_value={**BASIC_PARAMS, "integrationReliability": "B - Usually reliable"})
+
+    result = ip_lookup_command(client, "1.2.3.4")
+
+    outputs = result.outputs  # type: ignore[union-attr]
+    assert isinstance(outputs, list)
+    assert outputs[0].get("message") == short_message

--- a/Packs/Flashpoint/Integrations/Ignite/Ignite_test.py
+++ b/Packs/Flashpoint/Integrations/Ignite/Ignite_test.py
@@ -37,7 +37,7 @@ from Ignite import (
     vulnerability_list_command,
     cve_command,
     DEFAULT_REPUTATION_CONTEXT_LIMIT,
-    MESSAGE_MAX_LENGTH,
+    DEFAULT_MESSAGE_MAX_LENGTH,
     MESSAGE_TRUNCATION_SUFFIX,
     create_relationships_list_for_community_search,
     ip_lookup_command,
@@ -3802,7 +3802,7 @@ def test_client_default_reputation_enrichments_limit():
 
 def test_truncate_message_keeps_short_message_unchanged():
     """
-    Test that a message shorter than MESSAGE_MAX_LENGTH is returned unchanged.
+    Test that a message shorter than DEFAULT_MESSAGE_MAX_LENGTH is returned unchanged.
 
     Given:
         - A short message.
@@ -3817,21 +3817,21 @@ def test_truncate_message_keeps_short_message_unchanged():
 
 def test_truncate_message_cuts_at_max_length():
     """
-    Test that a message longer than MESSAGE_MAX_LENGTH is cut to that many characters.
+    Test that a message longer than DEFAULT_MESSAGE_MAX_LENGTH is cut to that many characters.
 
     Given:
-        - A message longer than MESSAGE_MAX_LENGTH characters.
+        - A message longer than DEFAULT_MESSAGE_MAX_LENGTH characters.
     When:
         - Calling `truncate_message`.
     Then:
-        - The result contains at most MESSAGE_MAX_LENGTH characters of original content,
+        - The result contains at most DEFAULT_MESSAGE_MAX_LENGTH characters of original content,
           followed by the truncation suffix.
     """
-    message = "a" * (MESSAGE_MAX_LENGTH + 1000)
+    message = "a" * (DEFAULT_MESSAGE_MAX_LENGTH + 1000)
 
     result = truncate_message(message)
 
-    assert result == message[:MESSAGE_MAX_LENGTH] + MESSAGE_TRUNCATION_SUFFIX
+    assert result == message[:DEFAULT_MESSAGE_MAX_LENGTH] + MESSAGE_TRUNCATION_SUFFIX
 
 
 def test_truncate_message_handles_empty_and_non_string_input():
@@ -3852,7 +3852,7 @@ def test_truncate_message_handles_empty_and_non_string_input():
 def test_ip_lookup_community_search_truncates_large_message(requests_mock, mocker):
     """
     Test that the community-search branch of `ip_lookup_command` truncates an oversized
-    "message" field down to MESSAGE_MAX_LENGTH characters in the context output.
+    "message" field down to DEFAULT_MESSAGE_MAX_LENGTH characters in the context output.
 
     Given:
         - A community search response where one indicator's "message" field contains
@@ -3861,7 +3861,7 @@ def test_ip_lookup_community_search_truncates_large_message(requests_mock, mocke
         - Calling `ip_lookup_command`.
     Then:
         - The "message" field stored in the outputs is reduced to at most
-          MESSAGE_MAX_LENGTH characters, not the full original content.
+          DEFAULT_MESSAGE_MAX_LENGTH characters, not the full original content.
     """
     client = Client(MOCK_URL, {}, False, None, False)
 
@@ -3905,7 +3905,7 @@ def test_ip_lookup_community_search_keeps_short_message_unchanged(requests_mock,
 
     Given:
         - A community search response where the indicator's "message" field is short
-          (fewer characters than MESSAGE_MAX_LENGTH).
+          (fewer characters than DEFAULT_MESSAGE_MAX_LENGTH).
     When:
         - Calling `ip_lookup_command`.
     Then:
@@ -3945,17 +3945,17 @@ def test_ip_lookup_community_search_keeps_short_message_unchanged(requests_mock,
 
 def test_client_default_message_max_length():
     """
-    Test that Client uses MESSAGE_MAX_LENGTH as the default when message_max_length is not provided.
+    Test that Client uses DEFAULT_MESSAGE_MAX_LENGTH as the default when message_max_length is not provided.
 
     Given:
         - A Client instantiated without the message_max_length argument.
     When:
         - Accessing client.message_max_length.
     Then:
-        - The value equals MESSAGE_MAX_LENGTH.
+        - The value equals DEFAULT_MESSAGE_MAX_LENGTH.
     """
     client = Client(MOCK_URL, {}, False, None, False)
-    assert client.message_max_length == MESSAGE_MAX_LENGTH
+    assert client.message_max_length == DEFAULT_MESSAGE_MAX_LENGTH
 
 
 def test_ip_lookup_community_search_message_truncated_to_client_param_limit(requests_mock, mocker):

--- a/Packs/Flashpoint/Integrations/Ignite/Ignite_test.py
+++ b/Packs/Flashpoint/Integrations/Ignite/Ignite_test.py
@@ -3905,7 +3905,7 @@ def test_ip_lookup_community_search_keeps_short_message_unchanged(requests_mock,
 
     Given:
         - A community search response where the indicator's "message" field is short
-          (fewer sentences than MESSAGE_MAX_SENTENCES).
+          (fewer characters than MESSAGE_MAX_LENGTH).
     When:
         - Calling `ip_lookup_command`.
     Then:

--- a/Packs/Flashpoint/ReleaseNotes/2_2_2.md
+++ b/Packs/Flashpoint/ReleaseNotes/2_2_2.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Flashpoint Ignite
+
+- Fixed an issue where the ***ip*** command returned an overly large ***message*** field.

--- a/Packs/Flashpoint/ReleaseNotes/2_2_2.md
+++ b/Packs/Flashpoint/ReleaseNotes/2_2_2.md
@@ -3,4 +3,4 @@
 
 ##### Flashpoint Ignite
 
-- Fixed an issue where the ***ip*** command returned an overly large ***message*** field.
+- Fixed an issue where the ***ip*** command returned an overly large *message* field.

--- a/Packs/Flashpoint/ReleaseNotes/2_2_2.md
+++ b/Packs/Flashpoint/ReleaseNotes/2_2_2.md
@@ -3,4 +3,4 @@
 
 ##### Flashpoint Ignite
 
-- Fixed an issue where the ***ip*** command returned an overly large *message* field.
+Fixed an issue where the ***ip*** command returned an excessively large *message* field.

--- a/Packs/Flashpoint/pack_metadata.json
+++ b/Packs/Flashpoint/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Flashpoint",
     "description": "Use the Flashpoint integration to reduce business risk.",
     "support": "partner",
-    "currentVersion": "2.2.1",
+    "currentVersion": "2.2.2",
     "author": "Flashpoint",
     "url": "https://flashpoint.my.site.com/helpcenter/s/",
     "email": "support@flashpoint-intel.com",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
<!-- To link a Jira ticket use fixes/related: link to the issue, for example fixes: CIAC-XXXX -->

## Description
Truncated the message value in the context key when it's over than 500 characters

## Must have
- [ ] Tests
- [ ] Documentation
