### PR TITLE
Added new commands for AWS integration

### DIFF
--- a/Packs/AWS/Integrations/AWS/AWS.py
+++ b/Packs/AWS/Integrations/AWS/AWS.py
@@ -8157,6 +8157,96 @@ class Lambda:
         return AWSErrorHandler.handle_response_error(response)
 
     @staticmethod
+    def get_function_concurrency_command(client: BotoClient, args: Dict[str, Any]) -> CommandResults:
+        """
+        Retrieves the reserved concurrency configuration for a Lambda function.
+
+        Args:
+            client (BotoClient): The boto3 client for Lambda service.
+            args (Dict[str, Any]): Command arguments including:
+                - function_name (str): The name or ARN of the Lambda function.
+
+        Returns:
+            CommandResults: Results of the operation with the reserved concurrency details.
+        """
+        function_name = args.get("function_name")
+        kwargs = {"FunctionName": function_name}
+
+        print_debug_logs(client, f"Calling get_function_concurrency with {kwargs=}")
+        response = client.get_function_concurrency(**kwargs)
+
+        if response.get("ResponseMetadata", {}).get("HTTPStatusCode") != HTTPStatus.OK:
+            AWSErrorHandler.handle_response_error(response, args.get("account_id"))
+
+        reserved = response.get("ReservedConcurrentExecutions")
+        outputs = {"FunctionName": function_name, "ReservedConcurrentExecutions": reserved}
+
+        human_readable = tableToMarkdown(
+            f"Lambda Function Concurrency: {function_name}",
+            outputs,
+            headerTransform=pascalToSpace,
+            removeNull=True,
+        )
+
+        return CommandResults(
+            outputs_prefix="AWS.Lambda.FunctionConcurrency",
+            outputs_key_field="FunctionName",
+            outputs=outputs,
+            readable_output=human_readable,
+            raw_response=response,
+        )
+
+    @staticmethod
+    def put_function_concurrency_command(client: BotoClient, args: Dict[str, Any]) -> CommandResults:
+        """
+        Sets the reserved concurrency configuration for a Lambda function.
+
+        Setting the reserved concurrency to 0 effectively disables the function by throttling
+        all invocations.
+
+        Args:
+            client (BotoClient): The boto3 client for Lambda service.
+            args (Dict[str, Any]): Command arguments including:
+                - function_name (str): The name or ARN of the Lambda function.
+                - reserved_concurrent_executions (int): The number of simultaneous executions
+                  to reserve for the function. Set to 0 to throttle (disable) the function.
+
+        Returns:
+            CommandResults: Results of the operation with the updated reserved concurrency details.
+        """
+        function_name = args.get("function_name")
+        reserved_concurrent_executions = arg_to_number(args.get("reserved_concurrent_executions"))
+
+        kwargs = {
+            "FunctionName": function_name,
+            "ReservedConcurrentExecutions": reserved_concurrent_executions,
+        }
+
+        print_debug_logs(client, f"Calling put_function_concurrency with {kwargs=}")
+        response = client.put_function_concurrency(**kwargs)
+
+        if response.get("ResponseMetadata", {}).get("HTTPStatusCode") != HTTPStatus.OK:
+            AWSErrorHandler.handle_response_error(response, args.get("account_id"))
+
+        reserved = response.get("ReservedConcurrentExecutions")
+        outputs = {"FunctionName": function_name, "ReservedConcurrentExecutions": reserved}
+
+        human_readable = tableToMarkdown(
+            f"Lambda Function Concurrency Updated: {function_name}",
+            outputs,
+            headerTransform=pascalToSpace,
+            removeNull=True,
+        )
+
+        return CommandResults(
+            outputs_prefix="AWS.Lambda.FunctionConcurrency",
+            outputs_key_field="FunctionName",
+            outputs=outputs,
+            readable_output=human_readable,
+            raw_response=response,
+        )
+
+    @staticmethod
     def delete_layer_version_command(client: BotoClient, args: Dict[str, Any]):
         """
         Deletes a version of a Lambda layer.
@@ -11037,6 +11127,8 @@ COMMANDS_MAPPING: dict[str, Callable] = {
     "aws-lambda-function-url-config-update": Lambda.update_function_url_configuration_command,
     "aws-lambda-function-configuration-update": Lambda.update_function_configuration_command,
     "aws-lambda-function-get": Lambda.get_function_command,
+    "aws-lambda-function-concurrency-get": Lambda.get_function_concurrency_command,
+    "aws-lambda-function-concurrency-put": Lambda.put_function_concurrency_command,
     "aws-lambda-functions-list": Lambda.list_functions_command,
     "aws-lambda-aliases-list": Lambda.list_aliases_command,
     "aws-lambda-account-settings-get": Lambda.get_account_settings_command,

--- a/Packs/AWS/Integrations/AWS/AWS.yml
+++ b/Packs/AWS/Integrations/AWS/AWS.yml
@@ -10020,6 +10020,125 @@ script:
       description: The function’s tenant isolation configuration settings. Determines whether the Lambda function runs on a shared or dedicated infrastructure per unique tenant.
       type: Unknown
 
+  - name: aws-lambda-function-concurrency-get
+    description: "Returns details about the reserved concurrency configuration for a Lambda function. Required IAM Permission: lambda:GetFunctionConcurrency."
+    arguments:
+    - name: account_id
+      required: false
+      required:platform: true
+      description: The AWS account ID. Required for Cortex Platform (which includes Cortex XSIAM version >=3.0 and Cortex Cloud). Optional for Cortex XSOAR and Cortex XSIAM version < 3.0, where it can be retrieved from the integration configuration.
+    - description: The AWS region. Required for Cortex Platform (which includes Cortex XSIAM version >=3.0 and Cortex Cloud). Optional for Cortex XSOAR and Cortex XSIAM version < 3.0, where it can be retrieved from the integration configuration.
+      name: region
+      required: false
+      required:platform: true
+      auto: PREDEFINED
+      predefined:
+      - us-east-1
+      - us-east-2
+      - us-west-1
+      - us-west-2
+      - af-south-1
+      - ap-east-1
+      - ap-south-2
+      - ap-southeast-3
+      - ap-southeast-5
+      - ap-southeast-4
+      - ap-south-1
+      - ap-northeast-3
+      - ap-northeast-2
+      - ap-southeast-1
+      - ap-southeast-2
+      - ap-southeast-7
+      - ap-northeast-1
+      - ca-central-1
+      - ca-west-1
+      - eu-central-1
+      - eu-west-1
+      - eu-west-2
+      - eu-south-1
+      - eu-west-3
+      - eu-south-2
+      - eu-north-1
+      - eu-central-2
+      - il-central-1
+      - mx-central-1
+      - me-south-1
+      - me-central-1
+      - sa-east-1
+      - us-gov-east-1
+      - us-gov-west-1
+    - name: function_name
+      required: true
+      description: The name or ARN of the Lambda function.
+    outputs:
+    - contextPath: AWS.Lambda.FunctionConcurrency.FunctionName
+      description: The name or ARN of the Lambda function.
+      type: String
+    - contextPath: AWS.Lambda.FunctionConcurrency.ReservedConcurrentExecutions
+      description: The number of simultaneous executions that are reserved for the function.
+      type: Number
+
+  - name: aws-lambda-function-concurrency-put
+    description: "Sets the maximum number of simultaneous executions for a Lambda function, and reserves capacity for that concurrency level. Set the value to 0 to throttle (effectively disable) the function so it stops processing invocations. Required IAM Permission: lambda:PutFunctionConcurrency."
+    arguments:
+    - name: account_id
+      required: false
+      required:platform: true
+      description: The AWS account ID. Required for Cortex Platform (which includes Cortex XSIAM version >=3.0 and Cortex Cloud). Optional for Cortex XSOAR and Cortex XSIAM version < 3.0, where it can be retrieved from the integration configuration.
+    - description: The AWS region. Required for Cortex Platform (which includes Cortex XSIAM version >=3.0 and Cortex Cloud). Optional for Cortex XSOAR and Cortex XSIAM version < 3.0, where it can be retrieved from the integration configuration.
+      name: region
+      required: false
+      required:platform: true
+      auto: PREDEFINED
+      predefined:
+      - us-east-1
+      - us-east-2
+      - us-west-1
+      - us-west-2
+      - af-south-1
+      - ap-east-1
+      - ap-south-2
+      - ap-southeast-3
+      - ap-southeast-5
+      - ap-southeast-4
+      - ap-south-1
+      - ap-northeast-3
+      - ap-northeast-2
+      - ap-southeast-1
+      - ap-southeast-2
+      - ap-southeast-7
+      - ap-northeast-1
+      - ca-central-1
+      - ca-west-1
+      - eu-central-1
+      - eu-west-1
+      - eu-west-2
+      - eu-south-1
+      - eu-west-3
+      - eu-south-2
+      - eu-north-1
+      - eu-central-2
+      - il-central-1
+      - mx-central-1
+      - me-south-1
+      - me-central-1
+      - sa-east-1
+      - us-gov-east-1
+      - us-gov-west-1
+    - name: function_name
+      required: true
+      description: The name or ARN of the Lambda function.
+    - name: reserved_concurrent_executions
+      required: true
+      description: The number of simultaneous executions to reserve for the function. Set to 0 to throttle (effectively disable) the function so it stops processing invocations.
+    outputs:
+    - contextPath: AWS.Lambda.FunctionConcurrency.FunctionName
+      description: The name or ARN of the Lambda function.
+      type: String
+    - contextPath: AWS.Lambda.FunctionConcurrency.ReservedConcurrentExecutions
+      description: The number of simultaneous executions that are reserved for the function.
+      type: Number
+
   - arguments:
     - description: The AWS account ID. Required for Cortex Platform (which includes Cortex XSIAM version >=3.0 and Cortex Cloud). Optional for Cortex XSOAR and Cortex XSIAM version < 3.0, where it can be retrieved from the integration configuration.
       name: account_id

--- a/Packs/AWS/Integrations/AWS/AWS_test.py
+++ b/Packs/AWS/Integrations/AWS/AWS_test.py
@@ -14881,6 +14881,116 @@ def test_update_function_configuration_command_error(mocker):
         Lambda.update_function_configuration_command(mock_client, args)
 
 
+def test_get_function_concurrency_command(mocker):
+    """
+    Given:
+        - A mock Boto3 client for AWS Lambda.
+        - Arguments containing the function name.
+    When:
+        - Calling get_function_concurrency_command.
+    Then:
+        - Ensure the command returns the expected reserved concurrency outputs.
+        - Ensure the Boto3 client is called with the correct parameters.
+    """
+    from AWS import Lambda
+
+    mock_client = mocker.Mock()
+    mock_client.get_function_concurrency.return_value = {
+        "ReservedConcurrentExecutions": 10,
+        "ResponseMetadata": {"HTTPStatusCode": 200},
+    }
+
+    args = {"function_name": "test-function"}
+
+    result = Lambda.get_function_concurrency_command(mock_client, args)
+
+    assert result.outputs.get("FunctionName") == "test-function"
+    assert result.outputs.get("ReservedConcurrentExecutions") == 10
+    assert result.outputs_prefix == "AWS.Lambda.FunctionConcurrency"
+    mock_client.get_function_concurrency.assert_called_once_with(FunctionName="test-function")
+
+
+def test_put_function_concurrency_command(mocker):
+    """
+    Given:
+        - A mock Boto3 client for AWS Lambda.
+        - Arguments containing the function name and reserved concurrent executions.
+    When:
+        - Calling put_function_concurrency_command.
+    Then:
+        - Ensure the command returns the expected reserved concurrency outputs.
+        - Ensure the Boto3 client is called with the correct parameters.
+    """
+    from AWS import Lambda
+
+    mock_client = mocker.Mock()
+    mock_client.put_function_concurrency.return_value = {
+        "ReservedConcurrentExecutions": 5,
+        "ResponseMetadata": {"HTTPStatusCode": 200},
+    }
+
+    args = {"function_name": "test-function", "reserved_concurrent_executions": "5"}
+
+    result = Lambda.put_function_concurrency_command(mock_client, args)
+
+    assert result.outputs.get("FunctionName") == "test-function"
+    assert result.outputs.get("ReservedConcurrentExecutions") == 5
+    assert result.outputs_prefix == "AWS.Lambda.FunctionConcurrency"
+    mock_client.put_function_concurrency.assert_called_once_with(FunctionName="test-function", ReservedConcurrentExecutions=5)
+
+
+def test_put_function_concurrency_command_disable(mocker):
+    """
+    Given:
+        - A mock Boto3 client for AWS Lambda.
+        - Arguments setting reserved concurrent executions to 0 (disabling the function).
+    When:
+        - Calling put_function_concurrency_command.
+    Then:
+        - Ensure the value 0 is passed through and not dropped as an empty value.
+    """
+    from AWS import Lambda
+
+    mock_client = mocker.Mock()
+    mock_client.put_function_concurrency.return_value = {
+        "ReservedConcurrentExecutions": 0,
+        "ResponseMetadata": {"HTTPStatusCode": 200},
+    }
+
+    args = {"function_name": "test-function", "reserved_concurrent_executions": "0"}
+
+    result = Lambda.put_function_concurrency_command(mock_client, args)
+
+    assert result.outputs.get("ReservedConcurrentExecutions") == 0
+    mock_client.put_function_concurrency.assert_called_once_with(FunctionName="test-function", ReservedConcurrentExecutions=0)
+
+
+def test_put_function_concurrency_command_error(mocker):
+    """
+    Given:
+        - A mock Boto3 client for AWS Lambda that returns an error response.
+        - Arguments containing the function name and reserved concurrent executions.
+    When:
+        - Calling put_function_concurrency_command.
+    Then:
+        - Ensure the command raises an exception with the expected error message.
+    """
+    from AWS import Lambda
+
+    mock_client = mocker.Mock()
+    mock_client.put_function_concurrency.return_value = {
+        "ResponseMetadata": {"HTTPStatusCode": 400},
+        "Error": {"Message": "Bad Request"},
+    }
+
+    args = {"function_name": "test-function", "reserved_concurrent_executions": "5"}
+
+    mocker.patch("AWS.AWSErrorHandler.handle_response_error", side_effect=Exception("Bad Request"))
+
+    with pytest.raises(Exception, match="Bad Request"):
+        Lambda.put_function_concurrency_command(mock_client, args)
+
+
 def test_eks_create_access_entry_command_success(mocker):
     """
     Given: A mocked boto3 EKS client and valid access entry creation arguments.

