### PR TITLE
SlackV3: skip user lookup for already-resolved user IDs

### DIFF
--- a/Packs/Slack/Integrations/SlackV3/SlackV3.py
+++ b/Packs/Slack/Integrations/SlackV3/SlackV3.py
@@ -29,6 +29,12 @@ SEVERITY_DICT = {"Unknown": 0, "Low": 1, "Medium": 2, "High": 3, "Critical": 4}
 
 USER_TAG_EXPRESSION = "<@(.*?)>"
 CHANNEL_TAG_EXPRESSION = "<#(.*?)>"
+# Matches an already-resolved Slack user/bot ID (e.g. U012A3CDE, W01AB2CD3, B0123ABCD).
+# Slack IDs are uppercase, start with U/W/B and are followed by uppercase letters/digits.
+# Real IDs are currently ~9-11 chars; the generous upper bound (8-15 total) leaves room
+# for future ID-length growth while keeping the match tight enough to avoid treating
+# human display names as IDs.
+SLACK_USER_ID_EXPRESSION = re.compile(r"^[UWB][A-Z0-9]{7,14}$")
 URL_EXPRESSION = r"<(https?://.+?)(?:\|.+)?>"
 GUID_REGEX = r"(\{){0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}"
 ENTITLEMENT_REGEX = rf"{GUID_REGEX}@(({GUID_REGEX})|(?:[\d_]+))_*(\|\S+)?\b"
@@ -2724,7 +2730,12 @@ def handle_tags_in_message_sync(message: str) -> str:
     """
     matches = re.finditer(USER_TAG_EXPRESSION, message)
     for match in matches:
-        slack_user = get_user_by_name(match.group(1))
+        tag = match.group(1)
+        # If the tag is already a resolved Slack user/bot ID (e.g. "<@U12345678>"),
+        # skip the expensive get_user_by_name lookup — the mention is already valid.
+        if SLACK_USER_ID_EXPRESSION.match(tag):
+            continue
+        slack_user = get_user_by_name(tag)
         if slack_user:
             message = message.replace(match.group(0), f"<@{slack_user.get('id')}>")
         else:

--- a/Packs/Slack/Integrations/SlackV3/SlackV3.py
+++ b/Packs/Slack/Integrations/SlackV3/SlackV3.py
@@ -2739,7 +2739,9 @@ def handle_tags_in_message_sync(message: str) -> str:
         if slack_user:
             message = message.replace(match.group(0), f"<@{slack_user.get('id')}>")
         else:
-            message = re.sub(USER_TAG_EXPRESSION, r"\1", message)
+            # Only strip the brackets of this specific unresolved tag, not every tag in the
+            # message (a blanket re.sub would also break already-valid ID mentions we skipped).
+            message = message.replace(match.group(0), tag)
     return message
 
 

--- a/Packs/Slack/Integrations/SlackV3/SlackV3_test.py
+++ b/Packs/Slack/Integrations/SlackV3/SlackV3_test.py
@@ -4371,6 +4371,30 @@ def test_handle_tags_in_message_sync_already_resolved_id(mocker):
     get_user_by_name_mock.assert_not_called()
 
 
+def test_handle_tags_in_message_sync_resolved_id_with_unresolved_name(mocker):
+    """
+    Given:
+        A message containing an already-resolved Slack ID mention followed by an
+        unresolved name tag (which get_user_by_name cannot resolve).
+    When:
+        Running handle_tags_in_message_sync.
+    Then:
+        Only the unresolved tag's brackets are stripped, while the already-valid ID
+        mention is preserved (regression for the blanket re.sub bug).
+    """
+    import SlackV3
+    from SlackV3 import handle_tags_in_message_sync
+
+    mocker.patch.object(SlackV3, "get_user_by_name", return_value={})
+
+    message = "cc <@U012A3CDE> and <@NoSuchUser>"
+
+    result = handle_tags_in_message_sync(message)
+
+    # The valid ID mention must remain intact; only the unresolved tag is stripped.
+    assert result == "cc <@U012A3CDE> and NoSuchUser"
+
+
 def test_send_message_to_destinations_non_strict():
     """
     Given:

--- a/Packs/Slack/Integrations/SlackV3/SlackV3_test.py
+++ b/Packs/Slack/Integrations/SlackV3/SlackV3_test.py
@@ -4344,6 +4344,33 @@ def test_handle_tags_in_message_sync(mocker):
     assert user_message_doesnt_exist_result == "Goodbye PetahTikva!"
 
 
+def test_handle_tags_in_message_sync_already_resolved_id(mocker):
+    """
+    Given:
+        A message containing an already-resolved Slack user/bot ID mention (e.g. "<@U012A3CDE>").
+    When:
+        Running handle_tags_in_message_sync.
+    Then:
+        The mention is left untouched and no user lookup (get_user_by_name) is performed,
+        avoiding the expensive paginated Slack user search.
+    """
+    import SlackV3
+    from SlackV3 import handle_tags_in_message_sync
+
+    get_user_by_name_mock = mocker.patch.object(SlackV3, "get_user_by_name")
+
+    bot_id_message = "💡 For help, type <@U012A3CDE> !help"
+    multiple_ids_message = "cc <@W01AB2CD3> and <@B0123ABCD> please"
+
+    bot_id_result = handle_tags_in_message_sync(bot_id_message)
+    multiple_ids_result = handle_tags_in_message_sync(multiple_ids_message)
+
+    # Assert - messages are unchanged and no lookup was performed
+    assert bot_id_result == bot_id_message
+    assert multiple_ids_result == multiple_ids_message
+    get_user_by_name_mock.assert_not_called()
+
+
 def test_send_message_to_destinations_non_strict():
     """
     Given:

--- a/Packs/Slack/ReleaseNotes/3_8_10.md
+++ b/Packs/Slack/ReleaseNotes/3_8_10.md
@@ -3,4 +3,4 @@
 
 ##### Slack v3
 
-Improved performance when sending messages that contain already-resolved user mentions (e.g. `<@U012A3CDE>`) by skipping the unnecessary user lookup.
+Improved implementation of message sending by skipping unnecessary user lookups for already-resolved user mentions (e.g., `<@U012A3CDE>`).

--- a/Packs/Slack/ReleaseNotes/3_8_10.md
+++ b/Packs/Slack/ReleaseNotes/3_8_10.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Slack v3
+
+Improved performance when sending messages that contain already-resolved user mentions (e.g. `<@U012A3CDE>`) by skipping the unnecessary user lookup.

--- a/Packs/Slack/pack_metadata.json
+++ b/Packs/Slack/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Slack",
     "description": "Interact with Slack API - collect logs, send messages and notifications to your Slack team.",
     "support": "xsoar",
-    "currentVersion": "3.8.9",
+    "currentVersion": "3.8.10",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: CRTX-264968

## Description
handle_tags_in_message_sync no longer calls the expensive get_user_by_name (paginated Slack user search) when a tag already contains a resolved Slack user/bot ID (e.g. <@U012A3CDE>). This improves performance for Assistant flows such as the agent-selection help hint, which embed already-resolved bot mentions.

- Add SLACK_USER_ID_EXPRESSION and skip resolution for matching tags
- Add regression test asserting get_user_by_name is not called
- Bump Slack pack to 3.8.10 with release notes

## Must have
- [ ] Tests
- [ ] Documentation
