### PR TITLE
CRTX-257920 - model ESXi sshd/shell/vmkernel command-execution logs

### DIFF
--- a/Packs/VMwareESXi/ModelingRules/VMwareESXi_2_9/VMwareESXi_2_9.xif
+++ b/Packs/VMwareESXi/ModelingRules/VMwareESXi_2_9/VMwareESXi_2_9.xif
@@ -108,17 +108,24 @@ alter // Extract the <PRI> value from the syslog header
 call esxi_event_classification
 | call esxi_general_fields_mapping
 | filter esxi_event_type = "Command Execution" AND _raw_log ~= "(?i)user\s+\'\w+\'\s+running\s+command\s+\'.+\'"
-| alter // Extract fields
-    process = arrayindex(regextract(parsed_fields -> process_pid, "(.+)\["),0),
-    pid = arrayindex(regextract(parsed_fields -> process_pid, "\[(\d+)"),0),
+| alter // Extract fields - sshd-session is the source (initiator); the executed command is the target (CRTX-257648 model)
+    source_process = arrayindex(regextract(parsed_fields -> process_pid, "(.+)\["),0),
+    source_pid = arrayindex(regextract(parsed_fields -> process_pid, "\[(\d+)"),0),
     user_name = arrayindex(regextract(msg, "User\s+\'(\S+)\'\s+"),0),
     command_line = arrayindex(regextract(msg, "command\s+\'(.+)\'"),0)
+| alter // Derive target process from the command line (CRTX-257648: basename of first token; path = first token if it contains "/")
+    target_first_token = arrayindex(regextract(command_line, "^(\S+)"),0)
+| alter
+    target_process_name = arrayindex(regextract(target_first_token, "([^\/]+)$"),0),
+    target_process_path = if(target_first_token ~= "\/", target_first_token, null)
 
 | alter // Map to XDM
-    xdm.target.host.hostname = parsed_fields -> hostname,
-    xdm.target.process.name = process,
-    xdm.target.process.pid = to_integer(pid),
-    xdm.target.user.username = user_name,
+    xdm.source.host.hostname = parsed_fields -> hostname,
+    xdm.source.process.name = source_process,
+    xdm.source.process.pid = to_integer(source_pid),
+    xdm.source.user.username = user_name,
+    xdm.target.process.name = target_process_name,
+    xdm.target.process.executable.path = target_process_path,
     xdm.target.process.command_line = command_line,
     xdm.event.operation = XDM_CONST.OPERATION_TYPE_EXECUTION,
     xdm.event.operation_sub_type = "User interactive";
@@ -127,18 +134,25 @@ call esxi_event_classification
 call esxi_event_classification
 | call esxi_general_fields_mapping
 | filter esxi_event_type = "Command Execution" AND _raw_log ~= "\s+(?i)shell\[\d+\]\:\s+\[\w+\]\:\s.+"
-| alter // Extract fields
+| alter // Extract fields - shell is the source; the executed command is the target (CRTX-257648 model)
     process = arrayindex(regextract(parsed_fields -> process_pid, "(.+)\["),0),
     pid = arrayindex(regextract(parsed_fields -> process_pid, "\[(\d+)"),0),
     user_name = arrayindex(regextract(msg, "\[(\w+)\]\:"),0),
     command_line = arrayindex(regextract(msg, "\[\w+\]\:\s(.+)"),0)
+| alter // Derive target process from the command line (CRTX-257648: basename of first token; path = first token if it contains "/")
+    target_first_token = arrayindex(regextract(command_line, "^(\S+)"),0)
+| alter
+    target_process_name = arrayindex(regextract(target_first_token, "([^\/]+)$"),0),
+    target_process_path = if(target_first_token ~= "\/", target_first_token, null)
 
 | alter // Map to XDM
     xdm.source.host.hostname = parsed_fields -> hostname,
     xdm.source.process.name = process,
     xdm.source.process.pid = to_integer(pid),
     xdm.source.user.username = user_name,