--- a/Packs/AWS/Integrations/AWS/README.md
+++ b/Packs/AWS/Integrations/AWS/README.md
@@ -3153,6 +3153,55 @@ Lists the versions of an Lambda layer. Required IAM Permission: lambda:ListLayer
 | AWS.Lambda.LayerVersions.LicenseInfo | string | The layer's open-source license. |
 | AWS.Lambda.LayerVersions.CompatibleArchitectures | array | A list of compatible instruction set architectures. |
 
+### aws-lambda-function-concurrency-get
+
+***
+Returns details about the reserved concurrency configuration for a Lambda function. Required IAM Permission: lambda:GetFunctionConcurrency.
+
+#### Base Command
+
+`aws-lambda-function-concurrency-get`
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| account_id | The AWS account ID. Required for Cortex Platform (which includes Cortex XSIAM version &gt;=3.0 and Cortex Cloud). Optional for Cortex XSOAR and Cortex XSIAM version &lt; 3.0, where it can be retrieved from the integration configuration. | Optional |
+| region | The AWS region. Required for Cortex Platform (which includes Cortex XSIAM version &gt;=3.0 and Cortex Cloud). Optional for Cortex XSOAR and Cortex XSIAM version &lt; 3.0, where it can be retrieved from the integration configuration. Possible values are: us-east-1, us-east-2, us-west-1, us-west-2, af-south-1, ap-east-1, ap-south-2, ap-southeast-3, ap-southeast-5, ap-southeast-4, ap-south-1, ap-northeast-3, ap-northeast-2, ap-southeast-1, ap-southeast-2, ap-southeast-7, ap-northeast-1, ca-central-1, ca-west-1, eu-central-1, eu-west-1, eu-west-2, eu-south-1, eu-west-3, eu-south-2, eu-north-1, eu-central-2, il-central-1, mx-central-1, me-south-1, me-central-1, sa-east-1, us-gov-east-1, us-gov-west-1. | Optional |
+| function_name | The name or ARN of the Lambda function. | Required |
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| AWS.Lambda.FunctionConcurrency.FunctionName | String | The name or ARN of the Lambda function. |
+| AWS.Lambda.FunctionConcurrency.ReservedConcurrentExecutions | Number | The number of simultaneous executions that are reserved for the function. |
+
+### aws-lambda-function-concurrency-put
+
+***
+Sets the maximum number of simultaneous executions for a Lambda function, and reserves capacity for that concurrency level. Set the value to 0 to throttle (effectively disable) the function so it stops processing invocations. Required IAM Permission: lambda:PutFunctionConcurrency.
+
+#### Base Command
+
+`aws-lambda-function-concurrency-put`
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| account_id | The AWS account ID. Required for Cortex Platform (which includes Cortex XSIAM version &gt;=3.0 and Cortex Cloud). Optional for Cortex XSOAR and Cortex XSIAM version &lt; 3.0, where it can be retrieved from the integration configuration. | Optional |
+| region | The AWS region. Required for Cortex Platform (which includes Cortex XSIAM version &gt;=3.0 and Cortex Cloud). Optional for Cortex XSOAR and Cortex XSIAM version &lt; 3.0, where it can be retrieved from the integration configuration. Possible values are: us-east-1, us-east-2, us-west-1, us-west-2, af-south-1, ap-east-1, ap-south-2, ap-southeast-3, ap-southeast-5, ap-southeast-4, ap-south-1, ap-northeast-3, ap-northeast-2, ap-southeast-1, ap-southeast-2, ap-southeast-7, ap-northeast-1, ca-central-1, ca-west-1, eu-central-1, eu-west-1, eu-west-2, eu-south-1, eu-west-3, eu-south-2, eu-north-1, eu-central-2, il-central-1, mx-central-1, me-south-1, me-central-1, sa-east-1, us-gov-east-1, us-gov-west-1. | Optional |
+| function_name | The name or ARN of the Lambda function. | Required |
+| reserved_concurrent_executions | The number of simultaneous executions to reserve for the function. Set to 0 to throttle (effectively disable) the function so it stops processing invocations. | Required |
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| AWS.Lambda.FunctionConcurrency.FunctionName | String | The name or ARN of the Lambda function. |
+| AWS.Lambda.FunctionConcurrency.ReservedConcurrentExecutions | Number | The number of simultaneous executions that are reserved for the function. |
+
 ### aws-lambda-function-delete
 
 ***

