### PR TITLE
CommonScripts/DisplayMappedFields - Fix Multi-Value Item Parsing

### DIFF
--- a/Packs/CommonScripts/ReleaseNotes/1_22_37.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_22_37.md
@@ -4,3 +4,4 @@
 ##### displayMappedFields
 
 - Fixed an issue where some multi-select fields were rendered empty in the **Mapped Fields** section.
+- Updated the Docker image to: *demisto/python3:3.12.13.10404775*.

--- a/Packs/CommonScripts/ReleaseNotes/1_22_37.md
+++ b/Packs/CommonScripts/ReleaseNotes/1_22_37.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### displayMappedFields
+
+- Fixed an issue where some multi-select fields were rendered empty in the **Mapped Fields** section.

--- a/Packs/CommonScripts/Scripts/diplayMappedFields/diplayMappedFields.py
+++ b/Packs/CommonScripts/Scripts/diplayMappedFields/diplayMappedFields.py
@@ -32,20 +32,22 @@ def extract_keys_with_values(obj, parent_key=""):
 
 def escape_for_html_table(value):
     """Escape value for safe insertion into HTML table cells."""
-    escaped = html_module.escape(str(value))
-    return escaped.replace("|", "&#124;")
+    return html_module.escape(str(value))
 
 
 def format_data_to_rows(items):
     """
-    Formats the extracted data into rows and escapes pipes.
+    Formats the extracted data into (key, value) rows.
+
+    Each row is kept as a tuple rather than a pipe-delimited string so that values
+    that themselves contain the pipe character are never split into extra table columns.
     """
     rows = []
     for key, value in items:
         if isinstance(value, list):
-            # If the value is a list, join the items with a separator and escape the result
-            value = "|".join(map(str, value))
-        rows.append(f"{escape_for_html_table(key)}|{escape_for_html_table(str(value))}")
+            # If the value is a list, join the items with a comma for display
+            value = ", ".join(map(str, value))
+        rows.append((str(key), str(value)))
     return rows
 
 
@@ -53,21 +55,20 @@ def convert_to_html(rows):
     html = [
         """<table style="border-collapse:collapse;"><tbody style="font-family:Lato,Assistant,sans-serif;font-weight:600;font-size:12px;text-align:left;padding: 1px 0px 0px;margin:0px 5px 0px 0px;contrast:4.95">"""  # noqa: E501
     ]  # noqa: E501
-    for row in rows:
+    for key, value in rows:
         html.append("<tr>")
-        columns = row.split("|")
-        for i, column in enumerate(map(str.strip, columns)):
+        for i, column in enumerate((key.strip(), value.strip())):
             if column:
                 style = "color:var(--xdr-on-background-secondary)" if i == 0 else "color:var(--xdr-on-background)"
-                html.append(f'<td style="{style}">{column}</td>')
+                html.append(f'<td style="{style}">{escape_for_html_table(column)}</td>')
         html.append("</tr>")
     html.append("</tbody></table>")
     return "".join(html)
 
 
 def remove_empty_rows(rows):
-    # Filter out the rows that contain empty dictionaries
-    return [row for row in rows if not any(empty_value in row for empty_value in EMPTY_VALUES)]
+    # Filter out rows whose value is exactly an empty marker (not merely containing one)
+    return [(key, value) for key, value in rows if value.strip() not in EMPTY_VALUES]
 
 
 def main():

--- a/Packs/CommonScripts/Scripts/diplayMappedFields/diplayMappedFields.yml
+++ b/Packs/CommonScripts/Scripts/diplayMappedFields/diplayMappedFields.yml
@@ -10,7 +10,7 @@ tags:
 enabled: true
 scripttarget: 0
 subtype: python3
-dockerimage: demisto/python3:3.12.13.8428455
+dockerimage: demisto/python3:3.12.13.10404775
 runas: DBotWeakRole
 fromversion: 6.8.0
 tests:

--- a/Packs/CommonScripts/Scripts/diplayMappedFields/diplayMappedFields_test.py
+++ b/Packs/CommonScripts/Scripts/diplayMappedFields/diplayMappedFields_test.py
@@ -12,7 +12,7 @@ MULTISELECT_JSON_VALUE = (
 )
 
 
-def test_extract_keys_with_values_keeps_list_values():
+def test_extract_keys_with_values_keeps_list_values() -> None:
     """A multiSelect field value (a list) must be preserved as a list, not flattened away."""
     fields = {"additionaldata": [MULTISELECT_JSON_VALUE]}
 
@@ -21,7 +21,7 @@ def test_extract_keys_with_values_keeps_list_values():
     assert ("additionaldata", [MULTISELECT_JSON_VALUE]) in items
 
 
-def test_multiselect_value_survives_to_html():
+def test_multiselect_value_survives_to_html() -> None:
     """
     A multiSelect field (additionaldata/rawevent) whose value contains empty
     objects/arrays must still be rendered in the Mapped Fields HTML.
@@ -42,7 +42,7 @@ def test_multiselect_value_survives_to_html():
     assert "suspicious" in html
 
 
-def test_value_containing_pipe_is_not_split_into_extra_columns():
+def test_value_containing_pipe_is_not_split_into_extra_columns() -> None:
     """
     A field value that literally contains a pipe character must not be broken into
     extra table columns (delimiter collision).
@@ -61,7 +61,7 @@ def test_value_containing_pipe_is_not_split_into_extra_columns():
     assert ">a|b|c</td>" in html
 
 
-def test_multiselect_list_with_multiple_items_renders_all_items():
+def test_multiselect_list_with_multiple_items_renders_all_items() -> None:
     """A multiSelect list holding several plain values renders all of them joined."""
     fields = {"labels": ["alpha", "beta", "gamma"]}
 
