### PR TITLE
EIR-16868

### DIFF
--- a/Packs/knowbe4Phisher/Integrations/knowbe4Phisher/knowbe4Phisher.py
+++ b/Packs/knowbe4Phisher/Integrations/knowbe4Phisher/knowbe4Phisher.py
@@ -403,10 +403,7 @@ def test_module(client: Client) -> str:
             client=client, last_run=demisto.getLastRun(), first_fetch_time=first_fetch_time, max_fetch=fetch_limit, look_back=0
         )
 
-        if incidents:
-            return "ok"
-        else:
-            return "no data in the system, but connection looks ok"
+        return "ok"
     except Exception as e:
         if "Unauthorized" in str(e):
             return "Authorization Error: make sure API Key was set correctly"

--- a/Packs/knowbe4Phisher/Integrations/knowbe4Phisher/knowbe4Phisher.py
+++ b/Packs/knowbe4Phisher/Integrations/knowbe4Phisher/knowbe4Phisher.py
@@ -277,6 +277,7 @@ FETCH_WITHOUT_EVENTS = """query {{
       }}
       pipelineStatus
       rawUrl
+      reportedAt
       reportedBy
       rules {{
         createdAt
@@ -678,8 +679,11 @@ def fetch_incidents(
     for message in messages:
         events = message.get("events", {})
         creation_time = get_created_time(events)
-        # cursor field must stay in DATE_FORMAT for the SDK lookback helpers
-        message["created_at_cursor"] = creation_time if creation_time else start_fetch_time
+        # cursor uses reportedAt so it stays coherent with the reported_at Lucene query field —
+        # using createdAt (set after ingestion) caused a gap where reported_at < createdAt
+        # meant some messages fell behind the cursor start and were permanently missed
+        reported_at = message.get("reportedAt") or creation_time or start_fetch_time
+        message["created_at_cursor"] = reported_at
         message["created at"] = arg_to_datetime(creation_time).isoformat() if creation_time else start_fetch_time  # type: ignore
         message.pop("events", None)
 

--- a/Packs/knowbe4Phisher/Integrations/knowbe4Phisher/knowbe4Phisher_test.py
+++ b/Packs/knowbe4Phisher/Integrations/knowbe4Phisher/knowbe4Phisher_test.py
@@ -317,6 +317,44 @@ def test_fetch_incidents_query_uses_window(mocker):
     assert "TO *" not in call_arg
 
 
+@freeze_time("2024-01-01T11:00:00Z")
+def test_test_module_returns_ok_when_no_messages(mocker):
+    """
+    Given:
+    - A valid connection to PhishER that returns zero messages
+
+    When:
+    - test-module is called (e.g. from XSOAR integration config)
+
+    Then:
+    - "ok" is returned — empty inbox is not a failure
+    """
+    mocker.patch.object(client, "phisher_gql_request", return_value=_gql_response([]))
+    mocker.patch("knowbe4Phisher.demisto").getLastRun.return_value = {}
+    mocker.patch.object(client, "max_fetch", 50)
+    result = phisher.test_module(client)
+    assert result == "ok"
+
+
+@freeze_time("2024-01-01T11:00:00Z")
+def test_test_module_returns_ok_when_messages_exist(mocker):
+    """
+    Given:
+    - A valid connection to PhishER that returns messages
+
+    When:
+    - test-module is called
+
+    Then:
+    - "ok" is returned
+    """
+    mocker.patch.object(client, "phisher_gql_request", return_value=_gql_response([MSG_A]))
+    mocker.patch("knowbe4Phisher.demisto").getLastRun.return_value = {}
+    mocker.patch.object(client, "max_fetch", 50)
+    result = phisher.test_module(client)
+    assert result == "ok"
+
+
 def test_time_creation():
     """
     Given:

