### PR TITLE
Elasticsearch v2: fix fetch skipping incidents with identical sub-second timestamps

### DIFF
--- a/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2.py
+++ b/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2.py
@@ -888,20 +888,36 @@ def incident_label_maker(source, fields=None):
     return labels
 
 
-def results_to_incidents_timestamp(response, last_fetch):
+def results_to_incidents_timestamp(response, last_fetch, last_fetch_ids=None):
     """Converts the current results into incidents.
+
+    To avoid silently dropping documents that share an identical timestamp with the
+    high-water-mark (last_fetch) - which happens when several documents have the same
+    timestamp down to the sub-second and span a fetch boundary - the time query uses an
+    inclusive lower bound (gte) and de-duplication is done by document ``_id`` rather than
+    by discarding every hit that equals the boundary timestamp. Only the ``_id``s that were
+    already ingested at the boundary timestamp are skipped; all other hits are ingested.
 
     Args:
         response(dict): the raw search results from Elasticsearch.
         last_fetch(num): the date or timestamp of the last fetch before this fetch
         - this will hold the last date of the incident brought by this fetch.
+        last_fetch_ids(list): the ``_id``s of the documents already ingested at the
+        ``last_fetch`` boundary timestamp in the previous fetch.
 
     Returns:
         (list).The incidents.
         (num).The date of the last incident brought by this fetch.
+        (list).The ``_id``s of the documents ingested at the new boundary timestamp.
     """
     current_fetch = last_fetch
+    already_fetched_ids = set(last_fetch_ids or [])
     incidents = []
+    # tracks the _ids seen at the maximum timestamp so far in this fetch.
+    # seeded with the previously-persisted boundary ids so that ids already ingested at the
+    # boundary are carried forward and not re-ingested on the next fetch. It is reset whenever
+    # a strictly newer timestamp is encountered.
+    new_fetch_ids: list = list(dict.fromkeys(last_fetch_ids or []))
     for hit in response.get("hits", {}).get("hits"):
         source = hit.get("_source")
 
@@ -929,44 +945,73 @@ def results_to_incidents_timestamp(response, last_fetch):
                 # if timestamp convert to iso format date and save the timestamp
                 hit_date = timestamp_to_date(str(time_field_value))
                 hit_timestamp = int(time_field_value)
+                hit_id = hit.get("_id")
 
                 if hit_timestamp > last_fetch:
+                    # a strictly newer timestamp resets the boundary id tracking
                     last_fetch = hit_timestamp
+                    new_fetch_ids = []
 
-                # avoid duplication due to weak time query
-                if hit_timestamp > current_fetch:
-                    inc = {
-                        "name": "Elasticsearch: Index: " + str(hit.get("_index")) + ", ID: " + str(hit.get("_id")),
-                        "rawJSON": json.dumps(hit),
-                        "occurred": hit_date.isoformat() + "Z",
-                    }
-                    if hit.get("_id"):
-                        inc["dbotMirrorId"] = hit.get("_id")
+                # remember every id seen at the current maximum timestamp - including ids
+                # that are skipped below because they were already ingested - so the boundary
+                # id set is preserved across fetches and does not drift.
+                if hit_timestamp == last_fetch and hit_id and hit_id not in new_fetch_ids:
+                    new_fetch_ids.append(hit_id)
 
-                    if MAP_LABELS:
-                        inc["labels"] = incident_label_maker(hit.get("_source"))
+                # Skip only documents already ingested at the boundary timestamp,
+                # instead of dropping every hit that equals the boundary timestamp.
+                if hit_timestamp < current_fetch or (hit_id and hit_id in already_fetched_ids):
+                    demisto.debug(f"Skipping already-fetched hit ID: {hit_id} with {hit_timestamp=}.")
+                    continue
 
-                    incidents.append(inc)
+                inc = {
+                    "name": "Elasticsearch: Index: " + str(hit.get("_index")) + ", ID: " + str(hit_id),
+                    "rawJSON": json.dumps(hit),
+                    "occurred": hit_date.isoformat() + "Z",
+                }
+                if hit_id:
+                    inc["dbotMirrorId"] = hit_id
 
