### PR TITLE
Add CVE and subscribed CVE list commands to ThreatMon

### DIFF
--- a/Packs/ThreatMon/Integrations/ThreatMon/README.md
+++ b/Packs/ThreatMon/Integrations/ThreatMon/README.md
@@ -53,6 +53,8 @@ This integration is designed to help security teams streamline incident enrichme
 | `fetch-incidents` | Retrieves threat intelligence data for a specified indicator or time range. |
 | `threatmon_update_incident_status` | Updates the current incident with contextual threat intelligence. |
 | `threatmon_request_takedown` | Submits a takedown request for a specific Threatmon finding. Eligible finding types include Phishing Domain Detected, Rogue Mobile App Detected, Fake SM Account Detected, and similar alarm types. |
+| `threatmon_list_cves` | Retrieves a paginated list of all CVEs monitored by ThreatMon. |
+| `threatmon_list_subscribed_cves` | Retrieves a paginated list of CVEs affecting products that the authenticated company (or a specified child customer) is actively subscribed to. |
 
 > **Note:** Full command usage details and argument structures are available within the integration settings in XSOAR.
 

--- a/Packs/ThreatMon/Integrations/ThreatMon/ThreatMon.py
+++ b/Packs/ThreatMon/Integrations/ThreatMon/ThreatMon.py
@@ -42,6 +42,26 @@ class Client(BaseClient):
             resp_type="response",
         )
 
+    def get_cve_list(self, page: int = 0, cvss: str | None = None):
+        """Fetches a paginated list of all CVEs monitored by ThreatMon."""
+
+        params = {}
+        if cvss:
+            params["cvss"] = cvss
+
+        return self._http_request(method="GET", url_suffix=f"/cve/{page}", params=params)
+
+    def get_subscribed_cve_list(self, page: int = 0, cvss: str | None = None, customer_name: str | None = None):
+        """Fetches a paginated list of CVEs affecting products the company is subscribed to."""
+
+        params = {}
+        if cvss:
+            params["cvss"] = cvss
+        if customer_name:
+            params["customerName"] = customer_name
+
+        return self._http_request(method="GET", url_suffix=f"/cve/subscribed/{page}", params=params)
+
 
 def convert_to_demisto_severity(severity: str) -> int:
     """Maps Threatmon severity to Cortex XSOAR/XSIAM severity (1 to 4)."""
@@ -212,6 +232,79 @@ def request_takedown_command(client: Client, args: dict[str, Any]) -> CommandRes
         raise DemistoException(f"API Error: {status_code} - {response.text}")
 
 
+def format_cve_vendors(vendors: dict[str, list[str]]) -> str:
+    """Formats a vendor-to-products map into a human-readable string for the markdown table."""
+
+    if not vendors:
+        return ""
+    return "; ".join(f"{vendor}: {', '.join(products)}" for vendor, products in vendors.items())
+
+
+def build_cve_command_results(response: dict[str, Any], readable_title: str) -> CommandResults:
+    """Builds CommandResults for a page of CVE records returned by the ThreatMon CVE endpoints."""
+
+    records = response.get("data") or []
+    total_records = response.get("totalRecords", 0)
+
+    markdown_rows = []
+    for record in records:
+        row = dict(record)
+        row["vendors"] = format_cve_vendors(record.get("vendors") or {})
+        markdown_rows.append(row)
+
+    headers = [
+        "cve",
+        "summary",
+        "cvssV2",
+        "severityV2",
+        "cvssV3",
+        "severityV3",
+        "cvssV3_1",
+        "severityV3_1",
+        "cvssV4",
+        "severityV4",
+        "vendors",
+        "exploit",
+        "knownRansomwareCampaignUse",
+        "zeroday",
+        "createdAt",
+        "updatedAt",
+    ]
+    title = f"{readable_title} (Total Records: {total_records})"
+    readable_output = tableToMarkdown(
+        title,
+        markdown_rows,
+        headers=headers,
+        headerTransform=string_to_table_header,
+        removeNull=True,
+    )
+
+    return CommandResults(
+        outputs_prefix="ThreatMon.CVE",
+        outputs_key_field="cve",
+        outputs=records,
+        readable_output=readable_output,
+        raw_response=response,
+    )
+
+
+def list_cves_command(client: Client, args: dict[str, Any]) -> CommandResults:
+    page = arg_to_number(args.get("page")) or 0
+    cvss = args.get("cvss")
+
+    response = client.get_cve_list(page=page, cvss=cvss)
+    return build_cve_command_results(response, "ThreatMon CVE List")
+
+
+def list_subscribed_cves_command(client: Client, args: dict[str, Any]) -> CommandResults:
+    page = arg_to_number(args.get("page")) or 0
+    cvss = args.get("cvss")
+    customer_name = args.get("customer_name")
+
+    response = client.get_subscribed_cve_list(page=page, cvss=cvss, customer_name=customer_name)
+    return build_cve_command_results(response, "ThreatMon Subscribed CVE List")
+
+
 def main():
     """Main function called by Cortex XSOAR/XSIAM."""
     try:
