### PR TITLE
XSUP-72930 - improve BeyondTrust Password Safe target account extraction

### DIFF
--- a/Packs/BeyondTrust_Password_Safe/ModelingRules/BeyondTrust_Password_Safe/BeyondTrust_Password_Safe.xif
+++ b/Packs/BeyondTrust_Password_Safe/ModelingRules/BeyondTrust_Password_Safe/BeyondTrust_Password_Safe.xif
@@ -81,6 +81,7 @@ alter // Extract raw data (https://www.beyondtrust.com/docs/beyondinsight-passwo
     target_application = arrayindex(regextract(details, "Application=(\w+)"), 0),
     target_account = coalesce(
         arrayindex(regextract(event_target, "Account\:(\S+)"), 0),
+        arrayindex(regextract(event_target, "Account=(\S+)"), 0),
         arrayindex(regextract(_raw_log, "Username:\s\"?(\w.*?)\"?(?:,|\s{4}|\t)"), 0),
         arrayindex(regextract(_raw_log, "Account\s?Name:\s\"?(\w.*?)\"?(?:,|\s{4}|\t)"), 0)),
     target_asset = arrayindex(regextract(event_target, "Asset(?:\=|\:)(\S+)"), 0),

--- a/Packs/BeyondTrust_Password_Safe/ModelingRules/BeyondTrust_Password_Safe/BeyondTrust_Password_Safe.xif
+++ b/Packs/BeyondTrust_Password_Safe/ModelingRules/BeyondTrust_Password_Safe/BeyondTrust_Password_Safe.xif
@@ -80,11 +80,12 @@ alter // Extract raw data (https://www.beyondtrust.com/docs/beyondinsight-passwo
     request_id = arrayindex(regextract(details, "(?:Request \#|ReleaseRequestId=)(\w+)"), 0),
     target_application = arrayindex(regextract(details, "Application=(\w+)"), 0),
     target_account = coalesce(
-        arrayindex(regextract(event_target, "Account\:(\S+)"), 0),
-        arrayindex(regextract(event_target, "Account=(\S+)"), 0),
+        arrayindex(regextract(event_target, "Account[:=](\S+)"), 0),
         arrayindex(regextract(_raw_log, "Username:\s\"?(\w.*?)\"?(?:,|\s{4}|\t)"), 0),
         arrayindex(regextract(_raw_log, "Account\s?Name:\s\"?(\w.*?)\"?(?:,|\s{4}|\t)"), 0)),
-    target_asset = arrayindex(regextract(event_target, "Asset(?:\=|\:)(\S+)"), 0),
+    target_asset = coalesce(
+        arrayindex(regextract(event_target, "Asset(?:\=|\:)(\S+)"), 0),
+        arrayindex(regextract(event_target, "ManagedSystem\=(\S+)"),0)),
     target_netbios_name = arrayindex(regextract(message, "NetBiosName=([^,]+)"), 0),
     user_domain = coalesce(arrayindex(regextract(user, "(.+)\\.+"), 0), arrayindex(split(user, "@"), 1), arrayindex(split(email, "@"), 1)),
     user_name = coalesce(arrayindex(regextract(user, "\\(.+)"), 0), arrayindex(regextract(user, "(.+)\@"), 0), user),

--- a/Packs/BeyondTrust_Password_Safe/ReleaseNotes/1_1_14.md
+++ b/Packs/BeyondTrust_Password_Safe/ReleaseNotes/1_1_14.md
@@ -1,0 +1,6 @@
+
+#### Modeling Rules
+
+##### BeyondTrust Password Safe Modeling Rule
+
+Improved the target account extraction to support additional value formats.

--- a/Packs/BeyondTrust_Password_Safe/ReleaseNotes/1_1_14.md
+++ b/Packs/BeyondTrust_Password_Safe/ReleaseNotes/1_1_14.md
@@ -3,4 +3,4 @@
 
 ##### BeyondTrust Password Safe Modeling Rule
 
-Improved the target account extraction to support additional value formats.
+Improved the target account and target asset extraction to support additional value formats.

--- a/Packs/BeyondTrust_Password_Safe/pack_metadata.json
+++ b/Packs/BeyondTrust_Password_Safe/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "BeyondTrust Password Safe",
     "description": "Unified password and session management for seamless accountability and control over privileged accounts.",
     "support": "xsoar",
-    "currentVersion": "1.1.13",
+    "currentVersion": "1.1.14",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
Improves target account extraction in the BeyondTrust Password Safe Modeling Rule.

The `target_account` regex matched only the `Account:` delimiter; it now also accepts `=`, so `ManagedAccount=` (and `MAccount:`) values populate `xdm.target.user.identifier`. The change is a superset of the previous pattern, so existing formats are unaffected.

Related: XSUP-72930