-    return incidents, last_fetch
+                if MAP_LABELS:
+                    inc["labels"] = incident_label_maker(hit.get("_source"))
+
+                incidents.append(inc)
+
+    return incidents, last_fetch, new_fetch_ids
 
 
-def results_to_incidents_datetime(response, last_fetch):
+def results_to_incidents_datetime(response, last_fetch, last_fetch_ids=None):
     """Converts the current results into incidents.
+
+    To avoid silently dropping documents that share an identical timestamp with the
+    high-water-mark (last_fetch) - which happens when several documents have the same
+    timestamp down to the sub-second and span a fetch boundary - the time query uses an
+    inclusive lower bound (gte) and de-duplication is done by document ``_id`` rather than
+    by discarding every hit that equals the boundary timestamp. Only the ``_id``s that were
+    already ingested at the boundary timestamp are skipped; all other hits are ingested.
 
     Args:
         response(dict): the raw search results from Elasticsearch.
         last_fetch(datetime): the date or timestamp of the last fetch before this fetch or parameter default fetch time
         - this will hold the last date of the incident brought by this fetch.
+        last_fetch_ids(list): the ``_id``s of the documents already ingested at the
+        ``last_fetch`` boundary timestamp in the previous fetch.
 
     Returns:
         (list).The incidents.
         (datetime).The date of the last incident brought by this fetch.
+        (list).The ``_id``s of the documents ingested at the new boundary timestamp.
     """
     last_fetch = dateparser.parse(last_fetch)
     last_fetch_timestamp = int(last_fetch.timestamp() * 1000)  # type:ignore[union-attr]
     current_fetch = last_fetch_timestamp
+    already_fetched_ids = set(last_fetch_ids or [])
     incidents = []
+    # tracks the _ids seen at the maximum timestamp so far in this fetch.
+    # seeded with the previously-persisted boundary ids so that ids already ingested at the
+    # boundary are carried forward and not re-ingested on the next fetch. It is reset whenever
+    # a strictly newer timestamp is encountered.
+    new_fetch_ids: list = list(dict.fromkeys(last_fetch_ids or []))
 
     for hit in response.get("hits", {}).get("hits"):
         source = hit.get("_source")
@@ -994,34 +1039,46 @@ def results_to_incidents_datetime(response, last_fetch):
             if time_field_value is not None:
                 hit_date = parse(str(time_field_value))
                 hit_timestamp = int(hit_date.timestamp() * 1000)
+                hit_id = hit.get("_id")
 
                 if hit_timestamp > last_fetch_timestamp:
+                    # a strictly newer timestamp resets the boundary id tracking
                     last_fetch = hit_date
                     last_fetch_timestamp = hit_timestamp
+                    new_fetch_ids = []
 
-                if hit_timestamp > current_fetch:
-                    inc = {
-                        "name": "Elasticsearch: Index: " + str(hit.get("_index")) + ", ID: " + str(hit.get("_id")),
-                        "rawJSON": json.dumps(hit),
-                        # parse function returns iso format sometimes as YYYY-MM-DDThh:mm:ss+00:00
-                        # and sometimes as YYYY-MM-DDThh:mm:ss
-                        # we want to return format: YYYY-MM-DDThh:mm:ssZ in our incidents
-                        "occurred": format_to_iso(hit_date.isoformat()),
-                    }
-                    if hit.get("_id"):
-                        inc["dbotMirrorId"] = hit.get("_id")
+                # remember every id seen at the current maximum timestamp - including ids
+                # that are skipped below because they were already ingested - so the boundary
+                # id set is preserved across fetches and does not drift.
+                if hit_timestamp == last_fetch_timestamp and hit_id and hit_id not in new_fetch_ids:
+                    new_fetch_ids.append(hit_id)
 
-                    if MAP_LABELS:
-                        # Pass both _source and normalized fields to label maker
-                        inc["labels"] = incident_label_maker(hit.get("_source"), fields=fields)
-
-                    incidents.append(inc)
-                else:
+                # Skip only documents already ingested at the boundary timestamp,
+                # instead of dropping every hit that equals the boundary timestamp.
+                if hit_timestamp < current_fetch or (hit_id and hit_id in already_fetched_ids):
                     demisto.debug(
-                        f"Skipping hit ID: {hit.get('_id')} since {hit_timestamp=} is earlier than the {current_fetch=}"
+                        f"Skipping hit ID: {hit_id} since {hit_timestamp=} was already fetched (id previously ingested)"
                     )
