### PR TITLE
Fix ES fetch-incidents parsing error when fields to fetch left empty

### DIFF
--- a/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2.py
+++ b/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2.py
@@ -1384,6 +1384,27 @@ def execute_raw_query(es, raw_query, index=None, size=None, page=None):
     return response
 
 
+def build_fetch_extra_params(fields_list: list) -> dict:
+    """Builds the extra request-body parameters for the fetch Search request.
+
+    The "Fields to Fetch" parameter is optional. When it is left blank,
+    ``fields_list`` is an empty list and the "fields" key must be omitted from the
+    request body entirely. Sending ``"fields": []`` causes Elasticsearch to fail with:
+    ``ParsingException 400 'Unknown key for a START_ARRAY in [fields]'``.
+
+    Args:
+        fields_list (list): The list of fields to fetch (may be empty).
+
+    Returns:
+        dict: The kwargs to pass to ``Search.extra``. Always requests ``_source``,
+            and includes ``fields`` only when ``fields_list`` is non-empty.
+    """
+    extra_params: dict = {"_source": True}
+    if fields_list:
+        extra_params["fields"] = fields_list
+    return extra_params
+
+
 def fetch_incidents(proxies):
     last_run = demisto.getLastRun()
     last_fetch = last_run.get("time") or FETCH_TIME
@@ -1401,7 +1422,10 @@ def fetch_incidents(proxies):
         # Elastic search can use epoch timestamps (in milliseconds) as date representation regardless of date format.
         search = Search(using=es, index=FETCH_INDEX).filter(time_range_dict)
         search = search.sort({TIME_FIELD: {"order": "asc"}})[0:FETCH_SIZE].query(query)
-        search = search.extra(fields=FIELDS_LIST, _source=True)
+        # Only add the "fields" key to the request body when there are fields to fetch.
+        # Passing an empty list results in "fields": [] in the body, which Elasticsearch
+        # rejects with: ParsingException 400 'Unknown key for a START_ARRAY in [fields]'.
+        search = search.extra(**build_fetch_extra_params(FIELDS_LIST))
 
         if ELASTIC_SEARCH_CLIENT in [ELASTICSEARCH_V9, ELASTICSEARCH_V8, OPEN_SEARCH]:
             response = search.execute().to_dict()

--- a/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2.yml
+++ b/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2.yml
@@ -151,11 +151,25 @@ configuration:
   type: 13
   section: Connect
   required: false
+  supportedModules:
+  - xsiam
+  - agentix
 - display: Fetch incidents
   name: isFetch
   type: 8
   section: Collect
   required: false
+  supportedModules:
+  - xsiam
+  - agentix
+- display: Incidents Fetch Interval
+  name: incidentFetchInterval
+  type: 19
+  section: Collect
+  required: false
+  supportedModules:
+  - xsiam
+  - agentix
 - display: Space ID
   name: space_id
   type: 0
@@ -2230,7 +2244,7 @@ script:
     - contextPath: Elasticsearch.Kibana.ValueListItem.created_at
       description: The creation date of the value list item.
       type: Date
-  dockerimage: demisto/elasticsearch:1.0.0.8425368
+  dockerimage: demisto/elasticsearch:1.0.0.11195141
   isfetch: true
   runonce: false
   script: '-'

--- a/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2_test.py
+++ b/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2_test.py
@@ -3282,3 +3282,26 @@ class TestEsKibanaValueListItemImportCommand:
 
         with pytest.raises(DemistoException):
             Elasticsearch_v2.es_kibana_value_list_item_import_command({}, {})
+
+
+class TestBuildFetchExtraParams:
+    """ Tests for build_fetch_extra_params.
+    A blank "Fields to Fetch" parameter must not add an empty "fields": [] entry to the
+    fetch request body, otherwise Elasticsearch fails with:
+    ParsingException 400 'Unknown key for a START_ARRAY in [fields]'.
+    """
+
+    def test_empty_fields_list_omits_fields_key(self):
+        import Elasticsearch_v2
+
+        extra_params = Elasticsearch_v2.build_fetch_extra_params([])
+
+        assert "fields" not in extra_params
+        assert extra_params == {"_source": True}
+
+    def test_populated_fields_list_includes_fields_key(self):
+        import Elasticsearch_v2
+
+        extra_params = Elasticsearch_v2.build_fetch_extra_params(["field_a", "field_b"])
+
+        assert extra_params == {"_source": True, "fields": ["field_a", "field_b"]}

--- a/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2_test.py
+++ b/Packs/Elasticsearch/Integrations/Elasticsearch_v2/Elasticsearch_v2_test.py
@@ -3285,7 +3285,7 @@ class TestEsKibanaValueListItemImportCommand:
 
 
 class TestBuildFetchExtraParams:
-    """ Tests for build_fetch_extra_params.
+    """Tests for build_fetch_extra_params.
     A blank "Fields to Fetch" parameter must not add an empty "fields": [] entry to the
     fetch request body, otherwise Elasticsearch fails with:
     ParsingException 400 'Unknown key for a START_ARRAY in [fields]'.

--- a/Packs/Elasticsearch/ReleaseNotes/1_5_1.md
+++ b/Packs/Elasticsearch/ReleaseNotes/1_5_1.md
@@ -3,4 +3,4 @@
 
 ##### Elasticsearch v2
 
-- Fixed an issue where the ***fetch-incidents*** command failed with a *ParsingException* when the **Fields to Fetch** parameter was left empty.
+- Fixed an issue where the ***fetch-incidents*** command failed with a *ParsingException* when the *Fields to Fetch* parameter was left empty.

--- a/Packs/Elasticsearch/ReleaseNotes/1_5_1.md
+++ b/Packs/Elasticsearch/ReleaseNotes/1_5_1.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Elasticsearch v2
+
+- Fixed an issue where the ***fetch-incidents*** command failed with a *ParsingException* when the **Fields to Fetch** parameter was left empty.

--- a/Packs/Elasticsearch/ReleaseNotes/1_5_1.md
+++ b/Packs/Elasticsearch/ReleaseNotes/1_5_1.md
@@ -3,4 +3,5 @@
 
 ##### Elasticsearch v2
 
+- Updated the Docker image to: *demisto/elasticsearch:1.0.0.11195141*.
 - Fixed an issue where the ***fetch-incidents*** command failed with a *ParsingException* when the *Fields to Fetch* parameter was left empty.

--- a/Packs/Elasticsearch/pack_metadata.json
+++ b/Packs/Elasticsearch/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Elasticsearch",
     "description": "Search for and analyze data in real time. \n Supports version 6 and later.",
     "support": "xsoar",
-    "currentVersion": "1.5.0",
+    "currentVersion": "1.5.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://jira-dc.paloaltonetworks.com/browse/XSUP-73753

## Description
Add build_fetch_extra_params function to handle empty fields list parameter and avoid parsing issues in fetch-incidents

## Must have
- [ ] Tests
- [ ] Documentation
