### PR TITLE
GoogleDriveStandardConnector: fix fetch params display (IN121)

### DIFF
--- a/Packs/GoogleDriveStandardConnector/Integrations/GoogleDriveStandardConnector/GoogleDriveStandardConnector.yml
+++ b/Packs/GoogleDriveStandardConnector/Integrations/GoogleDriveStandardConnector/GoogleDriveStandardConnector.yml
@@ -66,13 +66,13 @@ configuration:
   advanced: true
   additionalinfo: itemName or folderName for fetching the incident.
   required: false
-- display: Fetch incidents
+- display: Fetch alerts
   name: isFetch
   type: 8
   section: Collect
   required: false
 - name: incidentType
-  display: Incident type
+  display: Alert type
   type: 13
   required: false
   section: Collect

--- a/Packs/GoogleDriveStandardConnector/ReleaseNotes/1_0_2.md
+++ b/Packs/GoogleDriveStandardConnector/ReleaseNotes/1_0_2.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Google Drive (Standard Connector)
+
+- Fixed the fetch configuration parameters to use the correct alert terminology (**Fetch alerts** and **Alert type**).

--- a/Packs/GoogleDriveStandardConnector/pack_metadata.json
+++ b/Packs/GoogleDriveStandardConnector/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Google Drive (Standard Connector)",
     "description": "Satellite pack of Google Drive used for the Standard Connector deployment. Shares core logic with the Google Drive pack via the GoogleDriveApiModule.",
     "support": "xsoar",
-    "currentVersion": "1.0.0",
+    "currentVersion": "1.0.2",
     "serverMinVersion": "8.15.0",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
## Summary
Fixes the `IN121` validation error on the GoogleDriveStandardConnector fetch integration.

Since this is a `platform` fetch integration, the fetch configuration parameters must use *alert* terminology:
- `isFetch` display: `Fetch incidents` -> `Fetch alerts`
- `incidentType` display: `Incident type` -> `Alert type`

## Changes
- Updated the two fetch params in `GoogleDriveStandardConnector.yml`.
- Bumped the pack to version 1.0.2 and added release notes.

## Testing
- `demisto-sdk validate -g` -> All validations passed.