### PR TITLE
`ruff`: drop deprecated `UP038` rule check

### DIFF
--- a/Packs/RubrikPolaris/Integrations/RubrikPolaris/RubrikPolaris.py
+++ b/Packs/RubrikPolaris/Integrations/RubrikPolaris/RubrikPolaris.py
@@ -4950,11 +4950,11 @@ def remove_typename(data: Union[dict, list]) -> Union[dict, list]:
         if "__typename" in data:
             data.pop("__typename")
         for key, value in data.items():
-            if isinstance(value, (dict, list)):  # noqa: UP038
+            if isinstance(value, (dict, list)):
                 data[key] = remove_typename(value)
     elif isinstance(data, list):
         for index, value in enumerate(data):
-            if isinstance(value, (dict, list)):  # noqa: UP038
+            if isinstance(value, (dict, list)):
                 data[index] = remove_typename(value)
     return data
 

--- a/nightly_ruff.toml
+++ b/nightly_ruff.toml
@@ -257,7 +257,6 @@ lint.select = [
     "UP035", # deprecated-import
     "UP036", # outdated-version-block
     "UP037", # quoted-annotation
-    "UP038", # non-pep604-isinstance
 
     "W291", # trailing-whitespace
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -359,7 +359,6 @@ select = [
     "UP035", # deprecated-import
     "UP036", # outdated-version-block
     "UP037", # quoted-annotation
-    "UP038", # non-pep604-isinstance
 
     "W291", # trailing-whitespace
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)


## Description

Same reasoning as https://github.com/demisto/content/pull/43981:
- `UP038` was deprecated since March 2025 https://astral.sh/blog/ruff-v0.10.0#rule-deprecations and removed in September 2025 https://astral.sh/blog/ruff-v0.13.0#rule-removals
- this repo is still using older ruff version `0.8.0`, but this change will help prepare to version bump in the future

https://github.com/demisto/content/blob/6f9070a60313e3b0f384eb44dc345f4d75f1b0f8/.pre-commit-config_template.yaml#L38

- this repo used to be part of `ruff-ecosystem` check - basically comparing differences before and after changes in ruff on the real code to see what effect they have on Python ecosystem. It was commented out a while a go because removed `E999` rule was used - this rule no longer an issue, but `UP038` is a new blocker.

https://github.com/astral-sh/ruff/blob/34d0944f3b1d0ce51db6a583e17faeb933df9be6/python/ruff-ecosystem/ruff_ecosystem/defaults.py#L44-L52

```python
    # Disabled due to use of explicit `select` with `E999`, which has been removed.
    # See: https://github.com/astral-sh/ruff/pull/12129
    # Project(
    #     repo=Repository(owner="demisto", name="content", ref="master"),
    #     format_options=FormatOptions(
    #         # Syntax errors in this file
    #         exclude="Packs/ThreatQ/Integrations/ThreatQ/ThreatQ.py"
    #     ),
    # ),
```


## Must have
- [ ] Tests
- [ ] Documentation


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-17453