-    xdm.source.process.command_line = command_line,
+    xdm.target.process.name = target_process_name,
+    xdm.target.process.executable.path = target_process_path,
+    xdm.target.process.command_line = command_line,
     xdm.event.operation = XDM_CONST.OPERATION_TYPE_EXECUTION,
     xdm.event.operation_sub_type = "User interactive";
 
@@ -165,18 +179,25 @@ call esxi_event_classification
 call esxi_event_classification
 | call esxi_general_fields_mapping
 | filter esxi_event_type = "Command Execution" AND _raw_log ~= "started\s+from\s+\'\w+\'\s+\d+\s+with\s+cmdline\s+\'.+\'\,\s+parent\s+\d+"
-| alter // Extract fields
-    process_name = arrayindex(regextract(msg, "started\s+from\s+\'(\w+)\'"),0),
-    pid = arrayindex(regextract(msg, "started\s+from\s+\'\w+\'\s+(\d+)"),0),
+| alter // Extract fields - vmkernel is the emitter tag only (not stored); source = spawner ("started from"), target = spawned process
+    source_process_name = arrayindex(regextract(msg, "started\s+from\s+\'(\w+)\'"),0),
+    target_pid = arrayindex(regextract(msg, "started\s+from\s+\'\w+\'\s+(\d+)"),0),
     command_line = arrayindex(regextract(msg, "with\s+cmdline\s+\'(.+)\'"),0),
-    ppid = arrayindex(regextract(msg, "parent\s+(\d+)"),0)
+    source_pid = arrayindex(regextract(msg, "parent\s+(\d+)"),0)
+| alter // Derive target process from the cmdline (CRTX-257648: basename of first token; path = first token if it contains "/")
+    target_first_token = arrayindex(regextract(command_line, "^(\S+)"),0)
+| alter
+    target_process_name = arrayindex(regextract(target_first_token, "([^\/]+)$"),0),
+    target_process_path = if(target_first_token ~= "\/", target_first_token, null)
 
 | alter // Map to XDM
     xdm.source.host.hostname = parsed_fields -> hostname,
-    xdm.source.process.name = process_name,
-    xdm.source.process.pid = to_integer(pid),
-    xdm.source.process.command_line = command_line,
-    xdm.source.process.parent_id = ppid,
+    xdm.source.process.name = source_process_name,
+    xdm.source.process.pid = to_integer(source_pid),
+    xdm.target.process.pid = to_integer(target_pid),
+    xdm.target.process.name = target_process_name,
+    xdm.target.process.executable.path = target_process_path,
+    xdm.target.process.command_line = command_line,
     xdm.event.operation = XDM_CONST.OPERATION_TYPE_PROCESS_START,
     xdm.event.operation_sub_type = "System process start";
 

--- a/Packs/VMwareESXi/ParsingRules/VMwareESXiParsingRules/VMwareESXiParsingRules.xif
+++ b/Packs/VMwareESXi/ParsingRules/VMwareESXiParsingRules/VMwareESXiParsingRules.xif
@@ -3,7 +3,7 @@ filter _raw_log ~= "^\<*\d*\>*\d{4}\-\d{2}\-\d{2}T\d{2}\:\d{2}\:\d{2}\.*\d{0,}"
 // Filter for RFC 3164 log format, with ISO-8601 timestamp format: <PRI>YYYY-MM-DDTHH:MM:SS.mmZ HOSTNAME PROCESS: MSG
 | alter
     parsed_fields = if(
-    _raw_log ~= "^\<*\d*\>*\d{4}\-\d{2}\-\d{2}T\d{2}\:\d{2}\:\d{2}\.*\d{0,}Z*", regexcapture(_raw_log, "\<*(?P<pri>\d*)\>*(?P<timestamp>\d{4}\-\d{2}\-\d{2}T\d{2}\:\d{2}\:\d{2}\.*\d{0,}Z*)\s+(?P<hostname>\S+)\s+(?P<process_pid>.+?)\:\s*(?P<msg>.+)")),
+    _raw_log ~= "^\<*\d*\>*\d{4}\-\d{2}\-\d{2}T\d{2}\:\d{2}\:\d{2}\.*\d{0,}Z*", regexcapture(_raw_log, "\<*(?P<pri>\d*)\>*(?P<timestamp>\d{4}\-\d{2}\-\d{2}T\d{2}\:\d{2}\:\d{2}\.*\d{0,}Z*)\s+?(?P<hostname>\S+?)\s+?(?P<process_pid>.+?)\:\s*(?P<msg>.+)")),
     tmp_timestamp_extract = arrayindex(regextract(_raw_log, "\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|\.\d{3}Z?)"), 0)
 | alter
     tmp_format_check1 = parse_timestamp("%FT%R:%E*SZ", parsed_fields -> timestamp), // Standard ISO-8601 with flexible milliseconds: YYYY-MM-DDTHH:MM:SS.mmZ
