### PR TITLE
Update edl instructions on how to access the service

### DIFF
--- a/Packs/EDL/Integrations/EDL/EDL_description.md
+++ b/Packs/EDL/Integrations/EDL/EDL_description.md
@@ -110,5 +110,5 @@ To view logs concerning the creation of the indicator list and its current statu
 `https://*<xsoar_address>*/instance/execute/*<instance_name>*/log`
 </~XSOAR_ON_PREM>
 <~XSIAM>
-`https://ext-<cortex-xsiam-address>/xsoar/instance/execute/<instance-name>/log` and replace the `xdr` in the url with `crtx`.
+`https://ext-<cortex-xsiam-address>/xsoar/instance/execute/<instance-name>/log` and replace the `xdr` in the URL with `crtx`.
 </~XSIAM>

--- a/Packs/EDL/Integrations/EDL/EDL_description.md
+++ b/Packs/EDL/Integrations/EDL/EDL_description.md
@@ -13,10 +13,10 @@ The Generic Export Indicators Service is a long-running integration. For more in
 **Note**: The External Dynamic List is not accessible via web browsers and you will receive an unauthorized error if accessing the External Dynamic List via a browser.
 
 1. To access the **Generic Export Indicators Service** by instance name, set up the **username** and **password** values in the **External Dynamic List Integration** page (**Settings** > **Configurations** > **Integrations** > **External Dynamic List Integration**).
-2. You can access the External Dynamic List at the following url: `https://edl-<cortex-xsiam-address>/xsoar/instance/execute/<instance-name>`.
-3. For example to test via curl with an instance with instance name: `EDL_instance_1`, XSIAM address `my-xsiam-subdomain.us.paloaltonetworks.com` and credentials test/password:
+2. You can access the External Dynamic List at the following url: `https://ext-<cortex-xsiam-address>/xsoar/instance/execute/<instance-name>`. You must replace the `xdr` in the URL with `crtx`. For example, if the tenant URL is `https://platform-test.xdr-qa2-uat.us.example.com/`, use `https://ext-platform-test.crtx-qa2-uat.us.example.com/`.
+3. For example to test via curl with an instance with instance name: `EDL_instance_1`, XSIAM tenant URL `https://my-xsiam-subdomain.xdr.us.paloaltonetworks.com/` and credentials test/password:
 ```
-curl -v -u test:password https://edl-my-xsiam-subdomain.us.paloaltonetworks.com/xsoar/instance/execute/EDL_instance_1
+curl -v -u test:password https://ext-my-xsiam-subdomain.crtx.us.paloaltonetworks.com/xsoar/instance/execute/EDL_instance_1
 ```
 
 </~XSIAM>
@@ -110,5 +110,5 @@ To view logs concerning the creation of the indicator list and its current statu
 `https://*<xsoar_address>*/instance/execute/*<instance_name>*/log`
 </~XSOAR_ON_PREM>
 <~XSIAM>
-`https://edl-<cortex-xsiam-address>/xsoar/instance/execute/<instance-name>/log`
+`https://ext-<cortex-xsiam-address>/xsoar/instance/execute/<instance-name>/log` and replace the `xdr` in the url with `crtx`.
 </~XSIAM>

--- a/Packs/EDL/Integrations/EDL/README.md
+++ b/Packs/EDL/Integrations/EDL/README.md
@@ -46,7 +46,7 @@ For Cortex XSOAR On-prem -
 `https://*<xsoar_address>*/instance/execute/*<instance_name>*/log`
 
 For Cortex XSIAM -
-`https://ext-<cortex-xsiam-address>/xsoar/instance/execute/<instance-name>/log` and replace the `xdr` in the url with `crtx`.
+`https://ext-<cortex-xsiam-address>/xsoar/instance/execute/<instance-name>/log` and replace the `xdr` in the URL with `crtx`.
 
 ## Use Cases
 
@@ -194,7 +194,7 @@ For Cortex XSOAR On-prem (6.x or 8) or when using engines, you can set up authen
 For Cortex XSOAR 8 On-prem, you need to add the `ext-` FQDN DNS record to map the Cortex XSOAR DNS name to the external IP address.  
 For example, `ext-xsoar.mycompany.com`.
 
-For Cortex XSOAR 8 Cloud, Cortex XSOAR 8 On-prem and Cortex XSIAM, you can only access the Export Indicators Service using a third-party tool such as cURL.
+For Cortex XSOAR 8 Cloud, Cortex XSOAR 8 On-prem and Cortex XSIAM, you can only access the Export Indicators Service using a third-party tool such as curl.
 
 - For Cortex XSOAR, if the integration is configured to run on a tenant, use `https://ext-<cortex-xsoar-address>/xsoar/instance/execute/<instance-name>`.
 