@@ -231,6 +324,10 @@ def main():
             return_results(change_incident_status(client, demisto.args()))
         elif command == "threatmon_request_takedown":
             return_results(request_takedown_command(client, demisto.args()))
+        elif command == "threatmon_list_cves":
+            return_results(list_cves_command(client, demisto.args()))
+        elif command == "threatmon_list_subscribed_cves":
+            return_results(list_subscribed_cves_command(client, demisto.args()))
         elif command == "fetch-incidents":
             last_run = demisto.getLastRun() or {}
             incidents, last_run = fetch_incidents(client, last_run)

--- a/Packs/ThreatMon/Integrations/ThreatMon/ThreatMon.yml
+++ b/Packs/ThreatMon/Integrations/ThreatMon/ThreatMon.yml
@@ -93,6 +93,136 @@ script:
       required: true
       description: Description of the finding that justifies the takedown request.
     description: Submits a takedown request for a specific Threatmon finding. Eligible finding types include Phishing Domain Detected, Rogue Mobile App Detected, Fake SM Account Detected, and similar alarm types.
+  - name: threatmon_list_cves
+    arguments:
+    - name: page
+      description: Page number to retrieve (0-based). Each page contains up to 100 CVEs, sorted by last update time (descending).
+      defaultValue: "0"
+    - name: cvss
+      description: Filter CVEs by CVSS v3 severity.
+      auto: PREDEFINED
+      predefined:
+      - NONE
+      - LOW
+      - MEDIUM
+      - HIGH
+      - CRITICAL
+    outputs:
+    - contextPath: ThreatMon.CVE.cve
+      description: CVE identifier.
+      type: String
+    - contextPath: ThreatMon.CVE.summary
+      description: CVE summary.
+      type: String
+    - contextPath: ThreatMon.CVE.cvssV2
+      description: CVSS v2 score.
+      type: Number
+    - contextPath: ThreatMon.CVE.severityV2
+      description: CVSS v2 severity level.
+      type: String
+    - contextPath: ThreatMon.CVE.cvssV3
+      description: CVSS v3 score.
+      type: Number
+    - contextPath: ThreatMon.CVE.severityV3
+      description: CVSS v3 severity level.
+      type: String
+    - contextPath: ThreatMon.CVE.cvssV3_1
+      description: CVSS v3.1 score.
+      type: Number
+    - contextPath: ThreatMon.CVE.severityV3_1
+      description: CVSS v3.1 severity level.
+      type: String
+    - contextPath: ThreatMon.CVE.cvssV4
+      description: CVSS v4 score.
+      type: Number
+    - contextPath: ThreatMon.CVE.severityV4
+      description: CVSS v4 severity level.
+      type: String
+    - contextPath: ThreatMon.CVE.vendors
+      description: Map of vendor names to affected product names.
+      type: Unknown
+    - contextPath: ThreatMon.CVE.exploit
+      description: Whether a known exploit exists for this CVE.
+      type: Boolean
+    - contextPath: ThreatMon.CVE.knownRansomwareCampaignUse
+      description: Known ransomware campaign associated with this CVE, if any.
+      type: String
+    - contextPath: ThreatMon.CVE.zeroday
+      description: Whether this CVE was disclosed as a zero-day.
+      type: Boolean
+    - contextPath: ThreatMon.CVE.createdAt
+      description: Date the CVE record was created in ThreatMon.
+      type: Date
+    - contextPath: ThreatMon.CVE.updatedAt
+      description: Date the CVE record was last updated in ThreatMon.
+      type: Date
+    description: Retrieves a paginated list of all CVEs monitored by ThreatMon.
+  - name: threatmon_list_subscribed_cves
+    arguments:
+    - name: page
+      description: Page number to retrieve (0-based). Each page contains up to 100 CVEs, sorted by last update time (descending).
+      defaultValue: "0"
+    - name: cvss
+      description: Filter CVEs by CVSS v3 severity.
+      auto: PREDEFINED
+      predefined:
+      - NONE
+      - LOW
+      - MEDIUM
+      - HIGH
+      - CRITICAL
+    - name: customer_name
+      description: For MSSP accounts, retrieves subscribed CVEs on behalf of the specified child customer instead of the authenticated company.
+    outputs:
+    - contextPath: ThreatMon.CVE.cve
+      description: CVE identifier.
+      type: String
+    - contextPath: ThreatMon.CVE.summary
+      description: CVE summary.
+      type: String
+    - contextPath: ThreatMon.CVE.cvssV2
+      description: CVSS v2 score.
+      type: Number
+    - contextPath: ThreatMon.CVE.severityV2
+      description: CVSS v2 severity level.
+      type: String
+    - contextPath: ThreatMon.CVE.cvssV3
+      description: CVSS v3 score.
+      type: Number
+    - contextPath: ThreatMon.CVE.severityV3
+      description: CVSS v3 severity level.
+      type: String
+    - contextPath: ThreatMon.CVE.cvssV3_1
+      description: CVSS v3.1 score.
+      type: Number
+    - contextPath: ThreatMon.CVE.severityV3_1
+      description: CVSS v3.1 severity level.
+      type: String
+    - contextPath: ThreatMon.CVE.cvssV4
+      description: CVSS v4 score.
+      type: Number
+    - contextPath: ThreatMon.CVE.severityV4
+      description: CVSS v4 severity level.
+      type: String
+    - contextPath: ThreatMon.CVE.vendors
+      description: Map of vendor names to affected product names.
+      type: Unknown
+    - contextPath: ThreatMon.CVE.exploit
+      description: Whether a known exploit exists for this CVE.
+      type: Boolean
+    - contextPath: ThreatMon.CVE.knownRansomwareCampaignUse
+      description: Known ransomware campaign associated with this CVE, if any.
+      type: String
+    - contextPath: ThreatMon.CVE.zeroday
+      description: Whether this CVE was disclosed as a zero-day.
+      type: Boolean
+    - contextPath: ThreatMon.CVE.createdAt
+      description: Date the CVE record was created in ThreatMon.
+      type: Date
+    - contextPath: ThreatMon.CVE.updatedAt
+      description: Date the CVE record was last updated in ThreatMon.
+      type: Date
+    description: Retrieves a paginated list of CVEs affecting products that the authenticated company (or a specified child customer) is actively subscribed to.
   isfetch: true
   dockerimage: demisto/python3:3.12.13.7444307
 fromversion: 5.0.0