+                    continue
 
-    return incidents, last_fetch.isoformat()  # type:ignore[union-attr]
+                inc = {
+                    "name": "Elasticsearch: Index: " + str(hit.get("_index")) + ", ID: " + str(hit_id),
+                    "rawJSON": json.dumps(hit),
+                    # parse function returns iso format sometimes as YYYY-MM-DDThh:mm:ss+00:00
+                    # and sometimes as YYYY-MM-DDThh:mm:ss
+                    # we want to return format: YYYY-MM-DDThh:mm:ssZ in our incidents
+                    "occurred": format_to_iso(hit_date.isoformat()),
+                }
+                if hit_id:
+                    inc["dbotMirrorId"] = hit_id
+
+                if MAP_LABELS:
+                    # Pass both _source and normalized fields to label maker
+                    inc["labels"] = incident_label_maker(hit.get("_source"), fields=fields)
+
+                incidents.append(inc)
+
+    return incidents, last_fetch.isoformat(), new_fetch_ids  # type:ignore[union-attr]
 
 
 def format_to_iso(date_string):
@@ -1051,8 +1108,12 @@ def get_time_range(
     """
     Creates the time range filter's dictionary based on the last fetch and given params.
     The filter is using timestamps with the following logic:
-        start date (gt) - if this is the first fetch: use time_range_start param if provided, else use fetch time param.
-                          if this is not the fetch: use the last fetch provided
+        start date (gte) - if this is the first fetch: use time_range_start param if provided, else use fetch time param.
+                          if this is not the fetch: use the last fetch provided.
+                          Note: an inclusive lower bound (gte) is used so documents that share the exact
+                          high-water-mark timestamp are not permanently skipped by the query. De-duplication
+                          of documents already ingested at the boundary timestamp is handled by _id in
+                          results_to_incidents_datetime / results_to_incidents_timestamp.
         end date (lt) - use the given time range end param.
         When the `time_method` parameter is set to `Simple-Date` in order to avoid being related to the field datetime format,
             we add the format key to the query dict.
@@ -1065,7 +1126,7 @@ def get_time_range(
 
 
     Returns:
-        dictionary (Ex. {"range":{'gt': 1000 'lt': 1001}})
+        dictionary (Ex. {"range":{'gte': 1000 'lt': 1001}})
     """
     range_dict = {}
     if not last_fetch and time_range_start:  # this is the first fetch
@@ -1077,7 +1138,7 @@ def get_time_range(
 
     demisto.debug(f"Time range start time: {start_time}")
     if start_time:
-        range_dict["gt"] = start_time
+        range_dict["gte"] = start_time
 
     if time_range_end:
         end_date = dateparser.parse(time_range_end)
@@ -1136,6 +1197,9 @@ def execute_raw_query(es, raw_query, index=None, size=None, page=None):
 def fetch_incidents(proxies):
     last_run = demisto.getLastRun()
     last_fetch = last_run.get("time") or FETCH_TIME
+    # _ids of documents already ingested at the last_fetch boundary timestamp,
+    # used to de-duplicate hits that share an identical timestamp across fetches.
+    last_fetch_ids = last_run.get("last_fetch_ids") or []
 
     es = elasticsearch_builder(proxies)
     time_range_dict = get_time_range(time_range_start=last_fetch)
@@ -1163,12 +1227,14 @@ def fetch_incidents(proxies):
 
     if total_results > 0:
         if "Timestamp" in TIME_METHOD:
-            incidents, last_fetch = results_to_incidents_timestamp(response, last_fetch)
-            demisto.setLastRun({"time": last_fetch})
+            incidents, last_fetch, last_fetch_ids = results_to_incidents_timestamp(response, last_fetch, last_fetch_ids)
+            demisto.setLastRun({"time": last_fetch, "last_fetch_ids": last_fetch_ids})
 
         else:
-            incidents, last_fetch = results_to_incidents_datetime(response, last_fetch or FETCH_TIME)
-            demisto.setLastRun({"time": str(last_fetch)})
+            incidents, last_fetch, last_fetch_ids = results_to_incidents_datetime(
+                response, last_fetch or FETCH_TIME, last_fetch_ids
+            )
+            demisto.setLastRun({"time": str(last_fetch), "last_fetch_ids": last_fetch_ids})
 
         demisto.info(f"Extracted {len(incidents)} incidents.")
     demisto.incidents(incidents)

--- a/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2_test.py
+++ b/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2_test.py
@@ -519,7 +519,7 @@ def test_incident_creation_e6(params, mocker):
     from Elasticsearch_v2 import results_to_incidents_datetime
 
     last_fetch = "2019-08-29T14:44:00Z"
-    incidents, last_fetch2 = results_to_incidents_datetime(ES_V6_RESPONSE, last_fetch)
+    incidents, last_fetch2, _ = results_to_incidents_datetime(ES_V6_RESPONSE, last_fetch)
 
     # last fetch should not truncate the milliseconds
     assert str(last_fetch2) == "2019-08-29T14:46:00.123456+00:00"
@@ -536,7 +536,7 @@ def test_incident_creation_e7(params, mocker):
     from Elasticsearch_v2 import results_to_incidents_datetime
 
     last_fetch = "2019-08-27T17:59:00"
-    incidents, last_fetch2 = results_to_incidents_datetime(ES_V7_RESPONSE, last_fetch)
+    incidents, last_fetch2, _ = results_to_incidents_datetime(ES_V7_RESPONSE, last_fetch)
 
     # last fetch should not truncate the milliseconds
     assert str(last_fetch2) == "2019-08-27T18:01:25.343212+00:00"
@@ -576,12 +576,208 @@ def test_incident_creation_with_timestamp_e7(params, mocker):
     from Elasticsearch_v2 import results_to_incidents_timestamp
 
     lastfetch = int(datetime.strptime("2019-08-27T17:59:00Z", "%Y-%m-%dT%H:%M:%SZ").timestamp())
-    incidents, last_fetch2 = results_to_incidents_timestamp(ES_V7_RESPONSE_WITH_TIMESTAMP, lastfetch)
+    incidents, last_fetch2, _ = results_to_incidents_timestamp(ES_V7_RESPONSE_WITH_TIMESTAMP, lastfetch)
     assert last_fetch2 == 1572502640
     if params.get("map_labels"):
         assert str(incidents) == MOCK_ES7_INCIDENTS_FROM_TIMESTAMP
     else:
         assert str(incidents) == MOCK_ES7_INCIDENTS_FROM_TIMESTAMP_WITHOUT_LABELS
+
+
+# XSUP-72750: three documents sharing an identical sub-second timestamp at the fetch boundary.
+ES_IDENTICAL_TIMESTAMP_RESPONSE = {
+    "took": 1,
+    "timed_out": False,
+    "_shards": {"total": 1, "successful": 1, "skipped": 0, "failed": 0},
+    "hits": {
+        "total": {"value": 3, "relation": "eq"},
+        "max_score": 1.0,
+        "hits": [
+            {"_index": "customer", "_type": "doc", "_id": "a1", "_source": {"Date": "2019-08-27T18:00:00.120000Z"}},
+            {"_index": "customer", "_type": "doc", "_id": "a2", "_source": {"Date": "2019-08-27T18:00:00.120000Z"}},
+            {"_index": "customer", "_type": "doc", "_id": "a3", "_source": {"Date": "2019-08-27T18:00:00.120000Z"}},
+        ],
+    },
+}
+
+
+@pytest.mark.parametrize("params", MOCK_PARAMS)
+def test_datetime_identical_timestamps_no_data_loss_across_fetches(params, mocker):
+    """
+    XSUP-72750 regression test (Simple-Date / datetime path).
+
+    Given:
+        - Three documents that share an identical sub-second timestamp which is the
+          fetch high-water-mark, split across two fetch cycles (first fetch returns
+          only 'a1', second fetch returns all three because the query lower bound is now inclusive).
+    When:
+        - Running results_to_incidents_datetime twice, feeding the returned last_fetch and
+          last_fetch_ids from the first call into the second (mimicking demisto.setLastRun/getLastRun).
+    Then:
+        - All three documents are ingested exactly once (no data loss, no duplicates).
+    """
+    mocker.patch.object(demisto, "params", return_value=params)
+    importlib.reload(Elasticsearch_v2)
+    from Elasticsearch_v2 import results_to_incidents_datetime
+
+    first_response = {"hits": {"hits": [ES_IDENTICAL_TIMESTAMP_RESPONSE["hits"]["hits"][0]]}}
+
+    # First fetch: only 'a1' is available (page boundary cuts the rest off).
+    incidents1, last_fetch1, ids1 = results_to_incidents_datetime(first_response, "2019-08-27T17:59:00Z")
+    assert [inc["dbotMirrorId"] for inc in incidents1] == ["a1"]
+    assert ids1 == ["a1"]
+
+    # Second fetch: query is now gte the boundary timestamp, so all three are returned.
+    incidents2, last_fetch2, ids2 = results_to_incidents_datetime(ES_IDENTICAL_TIMESTAMP_RESPONSE, last_fetch1, ids1)
+    # 'a1' must be skipped (already ingested), 'a2' and 'a3' must be ingested.
+    assert [inc["dbotMirrorId"] for inc in incidents2] == ["a2", "a3"]
+    assert sorted(ids2) == ["a1", "a2", "a3"]
+
+    # Overall: all three ingested exactly once.
+    all_ingested = [inc["dbotMirrorId"] for inc in incidents1 + incidents2]
+    assert sorted(all_ingested) == ["a1", "a2", "a3"]
+
+
+@pytest.mark.parametrize("params", MOCK_PARAMS)
+def test_datetime_identical_timestamps_no_duplicates_on_replay(params, mocker):
+    """
+    XSUP-72750 regression test (Simple-Date / datetime path) - idempotency.
+
+    Given:
+        - A fetch that already ingested all three identically-timestamped documents.
+    When:
+        - The exact same response is returned again (e.g. no new documents arrived).
+    Then:
+        - No incidents are produced (all skipped by _id de-duplication), so no duplicates.
+    """
+    mocker.patch.object(demisto, "params", return_value=params)
+    importlib.reload(Elasticsearch_v2)
+    from Elasticsearch_v2 import results_to_incidents_datetime
+
+    incidents1, last_fetch1, ids1 = results_to_incidents_datetime(ES_IDENTICAL_TIMESTAMP_RESPONSE, "2019-08-27T17:59:00Z")
+    assert sorted(inc["dbotMirrorId"] for inc in incidents1) == ["a1", "a2", "a3"]
+
+    # Replay the same response with the persisted state.
+    incidents2, last_fetch2, ids2 = results_to_incidents_datetime(ES_IDENTICAL_TIMESTAMP_RESPONSE, last_fetch1, ids1)
+    assert incidents2 == []
+    assert sorted(ids2) == ["a1", "a2", "a3"]
+
+
+@pytest.mark.parametrize("params", MOCK_PARAMS)
+def test_timestamp_identical_timestamps_no_data_loss_across_fetches(params, mocker):
+    """
+    XSUP-72750 regression test (Timestamp path).
+
+    Given:
+        - Three documents that share an identical epoch-millisecond timestamp which is the
+          fetch high-water-mark, split across two fetch cycles.
+    When:
+        - Running results_to_incidents_timestamp twice, feeding the returned last_fetch and
+          last_fetch_ids from the first call into the second.
+    Then:
+        - All three documents are ingested exactly once (no data loss, no duplicates).
+    """
+    mocker.patch.object(demisto, "params", return_value=params)
+    importlib.reload(Elasticsearch_v2)
+    mocker.patch("Elasticsearch_v2.TIME_METHOD", "Timestamp-Milliseconds")
+    from Elasticsearch_v2 import results_to_incidents_timestamp
+
+    ts = 1566928800120  # 2019-08-27T18:00:00.120Z in epoch milliseconds
+    hit = {"_index": "customer", "_type": "doc", "_source": {"Date": ts}}
+    response = {
+        "hits": {
+            "hits": [
+                {**hit, "_id": "a1"},
+                {**hit, "_id": "a2"},
+                {**hit, "_id": "a3"},
+            ]
+        }
+    }
+    first_response = {"hits": {"hits": [{**hit, "_id": "a1"}]}}
+
+    last_fetch = 1566928740000  # earlier than ts
+    incidents1, last_fetch1, ids1 = results_to_incidents_timestamp(first_response, last_fetch)
+    assert [inc["dbotMirrorId"] for inc in incidents1] == ["a1"]
+    assert last_fetch1 == ts
+    assert ids1 == ["a1"]
+
+    incidents2, last_fetch2, ids2 = results_to_incidents_timestamp(response, last_fetch1, ids1)
+    assert [inc["dbotMirrorId"] for inc in incidents2] == ["a2", "a3"]
+    assert last_fetch2 == ts
+    assert sorted(ids2) == ["a1", "a2", "a3"]
+
+
+@pytest.mark.parametrize("params", MOCK_PARAMS)
+def test_datetime_identical_timestamps_boundary_ids_persist_over_three_fetches(params, mocker):
+    """
+    XSUP-72750 regression test - continuity over three fetch cycles.
+
+    Given:
+        - Three documents sharing an identical boundary timestamp, revealed one per fetch.
+    When:
+        - Running results_to_incidents_datetime three times, always feeding back the persisted
+          last_fetch and last_fetch_ids (mimicking demisto.getLastRun/setLastRun).
+    Then:
+        - Each document is ingested exactly once and the boundary id set never drifts,
+          so no document is ever re-ingested as a duplicate on a later cycle.
+    """
+    mocker.patch.object(demisto, "params", return_value=params)
+    importlib.reload(Elasticsearch_v2)
+    from Elasticsearch_v2 import results_to_incidents_datetime
+
+    hits = ES_IDENTICAL_TIMESTAMP_RESPONSE["hits"]["hits"]
+    fetch1 = {"hits": {"hits": hits[:1]}}
+    fetch2 = {"hits": {"hits": hits[:2]}}
+    fetch3 = {"hits": {"hits": hits[:3]}}
+
+    incidents1, last_fetch, ids = results_to_incidents_datetime(fetch1, "2019-08-27T17:59:00Z")
+    incidents2, last_fetch, ids = results_to_incidents_datetime(fetch2, last_fetch, ids)
+    incidents3, last_fetch, ids = results_to_incidents_datetime(fetch3, last_fetch, ids)
+
+    assert [inc["dbotMirrorId"] for inc in incidents1] == ["a1"]
+    assert [inc["dbotMirrorId"] for inc in incidents2] == ["a2"]
+    assert [inc["dbotMirrorId"] for inc in incidents3] == ["a3"]
+    assert sorted(ids) == ["a1", "a2", "a3"]
+
+    all_ingested = [inc["dbotMirrorId"] for inc in incidents1 + incidents2 + incidents3]
+    assert sorted(all_ingested) == ["a1", "a2", "a3"]
+
+
+@pytest.mark.parametrize("params", MOCK_PARAMS)
+def test_datetime_newer_timestamp_resets_boundary_ids(params, mocker):
+    """
+    XSUP-72750 regression test - boundary id reset when a newer timestamp appears.
+
+    Given:
+        - A page containing some documents at the boundary timestamp and some at a strictly
+          newer timestamp.
+    When:
+        - Running results_to_incidents_datetime with the boundary id already persisted.
+    Then:
+        - The previously-fetched boundary id is skipped, new documents are ingested, and the
+          returned boundary id set contains only the ids at the new (newer) high-water-mark.
+    """
+    mocker.patch.object(demisto, "params", return_value=params)
+    importlib.reload(Elasticsearch_v2)
+    from Elasticsearch_v2 import results_to_incidents_datetime
+
+    response = {
+        "hits": {
+            "hits": [
+                {"_index": "c", "_type": "doc", "_id": "a1", "_source": {"Date": "2019-08-27T18:00:00.120000Z"}},
+                {"_index": "c", "_type": "doc", "_id": "a2", "_source": {"Date": "2019-08-27T18:00:00.120000Z"}},
+                {"_index": "c", "_type": "doc", "_id": "b1", "_source": {"Date": "2019-08-27T18:05:00.500000Z"}},
+            ]
+        }
+    }
+
+    # 'a1' was already ingested at the previous boundary (18:00:00.120000).
+    incidents, last_fetch, ids = results_to_incidents_datetime(response, "2019-08-27T18:00:00.120000Z", ["a1"])
+
+    # 'a1' skipped, 'a2' and 'b1' ingested; the boundary advanced to b1's timestamp,
+    # so only 'b1' remains as the boundary id.
+    assert [inc["dbotMirrorId"] for inc in incidents] == ["a2", "b1"]
+    assert ids == ["b1"]
 
 
 @pytest.mark.parametrize("params", MOCK_PARAMS)
@@ -761,14 +957,14 @@ class TestIncidentLabelMaker(unittest.TestCase):
             "",
             "1.1.2000 12:00:00Z",
             "2.1.2000 12:00:00Z",
-            {"range": {"time_field": {"gt": 946728000000, "lt": 949406400000}}},
+            {"range": {"time_field": {"gte": 946728000000, "lt": 949406400000}}},
         ),
         (
             "Timestamp-Milliseconds",
             946728000000,
             "",
             "2.1.2000 12:00:00Z",
-            {"range": {"time_field": {"gt": 946728000000, "lt": 949406400000}}},
+            {"range": {"time_field": {"gte": 946728000000, "lt": 949406400000}}},
         ),
         ("Timestamp-Milliseconds", "", "", "2.1.2000 12:00:00Z", {"range": {"time_field": {"lt": 949406400000}}}),
         (
@@ -776,7 +972,7 @@ class TestIncidentLabelMaker(unittest.TestCase):
             "2.1.2000 12:00:00.000000",
             "",
             "",
-            {"range": {"time_field": {"gt": "2.1.2000 12:00:00.000000", "format": Elasticsearch_v2.ES_DEFAULT_DATETIME_FORMAT}}},
+            {"range": {"time_field": {"gte": "2.1.2000 12:00:00.000000", "format": Elasticsearch_v2.ES_DEFAULT_DATETIME_FORMAT}}},
         ),
     ],
 )