--- a/Packs/knowbe4Phisher/Integrations/knowbe4Phisher/knowbe4Phisher_test.py
+++ b/Packs/knowbe4Phisher/Integrations/knowbe4Phisher/knowbe4Phisher_test.py
@@ -105,6 +105,7 @@ MSG_A = {
     "id": "msg-a",
     "phishmlReport": None,
     "pipelineStatus": "PROCESSED",
+    "reportedAt": "2024-01-01T09:59:55Z",
     "severity": "UNKNOWN_SEVERITY",
     "subject": "Message A",
     "tags": [],
@@ -121,6 +122,7 @@ MSG_B = {
     "id": "msg-b",
     "phishmlReport": None,
     "pipelineStatus": "PROCESSED",
+    "reportedAt": "2024-01-01T10:04:55Z",
     "severity": "UNKNOWN_SEVERITY",
     "subject": "Message B",
     "tags": [],
@@ -315,6 +317,27 @@ def test_fetch_incidents_query_uses_window(mocker):
     call_arg = spy.call_args[0][0]
     assert "reported_at:{2024-01-01T10:30:00Z TO 2024-01-01T11:00:00Z}" in call_arg
     assert "TO *" not in call_arg
+
+
+@freeze_time("2024-01-01T11:00:00Z")
+def test_fetch_incidents_cursor_uses_reported_at(mocker):
+    """
+    Given:
+    - A message with reportedAt earlier than its CREATED event createdAt
+
+    When:
+    - fetch_incidents is called
+
+    Then:
+    - created_at_cursor is set to reportedAt, not createdAt, keeping the
+      cursor coherent with the reported_at Lucene query field
+    """
+    last_run = {"time": "2024-01-01T09:00:00Z", "found_incident_ids": {}}
+    mocker.patch.object(client, "phisher_gql_request", return_value=_gql_response([MSG_A]))
+    next_run, incidents = phisher.fetch_incidents(client, last_run, "7 days", 50)
+    assert len(incidents) == 1
+    raw = json.loads(incidents[0]["rawJSON"])
+    assert raw["created_at_cursor"] == "2024-01-01T09:59:55Z"  # reportedAt, not createdAt (10:00:00Z)
 
 
 @freeze_time("2024-01-01T11:00:00Z")

--- a/Packs/knowbe4Phisher/Integrations/knowbe4Phisher/test_data/mock_tests.py
+++ b/Packs/knowbe4Phisher/Integrations/knowbe4Phisher/test_data/mock_tests.py
@@ -159,6 +159,7 @@ response_fetch = [
                             "id": "bac9cf67-fa8e-46d1-ad67-69513fc44b5b",
                             "phishmlReport": "null",
                             "pipelineStatus": "PROCESSED",
+                            "reportedAt": "2021-08-08T14:06:08Z",
                             "severity": "UNKNOWN_SEVERITY",
                             "subject": "Fwd: We have received your IT request",
                             "tags": [{"name": "KB4:SECURITY", "type": "STANDARD"}, {"name": "KB4:URGENCY", "type": "STANDARD"}],
@@ -179,9 +180,10 @@ expected_fetch = [
                 "name": "Fwd: We have received your IT request",
                 "occurred": "2021-08-08T14:06:11+00:00",
                 "rawJSON": '{"actionStatus": "RECEIVED", "category": "UNKNOWN", "comments": [], "from": "ek@gmail.com", \
-"id": "bac9cf67-fa8e-46d1-ad67-69513fc44b5b", "phishmlReport": "null", "pipelineStatus": "PROCESSED", "severity": \
+"id": "bac9cf67-fa8e-46d1-ad67-69513fc44b5b", "phishmlReport": "null", "pipelineStatus": "PROCESSED", \
+"reportedAt": "2021-08-08T14:06:08Z", "severity": \
 "UNKNOWN_SEVERITY", "subject": "Fwd: We have received your IT request", "tags": [{"name": "KB4:SECURITY", "type": \
-"STANDARD"}, {"name": "KB4:URGENCY", "type": "STANDARD"}], "created_at_cursor": "2021-08-08T14:06:11Z", \
+"STANDARD"}, {"name": "KB4:URGENCY", "type": "STANDARD"}], "created_at_cursor": "2021-08-08T14:06:08Z", \
 "created at": "2021-08-08T14:06:11+00:00"}',
             }
         ]

--- a/Packs/knowbe4Phisher/ReleaseNotes/1_0_21.md
+++ b/Packs/knowbe4Phisher/ReleaseNotes/1_0_21.md
@@ -1,0 +1,6 @@
+#### Integrations
+
+##### PhishER
+
+- Fixed an issue where the *test-module* command returned a failure status when no messages were available in the configured fetch window (EIR-16868).
+- Fixed an issue where the fetch cursor was set from the message CREATED event time instead of *reportedAt*, which could cause messages to be permanently missed when those values differed.

--- a/Packs/knowbe4Phisher/pack_metadata.json
+++ b/Packs/knowbe4Phisher/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "PhishER",
     "description": "A pack for KnowBe4 PhishER integration",
     "support": "partner",
-    "currentVersion": "1.0.20",
+    "currentVersion": "1.0.21",
     "author": "KnowBe4",
     "url": "https://www.knowbe4.com/products/phisher",
     "email": "support@knowbe4.com",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
EIR-16868

## Description
- Fixed an issue where the *test-module* command returned a failure status when no messages were available in the configured fetch window.
- Fixed an issue where the fetch cursor was set from the message CREATED event time instead of *reportedAt*, which could cause messages  to be permanently missed when those values differed.

## Must have
- [x] Tests
- [x] Documentation


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-17331