### PR TITLE
threatq: fix py2-style artifacts resulting in `SyntaxError`

### DIFF
--- a/Packs/ThreatQ/Integrations/ThreatQ/ThreatQ.py
+++ b/Packs/ThreatQ/Integrations/ThreatQ/ThreatQ.py
@@ -103,7 +103,7 @@ def query_tq(keyword):
     try:
         object_type = str(response['data'][0]['object'])
         object_id = str(response['data'][0]['id']) # get the object id from the query results
-    except Exception, e:
+    except Exception:
         results = {'ContentsFormat': formats['markdown'], 'Type': entryTypes['note'], 'Contents': "No results from ThreatQ"}
         return results
     results = describe_by_id(object_type,object_id)
@@ -322,7 +322,7 @@ try:
     elif demisto.command() == 'fetch-incidents':
         fetch_incidents()
 
-except Exception, e:
+except Exception as e:
     raise
     return_error(e)
 


### PR DESCRIPTION

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Description

This file is the only syntax error present in the repo, see below.

https://github.com/demisto/content/blob/dc86e1fd2cbec04c044bb5f3d135f5fd13ab83dd/Packs/ThreatQ/Integrations/ThreatQ/ThreatQ.py#L106-L108

https://github.com/demisto/content/blob/dc86e1fd2cbec04c044bb5f3d135f5fd13ab83dd/Packs/ThreatQ/Integrations/ThreatQ/ThreatQ.py#L325-L327

```sh
uv run --no-project --python 3.10 -m compileall . -q
# ** Error compiling './Packs/ThreatQ/Integrations/ThreatQ/ThreatQ.py'...
#  File "./Packs/ThreatQ/Integrations/ThreatQ/ThreatQ.py", line 106
#    except Exception, e:
#           ^^^^^^^^^^^^
# SyntaxError: multiple exception types must be parenthesized
```

`except Exception, e:` looked like either artifact from Python 2 (Python was using this syntax instead of `except Exception as e`) or just a typo. To fix the issue I've dropped unused `e` in one case and replaced with `as e` in another.

## Must have
- [ ] Tests
- [ ] Documentation


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-17494