--- a/Packs/ThreatMon/ReleaseNotes/1_0_4.md
+++ b/Packs/ThreatMon/ReleaseNotes/1_0_4.md
@@ -1,0 +1,7 @@
+
+#### Integrations
+
+##### Threatmon
+
+- Added the **threatmon_list_cves** command to retrieve a paginated list of all CVEs monitored by ThreatMon, including CVSS v2, v3, v3.1, and v4 scores and severities.
+- Added the **threatmon_list_subscribed_cves** command to retrieve a paginated list of CVEs affecting products the authenticated company is subscribed to.

--- a/Packs/ThreatMon/pack_metadata.json
+++ b/Packs/ThreatMon/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ThreatMon",
     "description": "This integration pulls data from the ThreatMon API and updates XSOAR incidents. You can also update the status of your Incedents in the ThreatMon dashboard from the XSOAR interface with this integration.",
     "support": "community",
-    "currentVersion": "1.0.3",
+    "currentVersion": "1.0.4",
     "author": "ThreatMon",
     "url": "https://www.threatmon.io",
     "email": "integration@threatmonit.io",


### PR DESCRIPTION
## Summary
- Add `threatmon_list_cves` command, integrating the `/cve/{page}` endpoint to retrieve a paginated list of all CVEs monitored by ThreatMon.
- Add `threatmon_list_subscribed_cves` command, integrating the `/cve/subscribed/{page}` endpoint to retrieve CVEs affecting products the authenticated company (or a specified child customer) is subscribed to.
- Both commands support optional CVSS v3 severity filtering and expose CVSS v2/v3/v3.1/v4 scores and severities, vendor/product mapping, exploit and known-ransomware-campaign flags, and zero-day status in the `ThreatMon.CVE` context path.
- Bumped pack version to 1.0.4 with corresponding release notes.

## Test plan
- [x] `demisto-sdk validate -i Packs/ThreatMon` passes.
- [x] `demisto-sdk lint -i Packs/ThreatMon/Integrations/ThreatMon` passes (Flake8, XSOAR Linter, Bandit, Pylint, Vulture).


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-17454