--- a/Packs/EDL/Integrations/EDL/README.md
+++ b/Packs/EDL/Integrations/EDL/README.md
@@ -46,9 +46,7 @@ For Cortex XSOAR On-prem -
 `https://*<xsoar_address>*/instance/execute/*<instance_name>*/log`
 
 For Cortex XSIAM -
-`https://edl-<cortex-xsiam-address>/xsoar/instance/execute/<instance-name>/log`
-or
-`https://ext-<cortex-xsiam-address>/xsoar/instance/execute/<instance-name>/log` and replace the `xdr` in the url to `crtx`.
+`https://ext-<cortex-xsiam-address>/xsoar/instance/execute/<instance-name>/log` and replace the `xdr` in the url with `crtx`.
 
 ## Use Cases
 
@@ -195,14 +193,18 @@ For Cortex XSOAR On-prem (6.x or 8) or when using engines, you can set up authen
 **Note:**  
 For Cortex XSOAR 8 On-prem, you need to add the `ext-` FQDN DNS record to map the Cortex XSOAR DNS name to the external IP address.  
 For example, `ext-xsoar.mycompany.com`.
-  
-For Cortex XSOAR 8 Cloud, Cortex XSOAR On-prem and Cortex XSIAM, you can only access the Export Indicators Service using a third-party tool such as cURL.
 
-- If the integration is configured to run on a tenant, use `https://ext-<cortex-xsoar-address>/xsoar/instance/execute/<instance-name>`  
-  Note: For Cortex XSIAM, you can use the `edl-` prefix. Alternatively, if using the `ext-` prefix, replace the `xdr` in the url to `crtx`.  
+For Cortex XSOAR 8 Cloud, Cortex XSOAR 8 On-prem and Cortex XSIAM, you can only access the Export Indicators Service using a third-party tool such as cURL.
+
+- For Cortex XSOAR, if the integration is configured to run on a tenant, use `https://ext-<cortex-xsoar-address>/xsoar/instance/execute/<instance-name>`.
 
   For example: `curl -v -u user:pass https://ext-mytenant.paloaltonetworks.com/xsoar/instance/execute/edl_instance_01?q=type:ip`
-- If the integration is configured to run on an engine, use `http://<engine-address>:<integration listen port>`  
+
+- For Cortex XSIAM, if the integration is configured to run on a tenant, you must replace the `xdr` in the URL with `crtx`. For example, if the tenant URL is `https://platform-test.xdr-qa2-uat.us.example.com/`, use `https://ext-platform-test.crtx-qa2-uat.us.example.com/`.
+
+  For example: `curl -v -u user:pass https://ext-platform-test.crtx-qa2-uat.us.example.com/xsoar/instance/execute/edl_instance_01?q=type:ip`
+
+- If the integration is configured to run on an engine, use `http://<engine-address>:<integration listen port>`.
 
   For example: `curl -v -u user:pass http://<engine_address>:<listen_port>?n=50`
 

--- a/Packs/EDL/ReleaseNotes/3_3_36.md
+++ b/Packs/EDL/ReleaseNotes/3_3_36.md
@@ -3,4 +3,4 @@
 
 ##### Generic Export Indicators Service
 
-- Updated the documentation on how to access the Export Indicators Service on Cortex XSOAR and Cortex XSIAM tenants.
+- Updated the documentation on how to access the **Export Indicators Service** on Cortex XSOAR and Cortex XSIAM tenants.

--- a/Packs/EDL/ReleaseNotes/3_3_36.md
+++ b/Packs/EDL/ReleaseNotes/3_3_36.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Generic Export Indicators Service
+
+- Updated the documentation on how to access the Export Indicators Service on Cortex XSOAR and Cortex XSIAM tenants.

--- a/Packs/EDL/pack_metadata.json
+++ b/Packs/EDL/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Generic Export Indicators Service",
     "description": "Use this pack to generate a list based on your Threat Intel Library, and export it to any product in your network, such as firewalls, agents or SIEMs. This pack supports ongoing distribution of indicators from XSOAR to other products in the network, by creating an endpoint with a list of indicators that can be pulled by external vendors.",
     "support": "xsoar",
-    "currentVersion": "3.3.35",
+    "currentVersion": "3.3.36",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
<!-- To link a Jira ticket use fixes/related: link to the issue, for example fixes: CIAC-XXXX -->

## Description
Update EDL documentation on how to access the Export Indicators Service, standardizing on the  ext- prefix and clarifying the xdr→crtx URL replacement for Cortex XSIAM tenants.             
                                            

## Must have
- [ ] Tests
- [ ] Documentation
