### PR TITLE
LDAP Authentication - Fix trailling and leading spaces

### DIFF
--- a/Packs/OpenLDAP/Integrations/OpenLDAP/OpenLDAP.py
+++ b/Packs/OpenLDAP/Integrations/OpenLDAP/OpenLDAP.py
@@ -522,7 +522,7 @@ class LdapClient:
         and returns the Active Directory username.
 
         Surrounding whitespace is stripped to avoid creating duplicate users when a username is
-        entered with a leading/trailing space (XSUP-73382).
+        entered with a leading/trailing space.
         """
         logon_name = logon_name.strip()
         ad_username = logon_name

--- a/Packs/OpenLDAP/Integrations/OpenLDAP/OpenLDAP.py
+++ b/Packs/OpenLDAP/Integrations/OpenLDAP/OpenLDAP.py
@@ -520,7 +520,11 @@ class LdapClient:
         """
         Gets a User logon name (the username that is used for log in to XSOAR)
         and returns the Active Directory username.
+
+        Surrounding whitespace is stripped to avoid creating duplicate users when a username is
+        entered with a leading/trailing space (XSUP-73382).
         """
+        logon_name = logon_name.strip()
         ad_username = logon_name
         if "\\" in logon_name:
             ad_username = logon_name.split("\\")[1]

--- a/Packs/OpenLDAP/Integrations/OpenLDAP/OpenLDAP.yml
+++ b/Packs/OpenLDAP/Integrations/OpenLDAP/OpenLDAP.yml
@@ -236,7 +236,7 @@ script:
       defaultValue: 50
     description: A generic LDAP search command.
     name: ad-entries-search
-  dockerimage: demisto/py3-tools:1.0.0.114656
+  dockerimage: demisto/py3-tools:1.0.0.10895515
   runonce: false
   script: '-'
   subtype: python3

--- a/Packs/OpenLDAP/Integrations/OpenLDAP/OpenLDAP_test.py
+++ b/Packs/OpenLDAP/Integrations/OpenLDAP/OpenLDAP_test.py
@@ -157,16 +157,23 @@ class TestsActiveDirectory:
         [
             ("DEMISTO\\test1user", "test1user"),
             ("test2user@demisto.ad", "test2user"),
+            ("mertuz ", "mertuz"),
+            (" mertuz", "mertuz"),
+            ("  mertuz  ", "mertuz"),
+            ("DEMISTO\\test1user ", "test1user"),
+            (" DEMISTO\\test1user", "test1user"),
+            ("test2user@demisto.ad ", "test2user"),
+            (" test2user@demisto.ad", "test2user"),
         ],
     )
     def test_get_ad_username(self, user_logon_name, expected_ad_username):
         """
         Given:
-            - A user logon name (a username to login to XSOAR with).
+            - A user logon name (a username to login to XSOAR with), possibly with surrounding whitespace.
         When:
             - Running the 'get_ad_username()' function.
         Then:
-            - Verify that the returned Active Directory username is as expected.
+            - Verify that the returned Active Directory username is as expected and free of surrounding whitespace.
         """
         client = LdapClient({"ldap_server_vendor": "Active Directory", "host": "server_ip"})
 

--- a/Packs/OpenLDAP/ReleaseNotes/2_0_22.md
+++ b/Packs/OpenLDAP/ReleaseNotes/2_0_22.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### LDAP Authentication
+
+- Fixed an issue where an Active Directory user logging in with a leading or trailing whitespace in the username caused a duplicate user to be created.

--- a/Packs/OpenLDAP/ReleaseNotes/2_0_22.md
+++ b/Packs/OpenLDAP/ReleaseNotes/2_0_22.md
@@ -4,3 +4,4 @@
 ##### LDAP Authentication
 
 - Fixed an issue where an Active Directory user logging in with a leading or trailing whitespace in the username caused a duplicate user to be created.
+- Updated the Docker image to: *demisto/py3-tools:1.0.0.10895515*.

--- a/Packs/OpenLDAP/pack_metadata.json
+++ b/Packs/OpenLDAP/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "LDAP Authentication",
     "description": "Authenticate using Open LDAP or Active Directory",
     "support": "xsoar",
-    "currentVersion": "2.0.21",
+    "currentVersion": "2.0.22",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Related Issues
fixes: [XSUP-73382](https://jira-dc.paloaltonetworks.com/browse/XSUP-73382)

## Description
Fix an issue where an Active Directory user logging in with a leading or trailing whitespace in the username caused a duplicate user to be created.
