### PR TITLE
XSUP-72566 - MSGraphSecurity map observer.type productName fallback

### DIFF
--- a/Packs/MicrosoftGraphSecurity/ModelingRules/MicrosoftGraphSecurity/MicrosoftGraphSecurity.xif
+++ b/Packs/MicrosoftGraphSecurity/ModelingRules/MicrosoftGraphSecurity/MicrosoftGraphSecurity.xif
@@ -116,7 +116,7 @@ filter _reporting_device_name in ("https://graph.microsoft.com/beta/security/ale
     xdm.event.id = coalesce(to_string(incidentId), to_string(providerAlertId)),
     xdm.intermediate.host.fqdn = coalesce(to_string(alertWebUrl), to_string(incidentWebUrl)),
     xdm.alert.original_threat_name = coalesce(to_string(determination), analyzedMessageEvidence_threats),
-    xdm.observer.type = serviceSource,
+    xdm.observer.type = if(serviceSource != "unknownFutureValue", serviceSource, productName),
     xdm.intermediate.host.hostname = detectionSource,
     xdm.email.message_id = analyzedMessageEvidence_internetMessageId, 
     xdm.email.delivery_timestamp = parse_timestamp("%m/%d/%Y %H:%M:%S %p %z", arraystring(arraycreate(get_email_timestamp, get_email_zone), " ")),

--- a/Packs/MicrosoftGraphSecurity/ModelingRules/MicrosoftGraphSecurity/MicrosoftGraphSecurity_schema.json
+++ b/Packs/MicrosoftGraphSecurity/ModelingRules/MicrosoftGraphSecurity/MicrosoftGraphSecurity_schema.json
@@ -60,6 +60,10 @@
             "type": "string",
             "is_array": false
         },
+        "productName": {
+            "type": "string",
+            "is_array": false
+        },
         "detectionSource": {
             "type": "string",
             "is_array": false

--- a/Packs/MicrosoftGraphSecurity/ReleaseNotes/2_5_4.md
+++ b/Packs/MicrosoftGraphSecurity/ReleaseNotes/2_5_4.md
@@ -1,6 +1,6 @@
 
 #### Modeling Rules
 
-##### Microsoft Graph Security
+##### Microsoft Graph Security Modeling Rules
 
 - Updated the modeling rule so that `xdm.observer.type` falls back to the `productName` field when `serviceSource` is `unknownFutureValue`, which is common with the Microsoft Graph `alerts_v2` API.

--- a/Packs/MicrosoftGraphSecurity/ReleaseNotes/2_5_4.md
+++ b/Packs/MicrosoftGraphSecurity/ReleaseNotes/2_5_4.md
@@ -1,0 +1,6 @@
+
+#### Modeling Rules
+
+##### Microsoft Graph Security
+
+- Updated the modeling rule so that `xdm.observer.type` falls back to the `productName` field when `serviceSource` is `unknownFutureValue`, which is common with the Microsoft Graph `alerts_v2` API.

--- a/Packs/MicrosoftGraphSecurity/pack_metadata.json
+++ b/Packs/MicrosoftGraphSecurity/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Graph Security",
     "description": "Unified gateway to security insights - all from a unified Microsoft Graph\n  Security API.",
     "support": "xsoar",
-    "currentVersion": "2.5.3",
+    "currentVersion": "2.5.4",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
https://jira-dc.paloaltonetworks.com/browse/XSUP-72566

## Description
Updated the Microsoft Graph Security modeling rule so that `xdm.observer.type` falls back to the `productName` field when `serviceSource` is `unknownFutureValue`, which is common with the Microsoft Graph `alerts_v2` API. Previously `xdm.observer.type` was mapped directly to `serviceSource`, which returned `unknownFutureValue` for a large portion of alerts, making the field unusable for correlation-rule filtering.