### PR TITLE
CRTX-264887 - map OpenAI auth_target for login events

### DIFF
--- a/Packs/OpenAI/ModelingRules/OpenAIModelingRules/OpenAIModelingRules.xif
+++ b/Packs/OpenAI/ModelingRules/OpenAIModelingRules/OpenAIModelingRules.xif
@@ -78,6 +78,7 @@ alter
         type = "organization.updated",    json_extract_scalar(organization_updated, "$.id"),
         null),
     xdm.target.resource.name = if(
+        type in ("login.succeeded", "login.failed", "logout.succeeded", "logout.failed"), "OpenAI API Platform",
         type not in ("certificate.created", "certificate.updated", "certificate.deleted",
             "ip_allowlist.created", "ip_allowlist.deleted",
             "role.created", "role.updated", "group.created", "group.updated",

--- a/Packs/OpenAI/ReleaseNotes/2_1_3.md
+++ b/Packs/OpenAI/ReleaseNotes/2_1_3.md
@@ -1,0 +1,6 @@
+#### Modeling Rules
+
+##### OpenAI Modeling Rule
+
+Fixed an issue where *xdm.target.resource.name* was not mapped for authentication events (login/logout) in the *openai_admin_audit_raw* dataset, leaving *auth_target* empty in the Authentication Story. Mapped *xdm.target.resource.name* to *OpenAI API Platform* for the *login.succeeded*, *login.failed*, *logout.succeeded*, and *logout.failed* events.
+<~XSIAM> (Available from Cortex XSIAM 2.1.0).</~XSIAM>

--- a/Packs/OpenAI/pack_metadata.json
+++ b/Packs/OpenAI/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "OpenAI",
     "description": "The OpenAI API can be applied to virtually any task that involves understanding or generating natural language or code.",
     "support": "xsoar",
-    "currentVersion": "2.1.2",
+    "currentVersion": "2.1.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CRTX-264887

## Description
Fixed an issue where OpenAI API Platform authentication events (login/logout) in the `openai_admin_audit_raw` dataset were not populating `auth_target` in the Authentication Story (event_type 102). `xdm.target.resource.name` was only mapped for admin/audit event types; login/logout fell through to the `null` branch.

Mapped `xdm.target.resource.name` to `"OpenAI API Platform"` for `login.succeeded`, `login.failed`, `logout.succeeded`, and `logout.failed`. Verified on tenant xdr-us-467572787 that these events reach `edr_data` event_type=102 with all mandatory auth fields populated but `auth_target` empty; this change makes `auth_target` populate so auth_target-scoped queries and detections match.

Bumped OpenAI pack to 2.1.3 with release note.