@@ -77,7 +77,7 @@ def test_multiselect_list_with_multiple_items_renders_all_items():
     assert html.count("<td") == 2
 
 
-def test_genuinely_empty_values_are_removed():
+def test_genuinely_empty_values_are_removed() -> None:
     """Rows that are genuinely empty ("{}", "[{}]") must still be filtered out."""
     fields = {
         "emptyobj": "{}",
@@ -96,7 +96,7 @@ def test_genuinely_empty_values_are_removed():
     assert "emptylist" not in html
 
 
-def test_key_containing_empty_marker_substring_is_not_dropped():
+def test_key_containing_empty_marker_substring_is_not_dropped() -> None:
     """
     A field whose value merely CONTAINS an empty marker as a substring (e.g. a JSON
     payload with a nested "{}") must NOT be dropped. This is the core regression.

--- a/Packs/CommonScripts/Scripts/diplayMappedFields/diplayMappedFields_test.py
+++ b/Packs/CommonScripts/Scripts/diplayMappedFields/diplayMappedFields_test.py
@@ -1,0 +1,116 @@
+import pytest
+
+from diplayMappedFields import (
+    convert_to_html,
+    extract_keys_with_values,
+    format_data_to_rows,
+    remove_empty_rows,
+)
+
+MULTISELECT_JSON_VALUE = (
+    '{"process_evidence":[{"verdict":"suspicious","tags":[],' '"userAccount":{"resourceAccessEvents":[]}}],"custom_details":{}}'
+)
+
+
+def test_extract_keys_with_values_keeps_list_values():
+    """A multiSelect field value (a list) must be preserved as a list, not flattened away."""
+    fields = {"additionaldata": [MULTISELECT_JSON_VALUE]}
+
+    items = extract_keys_with_values(fields)
+
+    assert ("additionaldata", [MULTISELECT_JSON_VALUE]) in items
+
+
+def test_multiselect_value_survives_to_html():
+    """
+    A multiSelect field (additionaldata/rawevent) whose value contains empty
+    objects/arrays must still be rendered in the Mapped Fields HTML.
+
+    Previously the row was dropped/corrupted because the value was flattened into a
+    pipe-delimited row string that (a) was substring-matched against EMPTY_VALUES
+    (dropping any row containing "{}") and (b) was re-split on "|".
+    """
+    fields = {"additionaldata": [MULTISELECT_JSON_VALUE]}
+
+    items = extract_keys_with_values(fields)
+    rows = format_data_to_rows(items)
+    filtered_rows = remove_empty_rows(rows)
+    html = convert_to_html(filtered_rows)
+
+    assert "additionaldata" in html
+    assert "process_evidence" in html
+    assert "suspicious" in html
+
+
+def test_value_containing_pipe_is_not_split_into_extra_columns():
+    """
+    A field value that literally contains a pipe character must not be broken into
+    extra table columns (delimiter collision).
+    """
+    fields = {"somefield": "a|b|c"}
+
+    items = extract_keys_with_values(fields)
+    rows = format_data_to_rows(items)
+    filtered_rows = remove_empty_rows(rows)
+    html = convert_to_html(filtered_rows)
+
+    # Exactly one key cell and one value cell -> two <td> elements
+    assert html.count("<td") == 2
+    assert "somefield" in html
+    # The full literal value (including the pipes) must be preserved intact inside a single cell
+    assert ">a|b|c</td>" in html
+
+
+def test_multiselect_list_with_multiple_items_renders_all_items():
+    """A multiSelect list holding several plain values renders all of them joined."""
+    fields = {"labels": ["alpha", "beta", "gamma"]}
+
+    items = extract_keys_with_values(fields)
+    rows = format_data_to_rows(items)
+    filtered_rows = remove_empty_rows(rows)
+    html = convert_to_html(filtered_rows)
+
+    assert "labels" in html
+    for expected in ("alpha", "beta", "gamma"):
+        assert expected in html
+    # Still exactly one key + one value cell
+    assert html.count("<td") == 2
+
+
+def test_genuinely_empty_values_are_removed():
+    """Rows that are genuinely empty ("{}", "[{}]") must still be filtered out."""
+    fields = {
+        "emptyobj": "{}",
+        "emptylist": "[{}]",
+        "realfield": "hello",
+    }
+
+    items = extract_keys_with_values(fields)
+    rows = format_data_to_rows(items)
+    filtered_rows = remove_empty_rows(rows)
+    html = convert_to_html(filtered_rows)
+
+    assert "realfield" in html
+    assert "hello" in html
+    assert "emptyobj" not in html
+    assert "emptylist" not in html
+
+
+def test_key_containing_empty_marker_substring_is_not_dropped():
+    """
+    A field whose value merely CONTAINS an empty marker as a substring (e.g. a JSON
+    payload with a nested "{}") must NOT be dropped. This is the core regression.
+    """
+    fields = {"payload": '{"a":1,"nested":{}}'}
+
+    items = extract_keys_with_values(fields)
+    rows = format_data_to_rows(items)
+    filtered_rows = remove_empty_rows(rows)
+    html = convert_to_html(filtered_rows)
+
+    assert "payload" in html
+    assert "nested" in html
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/Packs/CommonScripts/pack_metadata.json
+++ b/Packs/CommonScripts/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Common Scripts",
     "description": "Frequently used scripts pack.",
     "support": "xsoar",
-    "currentVersion": "1.22.36",
+    "currentVersion": "1.22.37",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Related Issues
fixes: [XSUP-65229](https://jira-dc.paloaltonetworks.com/browse/XSUP-65229)

## Description
Fix an issue where some multi-select fields were rendered empty in the **Mapped Fields** section.