--- a/Packs/Elasticsearch/ReleaseNotes/1_4_9.md
+++ b/Packs/Elasticsearch/ReleaseNotes/1_4_9.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Elasticsearch v2
+
+- Fixed an issue where the fetch process skipped valid incidents that shared an identical timestamp (down to the sub-second) with the last fetched incident. The time filter now uses an inclusive lower bound and documents are de-duplicated by their ID to prevent both data loss and duplicates. Note: on the first fetch after upgrading an existing instance, documents that share the last fetched timestamp may be re-ingested once.

--- a/Packs/Elasticsearch/pack_metadata.json
+++ b/Packs/Elasticsearch/pack_metadata.json
@@ -12,7 +12,10 @@
     ],
     "tags": [],
     "useCases": [],
-    "keywords": [],
+    "keywords": [
+        "Elastic",
+        "Elasticsearch"
+    ],
     "marketplaces": [
         "xsoar",
         "marketplacev2",

--- a/Packs/Elasticsearch/pack_metadata.json
+++ b/Packs/Elasticsearch/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Elasticsearch",
     "description": "Search for and analyze data in real time. \n Supports version 6 and later.",
     "support": "xsoar",
-    "currentVersion": "1.4.8",
+    "currentVersion": "1.4.9",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION


## Related Issues
fixes: XSUP-72750

## Description
Fixes an issue in the Elasticsearch v2 integration where the fetch process silently skipped valid incidents that shared an identical timestamp (down to the sub-second) with the last fetched incident, causing data gaps with no error.

The time-range filter previously used an exclusive lower bound (`gt`), so documents equal to the last high-water-mark timestamp were never re-returned by Elasticsearch, and the in-code de-duplication discarded every hit equal to the boundary. The fix switches the filter to an inclusive lower bound (`gte`) and de-duplicates by document `_id`: only the IDs already ingested at the boundary timestamp are skipped, while all other documents are ingested. The set of boundary IDs is persisted in `lastRun` and carried across fetches so no document is lost or duplicated.
