### PR TITLE
CRTX-261027-Baracude-WAF

### DIFF
--- a/Packs/BarracudaWAF/ModelingRules/BarracudaWAFModelingRules_1_3/BarracudaWAFModelingRules_1_3.xif
+++ b/Packs/BarracudaWAF/ModelingRules/BarracudaWAFModelingRules_1_3/BarracudaWAFModelingRules_1_3.xif
@@ -96,10 +96,10 @@ filter _raw_log ~= "\s(AUDIT)\s"
     xdm.source.port = to_integer(arraystring(regextract(_raw_log, "AUDIT(?:\s\S+){3}\s(\S+)"), "")),
     xdm.event.operation = arraystring(regextract(_raw_log, "AUDIT(?:\s\S+){4}\s(\S+)"), ""),
     xdm.source.process.name = arraystring(regextract(_raw_log, "AUDIT(?:\s\S+){6}\s(\S+)"), ""),
-    xdm.target.resource.type = arraystring(regextract(_raw_log, "AUDIT(?:\s\S+){8}\s(\S+)"), ""),
-    xdm.target.resource.name = arraystring(regextract(_raw_log, "AUDIT(?:\s\S+){9}\s(\S+)"), ""),
-    xdm.target.resource_before.value = arraystring(regextract(_raw_log, "AUDIT(?:\s\S+){11}\s(\S+)"), ""),
-    xdm.target.resource.value = arraystring(regextract(_raw_log, "AUDIT(?:\s\S+){12}\s(\S+)"), "");
+    xdm.target.resource.type = arraystring(regextract(_raw_log, "AUDIT(?:\s+\S+){8}\s+(\S+)"), ""),
+    xdm.target.resource.name = arraystring(regextract(_raw_log, "AUDIT(?:\s+\S+){9}\s+(\S+)"), ""),
+    xdm.target.resource_before.value = arraystring(regextract(_raw_log, "config(?:\s+\S+){4}\s+(\"[^\"]*\")"), ""),
+    xdm.target.resource.value = arraystring(regextract(_raw_log, "config(?:\s+\S+){4}\s+\"[^\"]*\"\s+(\"[^\"]*\")"), "");
 
 filter _raw_log ~= "\s(NF)\s"
 | alter

--- a/Packs/BarracudaWAF/ModelingRules/BarracudaWAFModelingRules_1_3/BarracudaWAFModelingRules_1_3.xif
+++ b/Packs/BarracudaWAF/ModelingRules/BarracudaWAFModelingRules_1_3/BarracudaWAFModelingRules_1_3.xif
@@ -98,8 +98,8 @@ filter _raw_log ~= "\s(AUDIT)\s"
     xdm.source.process.name = arraystring(regextract(_raw_log, "AUDIT(?:\s\S+){6}\s(\S+)"), ""),
     xdm.target.resource.type = arraystring(regextract(_raw_log, "AUDIT(?:\s+\S+){8}\s+(\S+)"), ""),
     xdm.target.resource.name = arraystring(regextract(_raw_log, "AUDIT(?:\s+\S+){9}\s+(\S+)"), ""),
-    xdm.target.resource_before.value = arraystring(regextract(_raw_log, "config(?:\s+\S+){4}\s+(\"[^\"]*\")"), ""),
-    xdm.target.resource.value = arraystring(regextract(_raw_log, "config(?:\s+\S+){4}\s+\"[^\"]*\"\s+(\"[^\"]*\")"), "");
+    xdm.target.resource_before.value = arraystring(regextract(_raw_log, "config(?:\s+\S+){4}\s+\"([^\"]*)\""), ""),
+    xdm.target.resource.value = arraystring(regextract(_raw_log, "config(?:\s+\S+){4}\s+\"[^\"]*\"\s+\"([^\"]*)\""), "");
 
 filter _raw_log ~= "\s(NF)\s"
 | alter

--- a/Packs/BarracudaWAF/ReleaseNotes/1_0_7.md
+++ b/Packs/BarracudaWAF/ReleaseNotes/1_0_7.md
@@ -3,4 +3,4 @@
 
 ##### Barracuda WAF
 
-- Fixed an issue where the resource fields were not parsed correctly when the log contained extra whitespace or values with spaces.
+- Fixed an issue where the *resource* fields were not parsed correctly when the log contained extra whitespace or values with spaces.

--- a/Packs/BarracudaWAF/ReleaseNotes/1_0_7.md
+++ b/Packs/BarracudaWAF/ReleaseNotes/1_0_7.md
@@ -1,0 +1,6 @@
+
+#### Modeling Rules
+
+##### Barracuda WAF
+
+- Fixed an issue where the resource fields were not parsed correctly when the log contained extra whitespace or values with spaces.

--- a/Packs/BarracudaWAF/pack_metadata.json
+++ b/Packs/BarracudaWAF/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Barracuda WAF",
     "description": "Barracuda WAF modeling rules and parsing rules for XSIAM",
     "support": "xsoar",
-    "currentVersion": "1.0.6",
+    "currentVersion": "1.0.7",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CRTX-261027

## Description
Fixed an issue where the resource fields were not parsed correctly when the log contained extra whitespace or values with spaces.

## Must have
- [x] Tests
- [x] Documentation