--- a/Packs/AWS/ReleaseNotes/2_4_3.md
+++ b/Packs/AWS/ReleaseNotes/2_4_3.md
@@ -1,0 +1,6 @@
+#### Integrations
+
+##### Amazon Web Services
+
+- Added support for the ***aws-lambda-function-concurrency-get*** command, which returns details about the reserved concurrency configuration for a Lambda function. Required permissions: lambda:GetFunctionConcurrency.
+- Added support for the ***aws-lambda-function-concurrency-put*** command, which sets the reserved concurrency for a Lambda function. Setting the value to 0 throttles (effectively disables) the function. Required permissions: lambda:PutFunctionConcurrency.

--- a/Packs/AWS/pack_metadata.json
+++ b/Packs/AWS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "AWS",
     "description": "Amazon Web Services",
     "support": "xsoar",
-    "currentVersion": "2.4.2",
+    "currentVersion": "2.4.3",
     "author": "Cortex",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
<!-- To link a Jira ticket use fixes/related: link to the issue, for example fixes: CIAC-XXXX -->

## Description
- Added the aws-lambda-function-concurrency-get command AWS.Lambda.FunctionConcurrency.ReservedConcurrentExecutions).
- Added the[ aws-lambda-function-concurrency-put ](https://docs.aws.amazon.com/boto3/latest/reference/services/lambda/client/put_function_concurrency.html)command 
- 
## Must have
- [ ] Tests
- [ ] Documentation