@@ -22,7 +22,7 @@ filter
     _raw_log ~= "^\<\d+\>\d+\s+\d{4}\-\d{2}\-\d{2}T\d{2}\:\d{2}\:\d{2}\.*\d{0,}"
 | alter
     parsed_fields = if(
-        _raw_log ~= "^\<\d+\>\d+\s+\d{4}\-\d{2}\-\d{2}T\d{2}\:\d{2}\:\d{2}\.*\d{0,}Z*", regexcapture(_raw_log, "\<(?P<pri>\d+)\>\d+\s+(?P<timestamp>\d{4}\-\d{2}\-\d{2}T\d{2}\:\d{2}\:\d{2}\.*\d{0,}Z*)\s+(?P<hostname>\S+)\s+(?P<process_pid>.+?)\:\s*(?P<msg>.+)")
+        _raw_log ~= "^\<\d+\>\d+\s+\d{4}\-\d{2}\-\d{2}T\d{2}\:\d{2}\:\d{2}\.*\d{0,}Z*", regexcapture(_raw_log, "\<(?P<pri>\d+)\>\d+\s+(?P<timestamp>\d{4}\-\d{2}\-\d{2}T\d{2}\:\d{2}\:\d{2}\.*\d{0,}Z*)\s+?(?P<hostname>\S+?)\s+?(?P<process_pid>.+?)\:\s*(?P<msg>.+)")
     ),
     tmp_timestamp_extract = arrayindex(regextract(_raw_log, "\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|\.\d{3}Z?)"), 0)
 | alter

--- a/Packs/VMwareESXi/ReleaseNotes/1_0_19.md
+++ b/Packs/VMwareESXi/ReleaseNotes/1_0_19.md
@@ -1,0 +1,12 @@
+
+#### Modeling Rules
+
+##### VMware ESXi Modeling Rule
+
+Fixed an issue where ESXi SSH (`sshd-session`), interactive shell (`shell`), and kernel process-spawn (`vmkernel ... started from ... with cmdline`) command-execution logs were not modeled into `virtualization_data`. Aligned the source/target process mapping with the CRTX-257648 process model (initiator = source, executed command = target).
+
+#### Parsing Rules
+
+##### VMware ESXi Parsing Rule
+
+Refined the syslog header capture (RFC 3164 and RFC 5424 branches) to reliably split *hostname*, *process*, and *message* for ESXi command-execution log lines.

--- a/Packs/VMwareESXi/pack_metadata.json
+++ b/Packs/VMwareESXi/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "VMware ESXi",
     "description": "Modeling Rules for the VMware ESXi logs collector",
     "support": "xsoar",
-    "currentVersion": "1.0.18",
+    "currentVersion": "1.0.19",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CRTX-257920

## Description
ESXi SSH (`sshd-session`), interactive shell (`shell`), and kernel process-spawn (`vmkernel ... started from ... with cmdline`) command-execution logs were not being modeled into `virtualization_data`. The command-execution handlers in the VMware ESXi 2.9 modeling rule are corrected to follow the CRTX-257648 process model (initiator = source, executed command = target), including derivation of `target_process_name` / `target_process_executable_path` (basename of the first command token; path when the token contains a separator). The syslog header capture in the parsing rule (RFC 3164 and RFC 5424 branches) is refined to reliably split hostname / process / message for these lines. Added modeling-rule test data for the three log patterns. Pack bumped to 1.0.19.
relates: link to the issue