### PR TITLE
XSUP-73591: DBotFindSimilarIncidents script - fix broken incident hyperlinks

### DIFF
--- a/Packs/Base/ReleaseNotes/1_42_14.md
+++ b/Packs/Base/ReleaseNotes/1_42_14.md
@@ -1,0 +1,6 @@
+
+#### Scripts
+
+##### DBotFindSimilarIncidents
+
+- Fixed an issue where the generated similar incident hyperlinks used the legacy hash-based format (*#/Details/ID*), which redirected to the dashboard on Cortex XSOAR 8.x. Links now use the correct format for both Cortex XSOAR 6.x and 8.x.

--- a/Packs/Base/ReleaseNotes/1_42_14.md
+++ b/Packs/Base/ReleaseNotes/1_42_14.md
@@ -3,4 +3,4 @@
 
 ##### DBotFindSimilarIncidents
 
-- Fixed an issue where the generated similar incident hyperlinks used the legacy hash-based format (*#/Details/ID*), which redirected to the dashboard on Cortex XSOAR 8.x. Links now use the correct format for both Cortex XSOAR 6.x and 8.x.
+- Fixed an issue where the generated similar incident hyperlinks used the legacy hash-based format (*#/Details/ID*), which redirected to the dashboard on Cortex XSOAR 8.x. Links now use the correct format for each version.

--- a/Packs/Base/Scripts/DBotFindSimilarIncidents/DBotFindSimilarIncidents.py
+++ b/Packs/Base/Scripts/DBotFindSimilarIncidents/DBotFindSimilarIncidents.py
@@ -78,6 +78,20 @@ CONST_PARAMETERS_INDICATORS_SCRIPT = {
 }
 KEYS_ARGS_INDICATORS = ["indicatorsTypes", "maxIncidentsInIndicatorsForWhiteList", "minNumberOfIndicators", "incidentId"]
 
+
+def create_incident_link(incident_id: Any) -> str:
+    """Build a markdown link to an incident details page.
+
+    Uses a path-based URL (``/Details/{id}``) for Cortex XSOAR 8.x and later, and the
+    legacy hash-based URL (``#/Details/{id}``) for Cortex XSOAR 6.x. This ensures the
+    generated hyperlinks navigate directly to the incident on both platforms.
+
+    :param incident_id: The incident ID.
+    :return: A markdown-formatted link to the incident details page.
+    """
+    prefix = "" if is_demisto_version_ge("8.4.0") else "#"
+    return f"[{incident_id}]({prefix}/Details/{incident_id})"
+
 REGEX_DATE_PATTERN = [
     re.compile(r"^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})Z"),
     re.compile(r"(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}).*"),
@@ -586,7 +600,7 @@ def prepare_incidents_for_display(
     :return: Clean Dataframe
     """
     if "id" in similar_incidents.columns.tolist():
-        similar_incidents[COLUMN_ID] = similar_incidents["id"].apply(lambda _id: f"[{_id}](#/Details/{_id})")
+        similar_incidents[COLUMN_ID] = similar_incidents["id"].apply(create_incident_link)
     if COLUMN_TIME in similar_incidents.columns:
         similar_incidents[COLUMN_TIME] = similar_incidents[COLUMN_TIME].apply(lambda x: return_clean_date(x))
     if aggregate == "True":
@@ -946,7 +960,7 @@ def prepare_current_incident(
     if COLUMN_TIME in incident_filter.columns.tolist():
         incident_filter[COLUMN_TIME] = incident_filter[COLUMN_TIME].apply(lambda x: return_clean_date(x))
     if "id" in incident_filter.columns.tolist():
-        incident_filter[COLUMN_ID] = incident_filter["id"].apply(lambda _id: f"[{_id}](#/Details/{_id})")
+        incident_filter[COLUMN_ID] = incident_filter["id"].apply(create_incident_link)
     return incident_filter
 
 

--- a/Packs/Base/Scripts/DBotFindSimilarIncidents/DBotFindSimilarIncidents.py
+++ b/Packs/Base/Scripts/DBotFindSimilarIncidents/DBotFindSimilarIncidents.py
@@ -1,6 +1,7 @@
 import json
 import re
 import warnings
+from collections.abc import Callable
 from copy import deepcopy
 from types import UnionType
 from typing import Any
@@ -79,18 +80,31 @@ CONST_PARAMETERS_INDICATORS_SCRIPT = {
 KEYS_ARGS_INDICATORS = ["indicatorsTypes", "maxIncidentsInIndicatorsForWhiteList", "minNumberOfIndicators", "incidentId"]
 
 
-def create_incident_link(incident_id: Any) -> str:
-    """Build a markdown link to an incident details page.
+def get_incident_link_creator() -> Callable[[Any], str]:
+    """Returns a function to build a markdown link to an incident details page.
 
-    Uses a path-based URL (``/Details/{id}``) for Cortex XSOAR 8.x and later, and the
-    legacy hash-based URL (``#/Details/{id}``) for Cortex XSOAR 6.x. This ensures the
-    generated hyperlinks navigate directly to the incident on both platforms.
+    The URL format depends on the platform:
 
-    :param incident_id: The incident ID.
-    :return: A markdown-formatted link to the incident details page.
+    - Unified Cortex platform (XSIAM v3 / XSOAR on platform): ``/issue-view/{id}``
+    - Cortex XSOAR 8.x (SaaS, non-platform): ``/Details/{id}``
+    - Cortex XSOAR 6.x (on-prem, legacy): ``#/Details/{id}``
+
+    This ensures the generated hyperlinks navigate directly to the incident/issue on
+    every supported platform.
+
+    :return: A function that takes an incident_id and returns a markdown-formatted link.
     """
-    prefix = "" if is_demisto_version_ge("8.4.0") else "#"
-    return f"[{incident_id}]({prefix}/Details/{incident_id})"
+    if is_platform():
+        template = "[{id}](/issue-view/{id})"
+    elif is_demisto_version_ge("8.4.0"):
+        template = "[{id}](/Details/{id})"
+    else:
+        template = "[{id}](#/Details/{id})"
+
+    def create_incident_link(incident_id: Any) -> str:
+        return template.format(id=incident_id)
+
+    return create_incident_link
 
 
 REGEX_DATE_PATTERN = [
@@ -601,7 +615,7 @@ def prepare_incidents_for_display(
     :return: Clean Dataframe
     """
     if "id" in similar_incidents.columns.tolist():
-        similar_incidents[COLUMN_ID] = similar_incidents["id"].apply(create_incident_link)
+        similar_incidents[COLUMN_ID] = similar_incidents["id"].apply(get_incident_link_creator())
     if COLUMN_TIME in similar_incidents.columns:
         similar_incidents[COLUMN_TIME] = similar_incidents[COLUMN_TIME].apply(lambda x: return_clean_date(x))
     if aggregate == "True":
@@ -961,7 +975,7 @@ def prepare_current_incident(
     if COLUMN_TIME in incident_filter.columns.tolist():
         incident_filter[COLUMN_TIME] = incident_filter[COLUMN_TIME].apply(lambda x: return_clean_date(x))
     if "id" in incident_filter.columns.tolist():
-        incident_filter[COLUMN_ID] = incident_filter["id"].apply(create_incident_link)
+        incident_filter[COLUMN_ID] = incident_filter["id"].apply(get_incident_link_creator())
     return incident_filter
 
 

--- a/Packs/Base/Scripts/DBotFindSimilarIncidents/DBotFindSimilarIncidents.py
+++ b/Packs/Base/Scripts/DBotFindSimilarIncidents/DBotFindSimilarIncidents.py
@@ -92,6 +92,7 @@ def create_incident_link(incident_id: Any) -> str:
     prefix = "" if is_demisto_version_ge("8.4.0") else "#"
     return f"[{incident_id}]({prefix}/Details/{incident_id})"
 
+
 REGEX_DATE_PATTERN = [
     re.compile(r"^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})Z"),
     re.compile(r"(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}).*"),

--- a/Packs/Base/Scripts/DBotFindSimilarIncidents/DBotFindSimilarIncidents_test.py
+++ b/Packs/Base/Scripts/DBotFindSimilarIncidents/DBotFindSimilarIncidents_test.py
@@ -547,24 +547,30 @@ def test_extract_fields_from_args(similar_text_field):
 
 
 @pytest.mark.parametrize(
-    "version_ge, incident_id, expected_link",
+    "is_platform, version_ge, incident_id, expected_link",
     [
-        (True, "43076", "[43076](/Details/43076)"),
-        (False, "43076", "[43076](#/Details/43076)"),
+        (True, True, "43076", "[43076](/issue-view/43076)"),
+        (True, False, "43076", "[43076](/issue-view/43076)"),
+        (False, True, "43076", "[43076](/Details/43076)"),
+        (False, False, "43076", "[43076](#/Details/43076)"),
     ],
 )
-def test_create_incident_link(mocker, version_ge, incident_id, expected_link):
+def test_create_incident_link(mocker, is_platform, version_ge, incident_id, expected_link):
     """
     Given:
         - An incident ID.
-        - Case 1: Cortex XSOAR 8.x (version >= 8.4.0) -> path-based URL.
-        - Case 2: Cortex XSOAR 6.x (version < 8.4.0) -> legacy hash-based URL.
+        - Case 1: Unified Cortex platform (XSIAM v3 / XSOAR on platform) -> issue-view URL.
+        - Case 2: Unified Cortex platform takes precedence regardless of demisto version.
+        - Case 3: Cortex XSOAR 8.x (version >= 8.4.0) -> path-based URL.
+        - Case 4: Cortex XSOAR 6.x (version < 8.4.0) -> legacy hash-based URL.
     When:
-        Calling create_incident_link.
+        Calling the incident link creator.
     Then:
-        - Ensure the correct link format is produced for each platform version.
+        - Ensure the correct link format is produced for each platform.
     """
     import DBotFindSimilarIncidents
 
+    mocker.patch.object(DBotFindSimilarIncidents, "is_platform", return_value=is_platform)
     mocker.patch.object(DBotFindSimilarIncidents, "is_demisto_version_ge", return_value=version_ge)
-    assert DBotFindSimilarIncidents.create_incident_link(incident_id) == expected_link
+    link_creator = DBotFindSimilarIncidents.get_incident_link_creator()
+    assert link_creator(incident_id) == expected_link

--- a/Packs/Base/Scripts/DBotFindSimilarIncidents/DBotFindSimilarIncidents_test.py
+++ b/Packs/Base/Scripts/DBotFindSimilarIncidents/DBotFindSimilarIncidents_test.py
@@ -544,3 +544,27 @@ def test_extract_fields_from_args(similar_text_field):
         "xdralerts.user_name",
     ]
     assert results == expected_results
+
+
+@pytest.mark.parametrize(
+    "version_ge, incident_id, expected_link",
+    [
+        (True, "43076", "[43076](/Details/43076)"),
+        (False, "43076", "[43076](#/Details/43076)"),
+    ],
+)
+def test_create_incident_link(mocker, version_ge, incident_id, expected_link):
+    """
+    Given:
+        - An incident ID.
+        - Case 1: Cortex XSOAR 8.x (version >= 8.4.0) -> path-based URL.
+        - Case 2: Cortex XSOAR 6.x (version < 8.4.0) -> legacy hash-based URL.
+    When:
+        Calling create_incident_link.
+    Then:
+        - Ensure the correct link format is produced for each platform version.
+    """
+    import DBotFindSimilarIncidents
+
+    mocker.patch.object(DBotFindSimilarIncidents, "is_demisto_version_ge", return_value=version_ge)
+    assert DBotFindSimilarIncidents.create_incident_link(incident_id) == expected_link

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.42.13",
+    "currentVersion": "1.42.14",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-73591

## Description
Issue:
The DBotFindSimilarIncidents script hardcoded legacy XSOAR 6 hash-based hyperlinks ([id](#/Details/id)) for similar incident IDs, which are malformed on XSOAR 8.x and redirect analysts to the dashboard instead of the target incident.

Fix:
Added a create_incident_link helper that conditionally builds the URL based on the platform version (is_demisto_version_ge("8.4.0")), producing path-based links (/Details/id) on XSOAR 8.x and preserving legacy hash-based links (#/Details/id) on XSOAR 6.x.
