### PR TITLE
CRTX-258591 - fix Slack user_login auth mapping

### DIFF
--- a/Packs/Slack/ModelingRules/SlackModelingRules_2_10/SlackModelingRules_2_10.xif
+++ b/Packs/Slack/ModelingRules/SlackModelingRules_2_10/SlackModelingRules_2_10.xif
@@ -1,5 +1,5 @@
 [MODEL: dataset="slack_slack_raw"]
-filter action IN("user_login", "user_login_failed", "user_logout_compromised", "user_logout_non_compliant_mobile_app_version", "cli_login") //Authentication events mapping
+filter action IN("user_login", "user_login*", "user_logout_compromised", "user_logout_non_compliant_mobile_app_version", "cli_login") //Authentication events mapping
 // Extract actor and context fields
 | alter
     get_actor_user_email = json_extract_scalar(actor, "$['user']['email']"),
@@ -96,7 +96,7 @@ filter action IN("user_login", "user_login_failed", "user_logout_compromised", "
     xdm.target.file.extension = arrayindex(regextract(json_extract_scalar(entity, "$['file']['name']"), "\.(\w+)$"),0),
     xdm.alert.source_url = json_extract_scalar(details, "$['url_private']");
 
-filter action NOT IN("user_login", "user_login_failed", "user_logout_compromised", "user_logout_non_compliant_mobile_app_version", "cli_login") //SaaS Audit Mapping
+filter action NOT IN("user_login", "user_login*", "user_logout_compromised", "user_logout_non_compliant_mobile_app_version", "cli_login") //SaaS Audit Mapping
 // Extract actor and context fields
 | alter
     get_actor_user_email = json_extract_scalar(actor, "$['user']['email']"),

--- a/Packs/Slack/ModelingRules/SlackModelingRules_2_10/SlackModelingRules_2_10.xif
+++ b/Packs/Slack/ModelingRules/SlackModelingRules_2_10/SlackModelingRules_2_10.xif
@@ -1,5 +1,5 @@
 [MODEL: dataset="slack_slack_raw"]
-filter action IN("user_login*", "user_logout_compromised", "user_logout_non_compliant_mobile_app_version", "cli_login") //Authentication events mapping
+filter action IN("user_login", "user_login_failed", "user_logout_compromised", "user_logout_non_compliant_mobile_app_version", "cli_login") //Authentication events mapping
 // Extract actor and context fields
 | alter
     get_actor_user_email = json_extract_scalar(actor, "$['user']['email']"),
@@ -20,6 +20,7 @@ filter action IN("user_login*", "user_logout_compromised", "user_logout_non_comp
     xdm.event.operation = XDM_CONST.OPERATION_TYPE_AUTH_LOGIN,
     xdm.event.id = id,
     xdm.event.outcome = if(
+        action = "user_login_failed", XDM_CONST.OUTCOME_FAILED,
         action IN("user_logout_compromised", "user_logout_non_compliant_mobile_app_version"), XDM_CONST.OUTCOME_FAILED,
         action IN("user_login","cli_login") ,XDM_CONST.OUTCOME_SUCCESS
         ),
@@ -95,7 +96,7 @@ filter action IN("user_login*", "user_logout_compromised", "user_logout_non_comp
     xdm.target.file.extension = arrayindex(regextract(json_extract_scalar(entity, "$['file']['name']"), "\.(\w+)$"),0),
     xdm.alert.source_url = json_extract_scalar(details, "$['url_private']");
 
-filter action NOT IN("user_login*", "user_logout_compromised", "user_logout_non_compliant_mobile_app_version", "cli_login") //SaaS Audit Mapping
+filter action NOT IN("user_login", "user_login_failed", "user_logout_compromised", "user_logout_non_compliant_mobile_app_version", "cli_login") //SaaS Audit Mapping
 // Extract actor and context fields
 | alter
     get_actor_user_email = json_extract_scalar(actor, "$['user']['email']"),

--- a/Packs/Slack/ReleaseNotes/3_8_9.md
+++ b/Packs/Slack/ReleaseNotes/3_8_9.md
@@ -3,4 +3,4 @@
 
 ##### Slack Modeling Rule
 
-- Fixed an issue where Slack authentication events (**user_login**, **user_login_failed**) were not mapped to the Authentication data model because the filter used the literal string `"user_login*"` (which `IN` matches exactly, not as a wildcard). These events are now mapped to authentication instead of falling through to the SaaS audit mapping.
+- Fixed an issue where Slack authentication events (`user_login` and `user_login_failed`) were not mapped to the Authentication data model. The authentication filter matched on the literal value `user_login*`, which never matched the actual `user_login` action, so these events fell through to the SaaS audit mapping instead of the Authentication story.

--- a/Packs/Slack/ReleaseNotes/3_8_9.md
+++ b/Packs/Slack/ReleaseNotes/3_8_9.md
@@ -1,0 +1,6 @@
+
+#### Modeling Rules
+
+##### Slack Modeling Rule
+
+- Fixed an issue where Slack authentication events (**user_login**, **user_login_failed**) were not mapped to the Authentication data model because the filter used the literal string `"user_login*"` (which `IN` matches exactly, not as a wildcard). These events are now mapped to authentication instead of falling through to the SaaS audit mapping.

--- a/Packs/Slack/pack_metadata.json
+++ b/Packs/Slack/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Slack",
     "description": "Interact with Slack API - collect logs, send messages and notifications to your Slack team.",
     "support": "xsoar",
-    "currentVersion": "3.8.8",
+    "currentVersion": "3.8.9",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
### Related Issues
https://jira-dc.paloaltonetworks.com/browse/CRTX-258591

### Description
Slack authentication event `user_login` was not mapped to the Authentication data model, so it never reached the Authentication story. The Slack modeling rule's auth filter used the literal string `"user_login*"`, and XQL `IN()` performs exact string matching (not wildcard), so `user_login` never matched and fell through to the SaaS audit mapping.

Fix: enumerate the exact actions in both the authentication `IN(...)` filter and the mirror SaaS-audit `NOT IN(...)` filter, and map the `user_login_failed` outcome to FAILED.