### PR TITLE
SocFrameworkManager: install packs in place, surface upload errors, add diagnose action (1.1.0)

### DIFF
--- a/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/README.md
+++ b/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/README.md
@@ -9,10 +9,12 @@ pack. The script reads the SOC Framework pack catalog, sequences pack
 installs, configures integration instances and jobs, and synchronizes the
 `value_tags` lookup. Because XSIAM scripts can call `demisto.executeCommand`,
 all orchestration lives there. This integration stores the tenant URL,
-credentials, and TLS verification setting, and exposes a single command,
-`socfw-install-pack`, that downloads a pack ZIP and uploads it as system
-content. XSIAM integrations cannot call `demisto.executeCommand`, so the
-integration deliberately performs only the work that needs raw HTTP.
+credentials, TLS verification setting, and the pack catalog location, and
+exposes two commands: `socfw-install-pack`, which downloads a pack ZIP and
+uploads it as system content, and `socfw-get-catalog-url`, which returns the
+configured catalog location so the script can read it. XSIAM integrations
+cannot call `demisto.executeCommand`, so the integration deliberately performs
+only the work that needs raw HTTP.
 
 End users run `!SOCFWPackManager action=apply pack_id=...` from the XSIAM
 Playground. The script invokes `socfw-install-pack` on this integration
@@ -35,6 +37,7 @@ internally.
    | API Key | Secret value of the Standard API key. Stored masked. | True |
    | Trust any certificate (not secure) | Disable TLS certificate validation. Off by default. | False |
    | Use system proxy settings | Route HTTP traffic through the system proxy. Off by default. | False |
+   | Pack catalog URL | Location of the SOC Framework `pack_catalog.json`. Override to point at a fork or branch. Leave empty to use the SOC Framework repository default. | False |
 
 6. Click **Test** to validate the URL and credentials, then **Done**.
 
@@ -96,3 +99,45 @@ invoke directly.
 #### Human Readable Output
 
 > Pack **soc-optimization-unified-v3.6.3.zip** installed successfully.
+
+### socfw-get-catalog-url
+
+***
+Returns the SOC Framework pack catalog URL configured on this instance, or the
+SOC Framework default when the field is left empty. Called by the
+SOCFWPackManager script so the catalog location is set once on the instance
+instead of passed as an argument on every run.
+
+#### Base Command
+
+`socfw-get-catalog-url`
+
+#### Input
+
+There are no input arguments for this command.
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| SOCFramework.PackManager.CatalogURL | String | Pack catalog URL configured on this instance, or the SOC Framework default when the field is empty. |
+
+#### Command example
+
+```!socfw-get-catalog-url```
+
+#### Context Example
+
+```json
+{
+    "SOCFramework": {
+        "PackManager": {
+            "CatalogURL": "https://raw.githubusercontent.com/Palo-Cortex/secops-framework/refs/heads/main/pack_catalog.json"
+        }
+    }
+}
+```
+
+#### Human Readable Output
+
+> Pack catalog URL: <https://raw.githubusercontent.com/Palo-Cortex/secops-framework/refs/heads/main/pack_catalog.json>

--- a/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/README.md
+++ b/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/README.md
@@ -7,14 +7,16 @@ not invoke this integration directly.
 This integration is paired with the **SOCFWPackManager** script in the same
 pack. The script reads the SOC Framework pack catalog, sequences pack
 installs, configures integration instances and jobs, and synchronizes the
-`value_tags` lookup. Because XSIAM scripts can call `demisto.executeCommand`,
-all orchestration lives there. This integration stores the tenant URL,
-credentials, TLS verification setting, and the pack catalog location, and
-exposes two commands: `socfw-install-pack`, which downloads a pack ZIP and
-uploads it as system content, and `socfw-get-catalog-url`, which returns the
-configured catalog location so the script can read it. XSIAM integrations
-cannot call `demisto.executeCommand`, so the integration deliberately performs
-only the work that needs raw HTTP.
+`value_tags` lookup. Because Cortex XSIAM scripts can call
+`demisto.executeCommand`, all orchestration lives there.
+
+This integration stores the tenant URL, credentials, TLS verification setting,
+and the pack catalog location. It exposes two commands: `socfw-install-pack`,
+which downloads a pack ZIP and uploads it as system content, and
+`socfw-catalog-url-get`, which returns the configured catalog location so the
+script can read it. Cortex XSIAM integrations cannot call
+`demisto.executeCommand`, so the integration deliberately performs only the
+work that needs raw HTTP.
 
 End users run `!SOCFWPackManager action=apply pack_id=...` from the XSIAM
 Playground. The script invokes `socfw-install-pack` on this integration
@@ -30,14 +32,14 @@ internally.
 4. Search for **SOC Framework Pack Manager**.
 5. Click **Add instance** to create and configure a new integration instance.
 
-   | **Parameter** | **Description** | **Required** |
-   | --- | --- | --- |
-   | Server URL | Tenant API URL or tenant URL. The integration adds the `api-` prefix when it is missing. | True |
-   | API Key ID | Numeric ID of the Standard API key. | True |
-   | API Key | Secret value of the Standard API key. Stored masked. | True |
-   | Trust any certificate (not secure) | Disable TLS certificate validation. Off by default. | False |
-   | Use system proxy settings | Route HTTP traffic through the system proxy. Off by default. | False |
-   | Pack catalog URL | Location of the SOC Framework `pack_catalog.json`. Override to point at a fork or branch. Leave empty to use the SOC Framework repository default. | False |
+| **Parameter** | **Description** | **Required** |
+| --- | --- | --- |
+| Server URL | The tenant API URL or tenant URL. The integration adds the api- prefix when it is missing. | True |
+| API Key ID | The numeric ID of the Standard API key, shown in the API Keys table. | True |
+| API Key | The secret value of the Standard API key. | True |
+| Trust any certificate (not secure) | Whether to disable TLS certificate validation. Off by default. | False |
+| Use system proxy settings | Whether to route HTTP traffic through the system proxy. Off by default. | False |
+| Pack catalog URL | The location of the SOC Framework pack_catalog.json. Override to point at a fork or branch. Leave empty to use the SOC Framework repository default. | False |
 
 6. Click **Test** to validate the URL and credentials, then **Done**.
 
@@ -99,45 +101,23 @@ invoke directly.
 #### Human Readable Output
 
 > Pack **soc-optimization-unified-v3.6.3.zip** installed successfully.
-
-### socfw-get-catalog-url
+>
+### socfw-catalog-url-get
 
 ***
-Returns the SOC Framework pack catalog URL configured on this instance, or the
-SOC Framework default when the field is left empty. Called by the
-SOCFWPackManager script so the catalog location is set once on the instance
-instead of passed as an argument on every run.
+Returns the SOC Framework pack catalog URL configured on this instance. Called by the SOCFWPackManager script so the catalog location is set once on the instance instead of passed as an argument on every run.
 
 #### Base Command
 
-`socfw-get-catalog-url`
+`socfw-catalog-url-get`
 
 #### Input
 
-There are no input arguments for this command.
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
 
 #### Context Output
 
 | **Path** | **Type** | **Description** |
 | --- | --- | --- |
-| SOCFramework.PackManager.CatalogURL | String | Pack catalog URL configured on this instance, or the SOC Framework default when the field is empty. |
-
-#### Command example
-
-```!socfw-get-catalog-url```
-
-#### Context Example
-
-```json
-{
-    "SOCFramework": {
-        "PackManager": {
-            "CatalogURL": "https://raw.githubusercontent.com/Palo-Cortex/secops-framework/refs/heads/main/pack_catalog.json"
-        }
-    }
-}
-```
-
-#### Human Readable Output
-
-> Pack catalog URL: <https://raw.githubusercontent.com/Palo-Cortex/secops-framework/refs/heads/main/pack_catalog.json>
+| SOCFramework.PackManager.CatalogURL | String | The pack catalog URL configured on this instance, or the SOC Framework default when the field is empty. |

--- a/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager.py
+++ b/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager.py
@@ -21,6 +21,11 @@ from CommonServerPython import *  # noqa: F401,F403
 
 INTEGRATION_NAME = "SOCFWPackManager"
 
+# Location of the SOC Framework pack catalog. Set on the instance so a fork or
+# branch can be used without editing the pack or passing an argument on every
+# run; this value is the fallback when the instance leaves the field empty.
+DEFAULT_CATALOG_URL = "https://raw.githubusercontent.com/Palo-Cortex/secops-framework/refs/heads/main/pack_catalog.json"
+
 # Trailing release-version suffix on a pack asset filename, e.g. the
 # "-v3.11.2" in soc-optimization-unified-v3.11.2.zip, optionally followed by a
 # pre-release tag such as "-pr1008".
@@ -374,6 +379,23 @@ def install_pack_command(client: ContentClient, args: dict[str, Any]) -> Command
 # ---------------------------------------------------------------------------
 
 
+def get_catalog_url_command(params: dict[str, Any]) -> CommandResults:
+    """Return the pack catalog URL configured on this instance.
+
+    The SOCFWPackManager script cannot read another integration's instance
+    parameters, so it reads the configured location through this command. That
+    keeps the catalog location set once on the instance rather than passed as an
+    argument on every run.
+    """
+    catalog_url = (params.get("catalog_url") or "").strip() or DEFAULT_CATALOG_URL
+    return CommandResults(
+        outputs_prefix="SOCFramework.PackManager",
+        outputs={"CatalogURL": catalog_url},
+        raw_response={"catalog_url": catalog_url},
+        readable_output=f"Pack catalog URL: {catalog_url}",
+    )
+
+
 def main() -> None:
     params = demisto.params()
     args = demisto.args()
@@ -399,6 +421,8 @@ def main() -> None:
             return_results(test_module(client))
         elif command == "socfw-install-pack":
             return_results(install_pack_command(client, args))
+        elif command == "socfw-get-catalog-url":
+            return_results(get_catalog_url_command(params))
         else:
             raise NotImplementedError(f"Command not implemented: {command}")
     except Exception as exc:

--- a/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager.py
+++ b/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager.py
@@ -13,6 +13,7 @@ import shutil
 import tempfile
 import zipfile
 from pathlib import Path
+from urllib.parse import urlparse
 from typing import Any
 
 import demistomock as demisto  # noqa: F401
@@ -380,6 +381,20 @@ def install_pack_command(client: ContentClient, args: dict[str, Any]) -> Command
 # ---------------------------------------------------------------------------
 
 
+def _is_valid_catalog_url(url: str) -> bool:
+    """Whether the value is an absolute http(s) URL with a hostname.
+
+    A relative or scheme-less value resolves against the tenant host when the
+    catalog is fetched, which surfaces as a confusing 404 from the tenant rather
+    than an obvious misconfiguration of this parameter.
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return False
+    return parsed.scheme in ("http", "https") and bool(parsed.hostname)
+
+
 def get_catalog_url_command(params: dict[str, Any]) -> CommandResults:
     """Return the pack catalog URL configured on this instance.
 
@@ -387,8 +402,23 @@ def get_catalog_url_command(params: dict[str, Any]) -> CommandResults:
     parameters, so it reads the configured location through this command. That
     keeps the catalog location set once on the instance rather than passed as an
     argument on every run.
+
+    An unusable configured value is reported and ignored rather than returned,
+    because the caller would otherwise fetch it and fail somewhere less obvious.
     """
-    catalog_url = (params.get("catalog_url") or "").strip() or DEFAULT_CATALOG_URL
+    configured = (params.get("catalog_url") or "").strip()
+    if configured and not _is_valid_catalog_url(configured):
+        demisto.error(f"Configured pack catalog URL is not an absolute http(s) URL: {configured!r}")
+        return CommandResults(
+            outputs_prefix="SOCFramework.PackManager",
+            outputs={"CatalogURL": DEFAULT_CATALOG_URL},
+            raw_response={"catalog_url": DEFAULT_CATALOG_URL},
+            readable_output=(
+                f"⚠️ The configured pack catalog URL is not an absolute http(s) URL and was ignored: `{configured}`\n\n"
+                f"Using the default instead: {DEFAULT_CATALOG_URL}"
+            ),
+        )
+    catalog_url = configured or DEFAULT_CATALOG_URL
     return CommandResults(
         outputs_prefix="SOCFramework.PackManager",
         outputs={"CatalogURL": catalog_url},

--- a/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager.py
+++ b/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager.py
@@ -38,6 +38,7 @@ def pack_dir_name(filename: str) -> str:
     name = filename[:-4] if filename.lower().endswith(".zip") else filename
     return PACK_VERSION_SUFFIX.sub("", name).strip()
 
+
 # Hard cap on the size of a pack ZIP we will download or extract.
 # SOC Framework packs are small (a few MB); 500 MB leaves plenty of headroom
 # while bounding memory / disk usage for a wrong or malicious URL.

--- a/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager.py
+++ b/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager.py
@@ -26,10 +26,11 @@ INTEGRATION_NAME = "SOCFWPackManager"
 # run; this value is the fallback when the instance leaves the field empty.
 DEFAULT_CATALOG_URL = "https://raw.githubusercontent.com/Palo-Cortex/secops-framework/refs/heads/main/pack_catalog.json"
 
-# Trailing release-version suffix on a pack asset filename, e.g. the
-# "-v3.11.2" in soc-optimization-unified-v3.11.2.zip, optionally followed by a
-# pre-release tag such as "-pr1008".
-PACK_VERSION_SUFFIX = re.compile(r"-v\d+(?:\.\d+)*(?:-[A-Za-z0-9]+)?$")
+# Trailing release-version suffix on a release asset filename, e.g. "-v3.11.2"
+# or "-v3.11.1-pr1008". The pre-release group is restricted to recognized tag
+# forms on purpose: allowing any word there would strip a legitimate trailing
+# component, turning "soc-v3-tools" into "soc".
+PACK_VERSION_SUFFIX = re.compile(r"-v\d+(?:\.\d+)*(?:-(?:pr|rc|alpha|beta|dev)\d*)?$", re.IGNORECASE)
 
 
 def pack_dir_name(filename: str) -> str:

--- a/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager.py
+++ b/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager.py
@@ -421,7 +421,7 @@ def main() -> None:
             return_results(test_module(client))
         elif command == "socfw-install-pack":
             return_results(install_pack_command(client, args))
-        elif command == "socfw-get-catalog-url":
+        elif command == "socfw-catalog-url-get":
             return_results(get_catalog_url_command(params))
         else:
             raise NotImplementedError(f"Command not implemented: {command}")

--- a/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager.py
+++ b/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager.py
@@ -8,6 +8,7 @@ invokes ``socfw-install-pack`` on this integration.
 """
 
 import os
+import re
 import shutil
 import tempfile
 import zipfile
@@ -19,6 +20,23 @@ from CommonServerPython import *  # noqa: F401,F403
 
 
 INTEGRATION_NAME = "SOCFWPackManager"
+
+# Trailing release-version suffix on a pack asset filename, e.g. the
+# "-v3.11.2" in soc-optimization-unified-v3.11.2.zip, optionally followed by a
+# pre-release tag such as "-pr1008".
+PACK_VERSION_SUFFIX = re.compile(r"-v\d+(?:\.\d+)*(?:-[A-Za-z0-9]+)?$")
+
+
+def pack_dir_name(filename: str) -> str:
+    """Pack directory name for a release asset filename.
+
+    The directory name becomes the pack ID on the tenant, so the version
+    suffix has to be stripped. Keeping it installs every release as a separate
+    pack -- soc-optimization-unified-v3.11.2 alongside soc-optimization-unified
+    -- instead of upgrading the existing one in place.
+    """
+    name = filename[:-4] if filename.lower().endswith(".zip") else filename
+    return PACK_VERSION_SUFFIX.sub("", name).strip()
 
 # Hard cap on the size of a pack ZIP we will download or extract.
 # SOC Framework packs are small (a few MB); 500 MB leaves plenty of headroom
@@ -140,7 +158,14 @@ class ContentClient(BaseClient):
         from demisto_sdk.commands.common.logger import logging_setup
         from demisto_sdk.commands.upload.upload import upload_content_entity
 
-        logging_setup(INTEGRATION_NAME, console_threshold="CRITICAL", propagate=True)
+        # A CRITICAL console threshold suppresses the SDK's FAILED-UPLOADS
+        # report, which is the only place the real reason for a failed upload
+        # appears. Keep errors visible, and raise to DEBUG on demand.
+        logging_setup(
+            INTEGRATION_NAME,
+            console_threshold="DEBUG" if is_debug_mode() else "ERROR",
+            propagate=True,
+        )
 
         try:
             upload_content_entity(
@@ -248,7 +273,7 @@ def _prepare_pack_dir(zip_path: str, filename: str) -> str:
     Creates ``Tests/Marketplace/landingPage_sections.json`` to suppress SDK
     warnings during upload.
     """
-    pack_name = filename[:-4] if filename.endswith(".zip") else filename
+    pack_name = pack_dir_name(filename)
     packs_path = os.path.join(os.getcwd(), "Packs")
     pack_path = os.path.join(packs_path, pack_name)
     os.makedirs(pack_path, exist_ok=True)

--- a/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager.yml
+++ b/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager.yml
@@ -48,7 +48,7 @@ script:
   script: ''
   type: python
   subtype: python3
-  dockerimage: demisto/xsoar-tools:1.0.0.11449351
+  dockerimage: demisto/demisto-sdk:1.38.14.6091684
   runonce: false
   commands:
   - name: socfw-install-pack

--- a/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager.yml
+++ b/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager.yml
@@ -31,6 +31,14 @@ configuration:
   name: proxy
   type: 8
   required: false
+- section: Connect
+  advanced: true
+  display: Pack catalog URL
+  name: catalog_url
+  defaultvalue: https://raw.githubusercontent.com/Palo-Cortex/secops-framework/refs/heads/main/pack_catalog.json
+  type: 0
+  required: false
+  additionalinfo: Location of the SOC Framework pack_catalog.json. Override to point at a fork or branch. Leave empty to use the SOC Framework repository default.
 script:
   script: ''
   type: python
@@ -62,6 +70,13 @@ script:
     - contextPath: SOCFramework.PackInstall.response
       description: Raw response from demisto-sdk upload_content_entity.
       type: Unknown
+  - name: socfw-get-catalog-url
+    description: Return the SOC Framework pack catalog URL configured on this instance. Called by the SOCFWPackManager script so the catalog location is set once on the instance instead of passed as an argument on every run.
+    arguments: []
+    outputs:
+    - contextPath: SOCFramework.PackManager.CatalogURL
+      description: Pack catalog URL configured on this instance, or the SOC Framework default when the field is empty.
+      type: String
 commonfields:
   id: SOCFWPackManager
   version: -1

--- a/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager.yml
+++ b/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager.yml
@@ -2,6 +2,7 @@ display: SOC Framework Pack Manager
 name: SOCFWPackManager
 description: Downloads a SOC Framework content pack from a ZIP URL and installs it on the tenant as system content. Used internally by the SOCFWPackManager script — end users invoke the script, not this integration directly.
 category: Utilities
+supportlevelheader: community
 fromversion: 8.0.0
 system: true
 sectionorder:
@@ -9,12 +10,14 @@ sectionorder:
 configuration:
 - section: Connect
   display: Server URL
+  additionalinfo: The tenant API URL or tenant URL. The integration adds the api- prefix when it is missing.
   name: url
   defaultvalue: ''
   type: 0
   required: true
 - section: Connect
   display: API Key ID
+  additionalinfo: The numeric ID of the Standard API key, shown in the API Keys table, with the key secret itself as the password.
   displaypassword: API Key
   name: credentials
   type: 9
@@ -22,12 +25,14 @@ configuration:
 - section: Connect
   advanced: true
   display: Trust any certificate (not secure)
+  additionalinfo: Whether to disable TLS certificate validation. Off by default.
   name: insecure
   type: 8
   required: false
 - section: Connect
   advanced: true
   display: Use system proxy settings
+  additionalinfo: Whether to route HTTP traffic through the system proxy. Off by default.
   name: proxy
   type: 8
   required: false
@@ -38,12 +43,12 @@ configuration:
   defaultvalue: https://raw.githubusercontent.com/Palo-Cortex/secops-framework/refs/heads/main/pack_catalog.json
   type: 0
   required: false
-  additionalinfo: Location of the SOC Framework pack_catalog.json. Override to point at a fork or branch. Leave empty to use the SOC Framework repository default.
+  additionalinfo: The location of the SOC Framework pack_catalog.json. Override to point at a fork or branch. Leave empty to use the SOC Framework repository default.
 script:
   script: ''
   type: python
   subtype: python3
-  dockerimage: demisto/xsoar-tools:1.0.0.8457987
+  dockerimage: demisto/xsoar-tools:1.0.0.11449351
   runonce: false
   commands:
   - name: socfw-install-pack
@@ -70,12 +75,12 @@ script:
     - contextPath: SOCFramework.PackInstall.response
       description: Raw response from demisto-sdk upload_content_entity.
       type: Unknown
-  - name: socfw-get-catalog-url
-    description: Return the SOC Framework pack catalog URL configured on this instance. Called by the SOCFWPackManager script so the catalog location is set once on the instance instead of passed as an argument on every run.
+  - name: socfw-catalog-url-get
+    description: Returns the SOC Framework pack catalog URL configured on this instance. Called by the SOCFWPackManager script so the catalog location is set once on the instance instead of passed as an argument on every run.
     arguments: []
     outputs:
     - contextPath: SOCFramework.PackManager.CatalogURL
-      description: Pack catalog URL configured on this instance, or the SOC Framework default when the field is empty.
+      description: The pack catalog URL configured on this instance, or the SOC Framework default when the field is empty.
       type: String
 commonfields:
   id: SOCFWPackManager

--- a/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager_description.md
+++ b/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager_description.md
@@ -1,0 +1,28 @@
+Internal HTTP layer used by the **SOCFWPackManager** script to install SOC Framework content packs as system content. End users run the script, not this integration directly.
+
+### Create an API key
+
+1. Navigate to **Settings** > **Configurations** > **API Keys** and create a Standard API key.
+2. Copy the **Key** and note its numeric **ID** from the table.
+3. Click **Copy URL** to capture the tenant Server URL.
+
+### Configure the instance
+
+| Parameter | Value |
+| --- | --- |
+| Server URL | The copied tenant URL. The integration adds the `api-` prefix when it is missing. |
+| API Key ID | The numeric ID from the API Keys table. |
+| API Key | The secret value of the key. Stored masked. |
+| Pack catalog URL | Optional. Location of the SOC Framework `pack_catalog.json`. Leave empty to use the SOC Framework repository. |
+
+The API key requires the **Instance Administrator** role, because installing content as system content and creating integration instances cannot be delegated to a custom role.
+
+Click **Test** to confirm the URL and credentials, then **Done**.
+
+### Usage
+
+Run the script from the Playground:
+
+`!SOCFWPackManager action=list`
+
+`!SOCFWPackManager action=apply pack_id=soc-optimization-unified`

--- a/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager_description.md
+++ b/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager_description.md
@@ -1,4 +1,6 @@
-Internal HTTP layer used by the **SOCFWPackManager** script to install SOC Framework content packs as system content. End users run the script, not this integration directly.
+## SOCFWPackManager
+
+Internal HTTP layer used by the **SOCFWPackManager** script. End users run the script, not this integration directly.
 
 ### Create an API key
 
@@ -18,11 +20,3 @@ Internal HTTP layer used by the **SOCFWPackManager** script to install SOC Frame
 The API key requires the **Instance Administrator** role, because installing content as system content and creating integration instances cannot be delegated to a custom role.
 
 Click **Test** to confirm the URL and credentials, then **Done**.
-
-### Usage
-
-Run the script from the Playground:
-
-`!SOCFWPackManager action=list`
-
-`!SOCFWPackManager action=apply pack_id=soc-optimization-unified`

--- a/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager_test.py
+++ b/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager_test.py
@@ -547,3 +547,32 @@ def test_get_catalog_url_command_defaults_when_unset():
     for params in ({}, {"catalog_url": ""}, {"catalog_url": "   "}, {"catalog_url": None}):
         res = integration.get_catalog_url_command(params)
         assert res["outputs"]["CatalogURL"] == integration.DEFAULT_CATALOG_URL, params
+
+
+def test_pack_dir_name_keeps_version_like_strings_mid_filename():
+    """Only a trailing version suffix is a version.
+
+    A version-like component in the middle of the name is part of the pack ID
+    and must survive, and a legitimate trailing word must not be mistaken for a
+    pre-release tag -- "soc-v3-tools" previously reduced to "soc", which would
+    install the pack under the wrong ID.
+    """
+    integration, _ = load_integration()
+    cases = {
+        # Version-like component mid-name, real version at the end.
+        "soc-v2-endpoint-v1.0.0.zip": "soc-v2-endpoint",
+        "my-v10-agent-v2.5.zip": "my-v10-agent",
+        # Version-like component mid-name, no trailing version.
+        "soc-v3-tools.zip": "soc-v3-tools",
+        "soc-v2-endpoint.zip": "soc-v2-endpoint",
+        # Recognized pre-release tags are still stripped with the version.
+        "soc-pack-v1.2.3-pr1008.zip": "soc-pack",
+        "soc-pack-v1.2.3-rc2.zip": "soc-pack",
+        "soc-pack-v1.2.3-beta.zip": "soc-pack",
+        # An unrecognized trailing word is not a pre-release tag.
+        "soc-pack-v1.2.3-tools.zip": "soc-pack-v1.2.3-tools",
+        # Case-insensitive on the version marker.
+        "soc-pack-V1.2.3.zip": "soc-pack",
+    }
+    for given, expected in cases.items():
+        assert integration.pack_dir_name(given) == expected, given

--- a/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager_test.py
+++ b/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager_test.py
@@ -388,7 +388,10 @@ def test_command_install_pack_calls_download_and_sdk(tmp_path):
         os.chdir(orig)
 
     assert sdk_calls, "upload_pack_as_system_content should be called"
-    assert "Pack-v1.0.0" in sdk_calls[0]["pack_path"]
+    # The pack directory name becomes the pack ID on the tenant, so the release
+    # version must not survive into it.
+    assert sdk_calls[0]["pack_path"].endswith(os.sep + "Pack")
+    assert "Pack-v1.0.0" not in os.path.basename(sdk_calls[0]["pack_path"])
     assert sdk_calls[0]["verify"] is True
     # CommandResults stub returns kwargs; outputs include the filename.
     assert result.get("outputs", {}).get("filename") == "Pack-v1.0.0.zip"
@@ -494,3 +497,36 @@ def test_command_install_pack_appends_zip_if_missing(monkeypatch):
 
     assert derived
     assert derived[0].endswith(".zip")
+
+
+def test_pack_dir_name_strips_release_version():
+    """Regression: the pack directory name becomes the pack ID on the tenant,
+    so leaving the version on installed every release as a separate pack --
+    soc-optimization-unified-v3.11.2 alongside soc-optimization-unified --
+    rather than upgrading in place.
+    """
+    integration, _ = load_integration()
+    cases = {
+        "soc-optimization-unified.zip": "soc-optimization-unified",
+        "soc-optimization-unified-v3.11.2.zip": "soc-optimization-unified",
+        "soc-optimization-unified-v3.11.1-pr1008.zip": "soc-optimization-unified",
+        "soc-optimization-unified-v3.11.2": "soc-optimization-unified",
+        "SocFrameworkAbnormalSecurity-v1.0.4.zip": "SocFrameworkAbnormalSecurity",
+        "soc-vendor-thing.zip": "soc-vendor-thing",
+    }
+    for given, expected in cases.items():
+        assert integration.pack_dir_name(given) == expected, given
+
+
+def test_prepare_pack_dir_uses_version_stripped_directory(tmp_path, monkeypatch):
+    integration, _ = load_integration()
+    monkeypatch.chdir(tmp_path)
+
+    zip_path = tmp_path / "soc-optimization-unified-v3.11.2.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("soc-optimization-unified/pack_metadata.json", '{"name": "SOC Framework Unified"}')
+
+    pack_path = integration._prepare_pack_dir(str(zip_path), "soc-optimization-unified-v3.11.2.zip")
+
+    assert os.path.basename(pack_path) == "soc-optimization-unified"
+    assert not os.path.exists(tmp_path / "Packs" / "soc-optimization-unified-v3.11.2")

--- a/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager_test.py
+++ b/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager_test.py
@@ -576,3 +576,31 @@ def test_pack_dir_name_keeps_version_like_strings_mid_filename():
     }
     for given, expected in cases.items():
         assert integration.pack_dir_name(given) == expected, given
+
+
+def test_get_catalog_url_command_rejects_a_relative_url():
+    """A scheme-less value would resolve against the tenant host at fetch time
+    and surface as a confusing 404, so it is reported and ignored here.
+    """
+    integration, _ = load_integration()
+    for bad in (
+        "raw.githubusercontent.com/org/repo/main/pack_catalog.json",
+        "/Packs/pack_catalog.json",
+        "ftp://example.com/pack_catalog.json",
+        "not a url",
+        "https:///pack_catalog.json",
+    ):
+        res = integration.get_catalog_url_command({"catalog_url": bad})
+        assert res["outputs"]["CatalogURL"] == integration.DEFAULT_CATALOG_URL, bad
+        assert "ignored" in res["readable_output"], bad
+
+
+def test_get_catalog_url_command_accepts_a_valid_override():
+    integration, _ = load_integration()
+    for good in (
+        "https://fork.example/pack_catalog.json",
+        "http://internal.example:8080/catalog/pack_catalog.json",
+    ):
+        res = integration.get_catalog_url_command({"catalog_url": good})
+        assert res["outputs"]["CatalogURL"] == good, good
+        assert "ignored" not in res["readable_output"], good

--- a/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager_test.py
+++ b/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/SOCFWPackManager_test.py
@@ -530,3 +530,20 @@ def test_prepare_pack_dir_uses_version_stripped_directory(tmp_path, monkeypatch)
 
     assert os.path.basename(pack_path) == "soc-optimization-unified"
     assert not os.path.exists(tmp_path / "Packs" / "soc-optimization-unified-v3.11.2")
+
+
+def test_get_catalog_url_command_returns_configured_value():
+    """A script cannot read another integration instance's parameters, so the
+    configured catalog location is surfaced through this command instead.
+    """
+    integration, _ = load_integration()
+    res = integration.get_catalog_url_command({"catalog_url": "https://fork.example/pack_catalog.json"})
+    assert res["outputs"] == {"CatalogURL": "https://fork.example/pack_catalog.json"}
+    assert res["raw_response"] == {"catalog_url": "https://fork.example/pack_catalog.json"}
+
+
+def test_get_catalog_url_command_defaults_when_unset():
+    integration, _ = load_integration()
+    for params in ({}, {"catalog_url": ""}, {"catalog_url": "   "}, {"catalog_url": None}):
+        res = integration.get_catalog_url_command(params)
+        assert res["outputs"]["CatalogURL"] == integration.DEFAULT_CATALOG_URL, params

--- a/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/command_examples.txt
+++ b/Packs/SocFrameworkManager/Integrations/SOCFWPackManager/command_examples.txt
@@ -1,0 +1,1 @@
+!socfw-catalog-url-get

--- a/Packs/SocFrameworkManager/README.md
+++ b/Packs/SocFrameworkManager/README.md
@@ -5,10 +5,11 @@ Playground. No manual ZIP uploads, no separate REST API tooling.
 
 ## What does this pack do?
 
-- Browses the SOC Framework pack catalog from the XSIAM Playground
+- Browses the SOC Framework pack catalog from the XSIAM Playground, showing which packs are installed and which have updates available
 - Installs and updates SOC Framework content packs as system content
 - Applies integration instances, jobs, and lookup datasets from each pack's `xsoar_config.json`
 - Re-runs configuration without reinstalling, for recovery or config changes
+- Diagnoses the platform endpoints the install path depends on, to identify the cause when an install misbehaves
 - Synchronizes the legacy `value_tags` lookup for older deployments still using it
 
 ## Quick Start
@@ -17,6 +18,7 @@ Playground. No manual ZIP uploads, no separate REST API tooling.
 !SOCFWPackManager action=list
 !SOCFWPackManager action=apply pack_id=soc-optimization-unified
 !SOCFWPackManager action=configure pack_id=SocFrameworkTrendMicroVisionOne
+!SOCFWPackManager action=diagnose
 ```
 
 ## Prerequisites
@@ -43,8 +45,19 @@ passed as command arguments.
 !SOCFWPackManager action=list filter=crowdstrike
 ```
 
-Lists all available SOC Framework packs with ID, version, and path. Use
-`filter=` to narrow results.
+Lists all available SOC Framework packs grouped by catalog category, showing
+the installed version, whether an update is available, and a link to each
+pack's documentation. Use `filter=` to narrow results.
+
+### `action=diagnose` — Check the install path
+
+```
+!SOCFWPackManager action=diagnose
+```
+
+Probes each platform endpoint the install path depends on and reports which
+one fails. Read-only; nothing is installed or modified. Run this first when an
+install misbehaves.
 
 ### `action=apply` — Install or update a pack
 

--- a/Packs/SocFrameworkManager/README.md
+++ b/Packs/SocFrameworkManager/README.md
@@ -1,11 +1,11 @@
 # SOC Framework Pack Manager
 
-Install and configure SOC Framework content packs directly from the XSIAM
+Install and configure SOC Framework content packs directly from the Cortex XSIAM
 Playground. No manual ZIP uploads, no separate REST API tooling.
 
 ## What does this pack do?
 
-- Browses the SOC Framework pack catalog from the XSIAM Playground, showing which packs are installed and which have updates available
+- Browses the SOC Framework pack catalog from the Cortex XSIAM Playground, showing which packs are installed and which have updates available
 - Installs and updates SOC Framework content packs as system content
 - Applies integration instances, jobs, and lookup datasets from each pack's `xsoar_config.json`
 - Re-runs configuration without reinstalling, for recovery or config changes

--- a/Packs/SocFrameworkManager/README.md
+++ b/Packs/SocFrameworkManager/README.md
@@ -9,7 +9,7 @@ Playground. No manual ZIP uploads, no separate REST API tooling.
 - Installs and updates SOC Framework content packs as system content
 - Applies integration instances, jobs, and lookup datasets from each pack's `xsoar_config.json`
 - Re-runs configuration without reinstalling, for recovery or config changes
-- Diagnoses the platform endpoints the install path depends on, to identify the cause when an install misbehaves
+- Diagnoses the Cortex XSIAM platform endpoints the install path depends on, so the cause of a failed install can be identified
 - Synchronizes the legacy `value_tags` lookup for older deployments still using it
 
 ## Quick Start
@@ -55,9 +55,9 @@ pack's documentation. Use `filter=` to narrow results.
 !SOCFWPackManager action=diagnose
 ```
 
-Probes each platform endpoint the install path depends on and reports which
-one fails. Read-only; nothing is installed or modified. Run this first when an
-install misbehaves.
+Probes each Cortex XSIAM platform endpoint that the install path depends on and
+reports which one fails. This action is read-only; nothing is installed or
+modified. Run it first when an install does not behave as expected.
 
 ### `action=apply` — Install or update a pack
 
@@ -101,7 +101,7 @@ For deployments still running on the legacy `value_tags` lookup, this
 downloads `value_tags.json` from the SOC Framework repository and updates
 the `value_tags` lookup dataset, comparing a content hash against the
 previously stored version. If unchanged, the upload is skipped. Version
-state is stored in the `SOCFWTagsVersion` XSIAM List (visible at
+state is stored in the `SOCFWTagsVersion` Cortex XSIAM List (visible at
 **Settings** > **Advanced** > **Lists**).
 
 ## Recommended Installation Order
@@ -142,7 +142,7 @@ This pack ships two pieces that work together:
   as system content. The integration is internal plumbing; end users do not
   call it directly.
 
-The split exists because XSIAM integrations cannot call
+The split exists because Cortex XSIAM integrations cannot call
 `demisto.executeCommand`, so all multi-step orchestration must live in the
 script. The integration handles only the work that needs raw HTTP.
 

--- a/Packs/SocFrameworkManager/ReleaseNotes/1_0_1.md
+++ b/Packs/SocFrameworkManager/ReleaseNotes/1_0_1.md
@@ -6,13 +6,17 @@
 - Fixed an issue where each release of a pack was installed as a separate pack instead of upgrading the existing one.
 - Fixed an issue where the reason for a failed pack upload was not reported.
 - Added the **Pack catalog URL** parameter, which sets the location of the SOC Framework pack catalog on the instance. Defaults to the SOC Framework repository.
-- Added the ***socfw-get-catalog-url*** command, which returns the configured pack catalog URL.
+- Added the ***socfw-get-catalog-url*** command, which returns the pack catalog URL configured on the instance.
 
 #### Scripts
 
 ##### SOCFWPackManager
 
-- Added the **diagnose** action, which probes the platform endpoints the install path depends on and reports which one fails.
+- Marketplace pack installation no longer requires the **XSIAMContentPackInstaller** automation. Packs and their mandatory dependencies are installed through the platform marketplace endpoints instead. The *ConfigurationSetup.MarketplacePacks* context output is unchanged.
+- Fixed an issue where an install that completed successfully but returned an HTTP 500 was reported as a failure.
+- Added the **diagnose** action, which probes each platform endpoint the marketplace install path depends on and reports which one fails.
+- The **apply** action now resolves the full mandatory dependency set before installing, and reports when a requested pack is already satisfied.
+- The **list** action now reports the installed version and update status of each pack, groups packs under their catalog category, and links each pack to its documentation.
+- The **list** action now renders one line per pack by default, because the War Room transposes single-row tables. Set *output_format* to `table` for the previous behavior.
 - Added the *probe_pack*, *docs_base_url*, *group_by_category*, *output_format*, and *upgrade_marketplace* arguments.
-- The **list** action now reports the installed version of each pack alongside the catalog version.
-- The **apply** action now resolves mandatory dependencies before installing, and confirms a pack is installed before reporting a failure.
+- The catalog location is now read from the **SOC Framework Pack Manager** integration instance when the *catalog_url* argument is not supplied.

--- a/Packs/SocFrameworkManager/ReleaseNotes/1_0_1.md
+++ b/Packs/SocFrameworkManager/ReleaseNotes/1_0_1.md
@@ -1,0 +1,16 @@
+
+#### Integrations
+
+##### SOC Framework Pack Manager
+
+- Fixed an issue where each release of a pack was installed as a separate pack instead of upgrading the existing one.
+- Fixed an issue where the reason for a failed pack upload was not reported.
+
+#### Scripts
+
+##### SOCFWPackManager
+
+- Added the **diagnose** action, which probes the platform endpoints the install path depends on and reports which one fails.
+- Added the *probe_pack*, *docs_base_url*, *group_by_category*, *output_format*, and *upgrade_marketplace* arguments.
+- The **list** action now reports the installed version of each pack alongside the catalog version.
+- The **apply** action now resolves mandatory dependencies before installing, and confirms a pack is installed before reporting a failure.

--- a/Packs/SocFrameworkManager/ReleaseNotes/1_0_1.md
+++ b/Packs/SocFrameworkManager/ReleaseNotes/1_0_1.md
@@ -5,6 +5,8 @@
 
 - Fixed an issue where each release of a pack was installed as a separate pack instead of upgrading the existing one.
 - Fixed an issue where the reason for a failed pack upload was not reported.
+- Added the **Pack catalog URL** parameter, which sets the location of the SOC Framework pack catalog on the instance. Defaults to the SOC Framework repository.
+- Added the ***socfw-get-catalog-url*** command, which returns the configured pack catalog URL.
 
 #### Scripts
 

--- a/Packs/SocFrameworkManager/ReleaseNotes/1_1_0.md
+++ b/Packs/SocFrameworkManager/ReleaseNotes/1_1_0.md
@@ -6,18 +6,20 @@
 - Fixed an issue where each release of a pack was installed as a separate pack instead of upgrading the existing one.
 - Fixed an issue where the reason for a failed pack upload was not reported.
 - Added the **Pack catalog URL** parameter, which sets the location of the SOC Framework pack catalog on the instance. Defaults to the SOC Framework repository.
-- Added the ***socfw-get-catalog-url*** command, which returns the pack catalog URL configured on the instance.
+- Added the ***socfw-catalog-url-get*** command, which returns the pack catalog URL configured on the instance.
+- Updated the Docker image to *demisto/xsoar-tools:1.0.0.11449351*.
 
 #### Scripts
 
 ##### SOCFWPackManager
 
 - Marketplace pack installation no longer requires the **XSIAMContentPackInstaller** automation. Packs and their mandatory dependencies are installed through the platform marketplace endpoints instead. The *ConfigurationSetup.MarketplacePacks* context output is unchanged.
-- Fixed an issue where an install that completed successfully but returned an HTTP 500 was reported as a failure.
 - Added the **diagnose** action, which probes each platform endpoint the marketplace install path depends on and reports which one fails.
+- Added the *probe_pack*, *docs_base_url*, *group_by_category*, *output_format*, and *upgrade_marketplace* arguments.
+- Fixed an issue where an install that completed successfully but returned an HTTP 500 was reported as a failure.
+- Fixed an issue where a pre-release version suffix caused an incorrect version comparison, so that a version such as *1.0.6-pr1008* compared as greater than *1.0.6*.
+- Fixed an issue where a pack that was both requested and resolved as another pack's dependency could be returned to its installed version, undoing a requested upgrade.
 - The **apply** action now resolves the full mandatory dependency set before installing, and reports when a requested pack is already satisfied.
 - The **list** action now reports the installed version and update status of each pack, groups packs under their catalog category, and links each pack to its documentation.
-- The **list** action output was redesigned: each pack is prefixed with a status marker, pack IDs are emphasized and aligned so versions form a column, and the header summarizes the counts per status.
-- The **list** action now renders one line per pack by default, because the War Room transposes single-row tables. Set *output_format* to `table` for the previous behavior.
-- Added the *probe_pack*, *docs_base_url*, *group_by_category*, *output_format*, and *upgrade_marketplace* arguments.
+- The **list** action now renders one line per pack by default, and prefixes each pack with a status marker. Set *output_format* to *table* for the previous behavior.
 - The catalog location is now read from the **SOC Framework Pack Manager** integration instance when the *catalog_url* argument is not supplied.

--- a/Packs/SocFrameworkManager/ReleaseNotes/1_1_0.md
+++ b/Packs/SocFrameworkManager/ReleaseNotes/1_1_0.md
@@ -17,6 +17,7 @@
 - Added the **diagnose** action, which probes each platform endpoint the marketplace install path depends on and reports which one fails.
 - The **apply** action now resolves the full mandatory dependency set before installing, and reports when a requested pack is already satisfied.
 - The **list** action now reports the installed version and update status of each pack, groups packs under their catalog category, and links each pack to its documentation.
+- The **list** action output was redesigned: each pack is prefixed with a status marker, pack IDs are emphasized and aligned so versions form a column, and the header summarizes the counts per status.
 - The **list** action now renders one line per pack by default, because the War Room transposes single-row tables. Set *output_format* to `table` for the previous behavior.
 - Added the *probe_pack*, *docs_base_url*, *group_by_category*, *output_format*, and *upgrade_marketplace* arguments.
 - The catalog location is now read from the **SOC Framework Pack Manager** integration instance when the *catalog_url* argument is not supplied.

--- a/Packs/SocFrameworkManager/ReleaseNotes/1_1_0.md
+++ b/Packs/SocFrameworkManager/ReleaseNotes/1_1_0.md
@@ -7,7 +7,7 @@
 - Fixed an issue where a pack whose name ended in a non-version component, such as *soc-v3-tools*, had that component removed and was installed under the wrong pack ID.
 - Fixed an issue where the reason for a failed pack upload was not reported.
 - Added the *Pack catalog URL* parameter, which sets the location of the SOC Framework pack catalog on the instance. Defaults to the SOC Framework repository.
-- Added the ***socfw-catalog-url-get*** command, which returns the pack catalog URL configured on the instance.
+- Added the ***socfw-catalog-url-get*** command, which returns the pack catalog URL configured on the instance. A configured value that is not an absolute HTTP or HTTPS URL is reported and ignored in favor of the default.
 - Updated the Docker image to *demisto/demisto-sdk:1.38.14.6091684*.
 
 #### Scripts

--- a/Packs/SocFrameworkManager/ReleaseNotes/1_1_0.md
+++ b/Packs/SocFrameworkManager/ReleaseNotes/1_1_0.md
@@ -4,8 +4,9 @@
 ##### SOC Framework Pack Manager
 
 - Fixed an issue where each release of a pack was installed as a separate pack instead of upgrading the existing one.
+- Fixed an issue where a pack whose name ended in a non-version component, such as *soc-v3-tools*, had that component removed and was installed under the wrong pack ID.
 - Fixed an issue where the reason for a failed pack upload was not reported.
-- Added the **Pack catalog URL** parameter, which sets the location of the SOC Framework pack catalog on the instance. Defaults to the SOC Framework repository.
+- Added the *Pack catalog URL* parameter, which sets the location of the SOC Framework pack catalog on the instance. Defaults to the SOC Framework repository.
 - Added the ***socfw-catalog-url-get*** command, which returns the pack catalog URL configured on the instance.
 - Updated the Docker image to *demisto/demisto-sdk:1.38.14.6091684*.
 
@@ -13,13 +14,13 @@
 
 ##### SOCFWPackManager
 
-- Marketplace pack installation no longer requires the **XSIAMContentPackInstaller** automation. Packs and their mandatory dependencies are installed through the platform marketplace endpoints instead. The *ConfigurationSetup.MarketplacePacks* context output is unchanged.
-- Added the **diagnose** action, which probes each platform endpoint the marketplace install path depends on and reports which one fails.
+- Added the *diagnose* action, which probes each platform endpoint the marketplace install path depends on and reports which one fails.
 - Added the *probe_pack*, *docs_base_url*, *group_by_category*, *output_format*, and *upgrade_marketplace* arguments.
+- Updated marketplace pack installation to use the platform marketplace endpoints, so the *XSIAMContentPackInstaller* automation is no longer required. The *ConfigurationSetup.MarketplacePacks* context output is unchanged.
+- Updated the *apply* action to resolve the full mandatory dependency set before installing, and to report when a requested pack is already satisfied.
+- Updated the *list* action to report the installed version and update status of each pack, to group packs under their catalog category, and to link each pack to its documentation.
+- Updated the *list* action to render one line per pack by default, prefixed with a status marker. Set *output_format* to *table* for the previous behavior.
+- Updated the catalog location to be read from the *SOC Framework Pack Manager* integration instance when the *catalog_url* argument is not supplied.
 - Fixed an issue where an install that completed successfully but returned an HTTP 500 was reported as a failure.
-- Fixed an issue where a pre-release version suffix caused an incorrect version comparison, so that a version such as *1.0.6-pr1008* compared as greater than *1.0.6*.
+- Fixed an issue where a pre-release version suffix caused an incorrect version comparison, so that a version such as *1.0.6-pr1008* compared as greater than *1.0.7*.
 - Fixed an issue where a pack that was both requested and resolved as another pack's dependency could be returned to its installed version, undoing a requested upgrade.
-- The **apply** action now resolves the full mandatory dependency set before installing, and reports when a requested pack is already satisfied.
-- The **list** action now reports the installed version and update status of each pack, groups packs under their catalog category, and links each pack to its documentation.
-- The **list** action now renders one line per pack by default, and prefixes each pack with a status marker. Set *output_format* to *table* for the previous behavior.
-- The catalog location is now read from the **SOC Framework Pack Manager** integration instance when the *catalog_url* argument is not supplied.

--- a/Packs/SocFrameworkManager/ReleaseNotes/1_1_0.md
+++ b/Packs/SocFrameworkManager/ReleaseNotes/1_1_0.md
@@ -7,7 +7,7 @@
 - Fixed an issue where the reason for a failed pack upload was not reported.
 - Added the **Pack catalog URL** parameter, which sets the location of the SOC Framework pack catalog on the instance. Defaults to the SOC Framework repository.
 - Added the ***socfw-catalog-url-get*** command, which returns the pack catalog URL configured on the instance.
-- Updated the Docker image to *demisto/xsoar-tools:1.0.0.11449351*.
+- Updated the Docker image to *demisto/demisto-sdk:1.38.14.6091684*.
 
 #### Scripts
 

--- a/Packs/SocFrameworkManager/ReleaseNotes/1_1_0.md
+++ b/Packs/SocFrameworkManager/ReleaseNotes/1_1_0.md
@@ -21,6 +21,7 @@
 - Updated the *list* action to report the installed version and update status of each pack, to group packs under their catalog category, and to link each pack to its documentation.
 - Updated the *list* action to render one line per pack by default, prefixed with a status marker. Set *output_format* to *table* for the previous behavior.
 - Updated the catalog location to be read from the *SOC Framework Pack Manager* integration instance when the *catalog_url* argument is not supplied.
+- Updated the *configure_lookups* argument to default to false, so lookup datasets are no longer created or populated from *xsoar_config.json* unless requested. A pack that ships a Lookup directory already brings its dataset with it.
 - Fixed an issue where an install that completed successfully but returned an HTTP 500 was reported as a failure.
 - Fixed an issue where a pre-release version suffix caused an incorrect version comparison, so that a version such as *1.0.6-pr1008* compared as greater than *1.0.7*.
 - Fixed an issue where a pack that was both requested and resolved as another pack's dependency could be returned to its installed version, undoing a requested upgrade.

--- a/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/README.md
+++ b/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/README.md
@@ -1,7 +1,9 @@
 SOC Framework Pack Manager — bootloader script for the SOC Framework on
-XSIAM. Lists the SOC Framework pack catalog, installs and configures packs,
-re-runs configuration only, and synchronizes the `value_tags` lookup against
-the catalog version metadata.
+XSIAM. Lists the SOC Framework pack catalog with the installed version and
+update status of each pack, installs and configures packs, re-runs
+configuration only, diagnoses the platform endpoints the install path depends
+on, and synchronizes the `value_tags` lookup against the catalog version
+metadata.
 
 ## Architecture
 
@@ -24,7 +26,9 @@ through this script.
 
 | **Argument Name** | **Description** |
 | --- | --- |
-| action | One of `list`, `apply`, `configure`, or `sync-tags`. `list` shows the catalog. `apply` installs and configures a pack. `configure` re-runs configuration only (no pack install). `sync-tags` is a backward-compat action that updates the legacy `value_tags` lookup; modern SOC Framework deployments use `SOCActionTimeMap_V3` and do not need it. |
+| action | One of `list`, `apply`, `configure`, `sync-tags`, or `diagnose`. `list` shows the catalog with the installed version and update status of each pack. `apply` installs and configures a pack. `configure` re-runs configuration only (no pack install). `diagnose` probes every platform endpoint the marketplace install path depends on and reports which one fails; run it first when an install misbehaves. `sync-tags` is a backward-compat action that updates the legacy `value_tags` lookup; modern SOC Framework deployments use `SOCActionTimeMap_V3` and do not need it. |
+| probe_pack | `action=diagnose` only. Pack ID used to probe the marketplace metadata and dependency endpoints. Defaults to `Whois` because it is a stock Marketplace pack present on effectively every tenant, which makes it a dependable read-only probe target. Nothing is installed or modified. Falls back to an installed pack if this one is absent. |
+| upgrade_marketplace | `action=apply` only. Controls what a `marketplace_packs` entry of `latest` means. `false` (default) ensures the pack is present, leaving an already-installed pack at its current version. `true` brings each requested pack to the newest published version. Mandatory dependencies are never force-upgraded either way; they move only when a `minVersion` requires it. |
 | pack_id | The pack ID from `pack_catalog.json` (for example, `soc-optimization-unified`). Required for `action=apply` and `action=configure`. |
 | catalog_url | Override the catalog URL without modifying the integration instance parameters. |
 | using | Integration instance name to route core-api commands through. Defaults to the active instance. |
@@ -50,10 +54,13 @@ through this script.
 | filter | `action=list` only. Case-insensitive free-text filter applied to id, display_name, and path. |
 | limit | `action=list` only. Maximum number of rows to display per page. |
 | offset | `action=list` only. Row offset for paging. |
-| sort_by | `action=list` only. Column to sort by. One of `id`, `display_name`, `version`, `visible`, `path`. |
+| sort_by | `action=list` only. Column to sort by. One of `id`, `display_name`, `category`, `version`, `installed`, `status`, `visible`, or `path`. Ignored for ordering between categories when `group_by_category=true`. |
 | sort_dir | `action=list` only. Sort direction. `asc` or `desc`. |
 | visible_only | `action=list` only. Hide packs marked `visible=false`. Implied false when `include_hidden=true`. |
-| fields | `action=list` only. Comma-separated list of columns to show. Unknown fields are ignored. |
+| fields | `action=list` only. Comma-separated list of columns to show when `output_format=table`. Available columns are `id`, `display_name`, `category`, `version`, `installed`, `status`, `docs`, `visible`, and `path`. Unknown fields are ignored. |
+| group_by_category | `action=list` only. Group packs under their catalog category, one section per category. Set to `false` for a single flat list. |
+| output_format | `action=list` only. `list` renders one line per pack and is the default, because the War Room transposes single-row tables and truncates long ones. `table` renders the columns named in `fields`. |
+| docs_base_url | `action=list` only. Absolute base URL of the documentation site. The catalog supplies each pack's relative `docs_path`, and this value supplies the host, so each pack ID renders as a link to its overview page. Must be absolute, otherwise the link resolves against the tenant host. Set to an empty value to disable linking. |
 | show_total | `action=list` only. Display "showing X-Y of Z" paging information. |
 | include_doc_content | When printing pre and post config docs, also fetch a truncated preview of the README content into the War Room output. |
 | doc_content_max_chars | Maximum characters per doc preview when `include_doc_content=true`. |
@@ -70,6 +77,10 @@ through this script.
 | SOCFramework.PackManager.pack_id | Pack ID acted on for `action=apply` or `action=configure`. | String |
 | SOCFramework.PackManager.xsoar_config_url | URL of the `xsoar_config.json` fetched for the pack. | String |
 | SOCFramework.PackManager.catalog_url | URL of the pack catalog used to resolve the manifest. | String |
+| SOCFramework.PackManager.Diagnose.check | `action=diagnose` only. Name of the probed check. | String |
+| SOCFramework.PackManager.Diagnose.detail | `action=diagnose` only. What the probe observed. | String |
+| SOCFramework.PackManager.Diagnose.endpoint | `action=diagnose` only. Platform endpoint the check exercised. | String |
+| SOCFramework.PackManager.Diagnose.result | `action=diagnose` only. `pass` or `fail`. | String |
 | SOCFramework.PackManager.marketplace_errors | Marketplace install errors recorded during `action=apply`. | Unknown |
 | SOCFramework.PackManager.configure_summary.integrations | Integration instance configuration summary. | Unknown |
 | SOCFramework.PackManager.configure_summary.jobs | Job configuration summary. | Unknown |
@@ -91,7 +102,15 @@ through this script.
 
 ##### Human Readable Output
 
-> Renders a paged table of available SOC Framework packs (id, display_name, version, visible, path).
+> Lists the available SOC Framework packs grouped by catalog category. Each pack is prefixed with a status marker — 🔵 update available, ⚪ not installed, 🟢 up to date, 🟠 installed ahead of the catalog — followed by the pack ID, the version detail, and a link to the pack documentation. The header summarizes the counts per status.
+
+#### action=diagnose
+
+```!SOCFWPackManager action=diagnose```
+
+##### Human Readable Output
+
+> Probes each platform endpoint the marketplace install path depends on — the Core REST API instance, the installed-packs metadata endpoint, marketplace metadata resolution, and dependency lookup — and reports pass or fail per check with the endpoint exercised. Read-only; nothing is installed or modified. Run this first when an install misbehaves, to identify which endpoint is at fault before retrying.
 
 #### action=apply
 

--- a/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/README.md
+++ b/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/README.md
@@ -43,7 +43,7 @@ This script uses the following commands and scripts.
 | overwrite_lookup | Overwrite the SOC Framework lookup table. Save your customizations first. |
 | configure_jobs | When action=apply, run job configuration from xsoar_config.json. Ignored if apply_configure=false. |
 | configure_integrations | When action=apply, create or update integration instances from xsoar_config.json. Ignored if apply_configure=false. |
-| configure_lookups | When action=apply, create or update lookup datasets from xsoar_config.json. Ignored if apply_configure=false. |
+| configure_lookups | Whether to create or update lookup datasets from xsoar_config.json, for the apply and configure actions. A pack that ships a Lookup directory already brings its dataset with it, so configuring it again is redundant. Ignored when apply_configure is false. |
 | retry_count | Number of retry attempts for install or configure operations that fail transiently. |
 | retry_sleep_seconds | Seconds to wait between retry attempts. |
 | execution_timeout | Timeout in seconds for individual core-api commands invoked during configure. |

--- a/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/README.md
+++ b/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/README.md
@@ -1,47 +1,49 @@
-SOC Framework Pack Manager — bootloader script for the SOC Framework on
-XSIAM. Lists the SOC Framework pack catalog with the installed version and
-update status of each pack, installs and configures packs, re-runs
-configuration only, diagnoses the platform endpoints the install path depends
-on, and synchronizes the `value_tags` lookup against the catalog version
-metadata.
-
-## Architecture
-
-This script is the user-facing entry point. It depends on the **SOC
-Framework Pack Manager** integration, also shipped in this pack, for
-credential storage and the actual pack-install HTTP. Configure an instance
-of that integration before running `action=apply`. End users should never
-call the integration's `socfw-install-pack` command directly — invoke it
-through this script.
+The SOC Framework bootloader for Cortex XSIAM. Lists the SOC Framework pack
+catalog with the installed version and update status of each pack, installs
+and configures packs from xsoar_config.json, re-runs configuration only, and
+diagnoses the platform endpoints the install path depends on. Also includes
+sync-tags, a backward-compatible action for older SOC Framework deployments
+still using the value_tags lookup; modern versions use the
+SOCActionTimeMap_V3 list and do not require it.
 
 ## Script Data
+
+---
 
 | **Name** | **Description** |
 | --- | --- |
 | Script Type | python3 |
 | Tags | configuration, Content Management, SOC, SOC_Framework, SOC_Framework_Unified, SOCFWBootloader |
-| Cortex XSIAM Version | 5.0.0 and later |
+| Cortex XSOAR Version | 5.0.0 |
+
+## Dependencies
+
+---
+This script uses the following commands and scripts.
+
+* Sleep
 
 ## Inputs
 
+---
+
 | **Argument Name** | **Description** |
 | --- | --- |
-| action | One of `list`, `apply`, `configure`, `sync-tags`, or `diagnose`. `list` shows the catalog with the installed version and update status of each pack. `apply` installs and configures a pack. `configure` re-runs configuration only (no pack install). `diagnose` probes every platform endpoint the marketplace install path depends on and reports which one fails; run it first when an install misbehaves. `sync-tags` is a backward-compat action that updates the legacy `value_tags` lookup; modern SOC Framework deployments use `SOCActionTimeMap_V3` and do not need it. |
-| probe_pack | `action=diagnose` only. Pack ID used to probe the marketplace metadata and dependency endpoints. Defaults to `Whois` because it is a stock Marketplace pack present on effectively every tenant, which makes it a dependable read-only probe target. Nothing is installed or modified. Falls back to an installed pack if this one is absent. |
-| upgrade_marketplace | `action=apply` only. Controls what a `marketplace_packs` entry of `latest` means. `false` (default) ensures the pack is present, leaving an already-installed pack at its current version. `true` brings each requested pack to the newest published version. Mandatory dependencies are never force-upgraded either way; they move only when a `minVersion` requires it. |
-| pack_id | The pack ID from `pack_catalog.json` (for example, `soc-optimization-unified`). Required for `action=apply` and `action=configure`. |
+| action | The action to run. The diagnose action probes every platform endpoint the marketplace install path depends on and reports which one fails; run it first when an install misbehaves. The list action shows the catalog. The apply action installs and configures a pack. The configure action re-runs configuration only, without installing a pack. The sync-tags action is a backward-compatible action that updates the legacy value_tags lookup; modern SOC Framework deployments use SOCActionTimeMap_V3 and do not need it. |
+| probe_pack | The pack ID used to probe the marketplace metadata and dependency endpoints, for the diagnose action only. Whois is a stock Marketplace pack present on effectively every tenant, which makes it a dependable read-only probe target; nothing is installed or modified. Falls back to an installed pack if this one is absent. |
+| pack_id | The pack ID from pack_catalog.json \(for example, soc-optimization-unified\). Required for action=apply. |
 | catalog_url | Override the catalog URL without modifying the integration instance parameters. |
 | using | Integration instance name to route core-api commands through. Defaults to the active instance. |
-| include_hidden | Allow installing packs where `visible=false` in the catalog. |
+| include_hidden | Allow installing packs where visible=false in the catalog. |
 | dry_run | Show what would happen without installing or configuring. |
-| install_marketplace | Whether to install `marketplace_packs` from `xsoar_config.json`. |
-| skip_verify | Pass-through to `core-api-install-packs` for ZIP installs. |
-| skip_validation | Pass-through to `core-api-install-packs` for ZIP installs. |
-| apply_configure | Whether to apply the config sections from `xsoar_config.json` (instances, jobs, lookups). |
+| install_marketplace | Whether to install marketplace_packs from xsoar_config.json. |
+| skip_verify | Pass-through to core-api-install-packs for ZIP installs. |
+| skip_validation | Pass-through to core-api-install-packs for ZIP installs. |
+| apply_configure | Whether to apply the config sections from xsoar_config.json \(instances, jobs, lookups\). |
 | overwrite_lookup | Overwrite the SOC Framework lookup table. Save your customizations first. |
-| configure_jobs | When `action=apply`, run job configuration from `xsoar_config.json`. Ignored if `apply_configure=false`. |
-| configure_integrations | When `action=apply`, create or update integration instances from `xsoar_config.json`. Ignored if `apply_configure=false`. |
-| configure_lookups | When `action=apply`, create or update lookup datasets from `xsoar_config.json`. Ignored if `apply_configure=false`. |
+| configure_jobs | When action=apply, run job configuration from xsoar_config.json. Ignored if apply_configure=false. |
+| configure_integrations | When action=apply, create or update integration instances from xsoar_config.json. Ignored if apply_configure=false. |
+| configure_lookups | When action=apply, create or update lookup datasets from xsoar_config.json. Ignored if apply_configure=false. |
 | retry_count | Number of retry attempts for install or configure operations that fail transiently. |
 | retry_sleep_seconds | Seconds to wait between retry attempts. |
 | execution_timeout | Timeout in seconds for individual core-api commands invoked during configure. |
@@ -49,89 +51,46 @@ through this script.
 | post_install_poll_seconds | After an install timeout, total seconds to poll the tenant for the pack to appear installed. |
 | post_install_poll_interval_seconds | Interval in seconds between install completion polls. |
 | continue_on_install_timeout | Continue with configuration steps if a custom-pack install times out and polling does not confirm installation. |
+| upgrade_marketplace | Whether a marketplace_packs entry of "latest" brings each requested pack to the newest published version, for the apply action only. When false, an already-installed pack keeps its current version. Mandatory dependencies are never force-upgraded either way; they move only when a minVersion requires it. Upgrading resolves versions from the marketplace, which returns large responses, so it is slower. |
 | fail_on_marketplace_errors | Raise on marketplace install errors instead of recording them and continuing. |
 | debug | Verbose War Room logging and additional install detail. |
-| filter | `action=list` only. Case-insensitive free-text filter applied to id, display_name, and path. |
-| limit | `action=list` only. Maximum number of rows to display per page. |
-| offset | `action=list` only. Row offset for paging. |
-| sort_by | `action=list` only. Column to sort by. One of `id`, `display_name`, `category`, `version`, `installed`, `status`, `visible`, or `path`. Ignored for ordering between categories when `group_by_category=true`. |
-| sort_dir | `action=list` only. Sort direction. `asc` or `desc`. |
-| visible_only | `action=list` only. Hide packs marked `visible=false`. Implied false when `include_hidden=true`. |
-| fields | `action=list` only. Comma-separated list of columns to show when `output_format=table`. Available columns are `id`, `display_name`, `category`, `version`, `installed`, `status`, `docs`, `visible`, and `path`. Unknown fields are ignored. |
-| group_by_category | `action=list` only. Group packs under their catalog category, one section per category. Set to `false` for a single flat list. |
-| output_format | `action=list` only. `list` renders one line per pack and is the default, because the War Room transposes single-row tables and truncates long ones. `table` renders the columns named in `fields`. |
-| docs_base_url | `action=list` only. Absolute base URL of the documentation site. The catalog supplies each pack's relative `docs_path`, and this value supplies the host, so each pack ID renders as a link to its overview page. Must be absolute, otherwise the link resolves against the tenant host. Set to an empty value to disable linking. |
-| show_total | `action=list` only. Display "showing X-Y of Z" paging information. |
-| include_doc_content | When printing pre and post config docs, also fetch a truncated preview of the README content into the War Room output. |
-| doc_content_max_chars | Maximum characters per doc preview when `include_doc_content=true`. |
-| doc_content_max_lines | Maximum lines per doc preview when `include_doc_content=true`. |
-| pre_config_done | Set to `true` to acknowledge pre-config docs have been completed and continue with install or configure. |
-| pre_config_gate | When `true`, the script prints `pre_config_docs` and stops until `pre_config_done=true`. |
-| force | `action=sync-tags` only. Update `value_tags` even if the content hash matches the current version. |
-| tags_url | `action=sync-tags` only. Override the `value_tags.json` source URL. Defaults to the `soc-optimization-unified` pack on main. |
+| filter | action=list only. Case-insensitive free-text filter applied to id, display_name, and path. |
+| limit | action=list only. Maximum number of rows to display per page. |
+| offset | action=list only. Row offset for paging. offset=0 shows the first page. |
+| sort_by | The column to sort by, for the list action only. Ignored for ordering between categories when group_by_category is true. |
+| sort_dir | action=list only. Sort direction. |
+| visible_only | action=list only. Hide packs marked visible=false in the catalog. Implied false when include_hidden=true. |
+| fields | The comma-separated list of columns to show, for the list action only. Available columns are id, display_name, category, version, installed, status, docs, visible and path. Unknown fields are ignored. |
+| group_by_category | Whether to group packs under their catalog category, one section per category, for the list action only. When false, a single flat list is rendered. |
+| docs_base_url | The absolute base URL of the documentation site, for the list action only. The catalog supplies each pack's relative documentation path and this value supplies the host, so each pack links to its overview page. Must be absolute, otherwise the link resolves against the tenant host. Set to an empty value to disable linking. |
+| output_format | The output style for the list action only. The list style renders one line per pack, because the War Room transposes single-row tables and truncates long ones. The table style renders the columns named in fields. |
+| show_total | action=list only. If true, displays "showing X-Y of Z" paging information. |
+| include_doc_content | When printing pre_config_docs and post_config_docs, also fetch a truncated preview of the README content into the War Room output. |
+| doc_content_max_chars | Maximum characters per doc preview when include_doc_content=true. |
+| doc_content_max_lines | Maximum lines per doc preview when include_doc_content=true. |
+| pre_config_done | Set to true to acknowledge pre-config docs have been completed and continue with install or configure. |
+| pre_config_gate | When true, the script prints pre_config_docs and stops until pre_config_done=true. |
+| force | action=sync-tags only. Update value_tags even if the content hash matches the current version. |
+| tags_url | action=sync-tags only. Override the value_tags.json source URL. Defaults to the soc-optimization-unified pack on main. |
 
 ## Outputs
 
+---
+
 | **Path** | **Description** | **Type** |
 | --- | --- | --- |
-| SOCFramework.PackManager.pack_id | Pack ID acted on for `action=apply` or `action=configure`. | String |
-| SOCFramework.PackManager.xsoar_config_url | URL of the `xsoar_config.json` fetched for the pack. | String |
+| SOCFramework.PackManager.pack_id | Pack ID acted on for action=apply or action=configure. | String |
+| SOCFramework.PackManager.xsoar_config_url | URL of the xsoar_config.json fetched for the pack. | String |
 | SOCFramework.PackManager.catalog_url | URL of the pack catalog used to resolve the manifest. | String |
-| SOCFramework.PackManager.Diagnose.check | `action=diagnose` only. Name of the probed check. | String |
-| SOCFramework.PackManager.Diagnose.detail | `action=diagnose` only. What the probe observed. | String |
-| SOCFramework.PackManager.Diagnose.endpoint | `action=diagnose` only. Platform endpoint the check exercised. | String |
-| SOCFramework.PackManager.Diagnose.result | `action=diagnose` only. `pass` or `fail`. | String |
-| SOCFramework.PackManager.marketplace_errors | Marketplace install errors recorded during `action=apply`. | Unknown |
-| SOCFramework.PackManager.configure_summary.integrations | Integration instance configuration summary. | Unknown |
-| SOCFramework.PackManager.configure_summary.jobs | Job configuration summary. | Unknown |
-| SOCFramework.PackManager.configure_summary.lookups | Lookup dataset configuration summary. | Unknown |
-| SOCFramework.PackManager.SyncTags.status | `action=sync-tags` result. `up_to_date` or `updated`. | String |
-| SOCFramework.PackManager.SyncTags.dataset | Dataset name updated (`value_tags`). | String |
-| SOCFramework.PackManager.SyncTags.version | Short hash of the `value_tags` content currently installed. | String |
-| SOCFramework.PackManager.SyncTags.hash | Full content hash of the `value_tags` content currently installed. | String |
-| SOCFramework.PackManager.SyncTags.rows | Number of `value_tags` rows uploaded to the dataset. | Number |
+| SOCFramework.PackManager.marketplace_errors | Marketplace install errors recorded during action=apply. | Unknown |
+| SOCFramework.PackManager.configure_summary.integrations | Integration instance configuration summary \(attempted, ok, already_exists, failed\). | Unknown |
+| SOCFramework.PackManager.configure_summary.jobs | Job configuration summary \(attempted, ok, failed, notes\). | Unknown |
+| SOCFramework.PackManager.configure_summary.lookups | Lookup dataset configuration summary \(attempted, ok, failed\). | Unknown |
+| SOCFramework.PackManager.SyncTags.status | action=sync-tags result. up_to_date or updated. | String |
+| SOCFramework.PackManager.SyncTags.dataset | Dataset name updated \(value_tags\). | String |
+| SOCFramework.PackManager.SyncTags.version | Short hash of the value_tags content currently installed. | String |
+| SOCFramework.PackManager.SyncTags.hash | Full content hash of the value_tags content currently installed. | String |
+| SOCFramework.PackManager.SyncTags.rows | Number of value_tags rows uploaded to the dataset. | Number |
 | SOCFramework.PackManager.SyncTags.updated | Whether the dataset was updated on this run. | Boolean |
 | SOCFramework.PackManager.SyncTags.previous_hash | Previous content hash before this run, when applicable. | String |
-| SOCFramework.PackManager.SyncTags.updated_at | ISO 8601 timestamp the `value_tags` dataset was last updated. | String |
-
-## Command examples
-
-#### action=list
-
-```!SOCFWPackManager action=list```
-
-##### Human Readable Output
-
-> Lists the available SOC Framework packs grouped by catalog category. Each pack is prefixed with a status marker — 🔵 update available, ⚪ not installed, 🟢 up to date, 🟠 installed ahead of the catalog — followed by the pack ID, the version detail, and a link to the pack documentation. The header summarizes the counts per status.
-
-#### action=diagnose
-
-```!SOCFWPackManager action=diagnose```
-
-##### Human Readable Output
-
-> Probes each platform endpoint the marketplace install path depends on — the Core REST API instance, the installed-packs metadata endpoint, marketplace metadata resolution, and dependency lookup — and reports pass or fail per check with the endpoint exercised. Read-only; nothing is installed or modified. Run this first when an install misbehaves, to identify which endpoint is at fault before retrying.
-
-#### action=apply
-
-```!SOCFWPackManager action=apply pack_id=soc-optimization-unified```
-
-##### Human Readable Output
-
-> Streams progress to the war room as the marketplace dependencies install, the custom pack ZIP is uploaded as system content, and `xsoar_config.json` is applied.
-
-#### action=configure
-
-```!SOCFWPackManager action=configure pack_id=SocFrameworkTrendMicroVisionOne```
-
-##### Human Readable Output
-
-> Re-runs configuration only — integration instances, jobs, and lookup datasets — without reinstalling the pack.
-
-#### action=sync-tags
-
-```!SOCFWPackManager action=sync-tags```
-
-##### Human Readable Output
-
-> Backward-compat action. Updates the legacy `value_tags` lookup dataset for older deployments. Modern SOC Framework deployments use `SOCActionTimeMap_V3` and do not need this command.
+| SOCFramework.PackManager.SyncTags.updated_at | ISO 8601 timestamp the value_tags dataset was last updated. | String |

--- a/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager.py
+++ b/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager.py
@@ -4,6 +4,7 @@ from CommonServerPython import *  # noqa: F401,F403
 import json
 import re
 import time
+import traceback
 from typing import Any
 from urllib.parse import urlparse
 
@@ -493,6 +494,13 @@ def resolve_catalog_url(explicit: Any) -> str:
     res = exec_cmd("socfw-catalog-url-get", {}, fail_on_error=False)
     contents = get_contents(res)
     configured = _norm(contents.get("catalog_url")) if isinstance(contents, dict) else ""
+    if not configured:
+        demisto.debug(
+            "socfw-catalog-url-get returned no catalog URL; falling back to the built-in "
+            f"default {DEFAULT_CATALOG_URL}. The command is unavailable on older versions "
+            "of the integration, and an instance created before the parameter existed "
+            "reports it as empty."
+        )
     return configured or DEFAULT_CATALOG_URL
 
 
@@ -847,7 +855,7 @@ def find_core_rest_api_instances() -> list[dict[str, str]]:
     try:
         modules = demisto.getModules() or {}
     except Exception as e:
-        demisto.debug(f"getModules unavailable: {e}")
+        demisto.error(f"getModules unavailable: {e}\n{traceback.format_exc()}")
         return []
     found = []
     for name, meta in modules.items():
@@ -1052,11 +1060,25 @@ def resolve_install_closure(
                 # version itself depends on.
                 frontier.append({"id": dep_id, "version": version})
 
+    if frontier:
+        # The install endpoint validates the request as a self-contained graph
+        # and rejects a partial set, naming the install endpoint rather than the
+        # unresolved dependency. Say which packs were still expanding so the
+        # rejection is attributable.
+        unresolved = ", ".join(sorted(f"{p['id']}@{p['version']}" for p in frontier))
+        emit_progress(
+            f"⚠️ Dependency resolution stopped after {MAX_DEPENDENCY_ROUNDS} rounds with packs "
+            f"still unexpanded: {unresolved}. The dependency set may be incomplete, and the "
+            f"install endpoint rejects an incomplete set. Re-run with a narrower pack list, or "
+            f"raise MAX_DEPENDENCY_ROUNDS if the dependency graph is genuinely this deep.",
+            stage="packs.marketplace.closure.incomplete",
+        )
+
     return wanted
 
 
 def _marketplace_context_rows(
-    requested_ids: set,
+    requested_ids: set[str],
     installed_now: dict[str, str],
     already_present: dict[str, str],
     failed: dict[str, str],
@@ -2595,7 +2617,7 @@ def _run_main():
 # ---------------------------
 
 
-def do_diagnose(args: dict[str, Any]):
+def do_diagnose(args: dict[str, Any]) -> None:
     """Probe every platform endpoint the marketplace install path depends on.
 
     Read-only. Exists because a failure in any one of these surfaces later as a

--- a/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager.py
+++ b/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager.py
@@ -2,6 +2,7 @@ import demistomock as demisto  # noqa: F401
 from CommonServerPython import *  # noqa: F401,F403
 
 import json
+import re
 import time
 from typing import Any
 from urllib.parse import urlparse
@@ -12,7 +13,8 @@ import requests
 # SOCFWPackManager (bootloader)
 # - list: shows SOC Framework pack catalog (paging/filtering)
 # - apply: resolves pack_id via secops-framework pack_catalog.json
-# - marketplace install: uses XSIAMContentPackInstaller (when available)
+# - marketplace install: resolves the transitive mandatory-dependency set and
+#   installs it via core-api-* against the platform marketplace endpoints
 # - custom ZIP install: socfw-install-pack (SOCFWPackManager integration instance)
 #   credentials stored masked in integration params
 # - configure: integrations/jobs/lookups from xsoar_config.json (via core-api-*)
@@ -52,23 +54,26 @@ def _safe_sort_key(row: dict[str, Any], key: str) -> str:
 
 
 def _guess_pack_id_from_label(label: str) -> str:
-    """
+    """Pack ID for a release asset filename or label.
+
     Convert:
       - soc-common-playbooks-unified.zip               -> soc-common-playbooks-unified
       - soc-common-playbooks-unified-v2.7.53.zip       -> soc-common-playbooks-unified
       - soc-common-playbooks-unified-v2.7.53           -> soc-common-playbooks-unified
+      - soc-optimization-unified-v3.11.1-pr1008.zip    -> soc-optimization-unified
       - soc-common-playbooks-unified                   -> soc-common-playbooks-unified
-    Used ONLY for polling detection (timeout fallback).
+
+    Must agree with pack_dir_name() in the integration: that decides the pack
+    ID written to the tenant, and this decides the ID polled for afterwards.
+    Only a trailing "-v<version>" is stripped, so a pack whose own name
+    contains "-v" is left intact.
     """
     s = _norm(label)
     if not s:
         return s
-    if s.endswith(".zip"):
+    if s.lower().endswith(".zip"):
         s = s[:-4]
-    # Strip release suffix "-vX.Y.Z" if present
-    if "-v" in s:
-        s = s.split("-v")[0]
-    return s.strip()
+    return re.sub(r"-v\d+(?:\.\d+)*(?:-[A-Za-z0-9]+)?$", "", s).strip()
 
 
 def _extract_custom_packs_from_xsoar_cfg(xsoar_cfg: dict[str, Any]) -> list[dict[str, str]]:
@@ -536,6 +541,30 @@ def resolve_manifest(pack_id: str, include_hidden: bool, catalog_url: str) -> di
 # ---------------------------
 
 
+DEFAULT_DOCS_BASE_URL = "https://palo-cortex.github.io/secops-framework"
+
+
+def _pack_docs_url(pack: dict[str, Any], docs_base_url: str) -> str:
+    """Absolute URL to a pack's documentation.
+
+    Prefers an explicit `docs` URL from the catalog entry; otherwise derives one
+    from `docs_path` against the docs site. Must be absolute -- a relative href
+    is resolved against the tenant host and lands the analyst back in XSIAM.
+    """
+    explicit = _norm(pack.get("docs"))
+    if explicit.startswith("http://") or explicit.startswith("https://"):
+        return explicit
+
+    base = (docs_base_url or "").rstrip("/")
+    if not base:
+        return ""
+    docs_path = explicit or _norm(pack.get("docs_path")) or ""
+    slug = docs_path.rstrip("/").split("/")[-1] if docs_path else _norm(pack.get("id"))
+    if not slug:
+        return ""
+    return f"{base}/{slug}/overview/"
+
+
 def do_list(args: dict[str, Any]):
     using = _norm(args.get("using") or "")
     include_hidden = arg_to_bool(args.get("include_hidden"), False)
@@ -548,10 +577,17 @@ def do_list(args: dict[str, Any]):
     offset = max(0, to_int(args.get("offset"), 0))
     sort_by = (_norm(args.get("sort_by")) or "id").strip()
     sort_dir = (_norm(args.get("sort_dir")) or "asc").strip().lower()
-    fields = argToList(args.get("fields")) or ["id", "display_name", "version", "visible", "path"]
+    fields = argToList(args.get("fields")) or ["id", "version", "installed", "status", "docs"]
     show_total = arg_to_bool(args.get("show_total"), True)
+    group_by_category = arg_to_bool(args.get("group_by_category"), True)
+    output_format = (_norm(args.get("output_format")) or "list").strip().lower()
+    debug = arg_to_bool(args.get("debug"), False)
 
     catalog_url = _norm(args.get("catalog_url") or DEFAULT_CATALOG_URL)
+    # An explicitly empty docs_base_url disables linking, so distinguish it
+    # from the argument being absent.
+    docs_base_arg = args.get("docs_base_url")
+    docs_base_url = _norm(DEFAULT_DOCS_BASE_URL if docs_base_arg is None else docs_base_arg)
 
     emit_progress("Fetching catalog…", stage="list")
 
@@ -559,6 +595,11 @@ def do_list(args: dict[str, Any]):
     packs = catalog.get("packs") or catalog.get("Packs") or catalog.get("items") or []
     if not isinstance(packs, list):
         raise Exception("pack_catalog.json is missing 'packs' list")
+
+    # An empty map means the lookup failed rather than a tenant with no packs,
+    # so report unknown instead of claiming everything is missing.
+    installed = fetch_installed_packs(using)
+    installed_known = bool(installed)
 
     rows: list[dict[str, Any]] = []
     for p in packs:
@@ -572,12 +613,31 @@ def do_list(args: dict[str, Any]):
         if visible_only and (not visible):
             continue
 
+        pack_id = p.get("id", "")
+        catalog_version = p.get("version", "")
+        installed_version = (installed.get(pack_id) or {}).get("version") or ""
+
+        if not installed_known:
+            status = "unknown"
+        elif not installed_version:
+            status = "not installed"
+        elif _ver_key(catalog_version) > _ver_key(installed_version):
+            status = "update available"
+        elif _ver_key(catalog_version) < _ver_key(installed_version):
+            status = "ahead of catalog"
+        else:
+            status = "up to date"
+
         row = {
-            "id": p.get("id", ""),
+            "id": pack_id,
             "display_name": p.get("display_name") or p.get("name") or "",
-            "version": p.get("version", ""),
+            "category": p.get("category") or "Uncategorized",
+            "version": catalog_version,
+            "installed": installed_version or "-",
+            "status": status,
+            "docs": _pack_docs_url(p, docs_base_url),
             "visible": str(visible).lower(),
-            "path": p.get("path") or f"Packs/{p.get('id','')}",
+            "path": p.get("path") or f"Packs/{pack_id}",
         }
 
         if text_filter:
@@ -589,44 +649,383 @@ def do_list(args: dict[str, Any]):
 
     total = len(rows)
 
-    allowed_sort = {"id", "display_name", "version", "visible", "path"}
+    allowed_sort = {"id", "display_name", "category", "version", "installed", "status", "visible", "path"}
     if sort_by not in allowed_sort:
         sort_by = "id"
     reverse = sort_dir == "desc"
     rows.sort(key=lambda r: _safe_sort_key(r, sort_by), reverse=reverse)
+    if group_by_category:
+        rows.sort(key=lambda r: _to_lower(r.get("category")))
 
     page = rows[offset : offset + limit]
     start = offset + 1 if page else 0
     end = offset + len(page)
 
-    allowed_fields = ["id", "display_name", "version", "visible", "path"]
-    fields = [f for f in fields if f in allowed_fields] or ["id", "display_name", "version", "visible", "path"]
+    allowed_fields = ["id", "display_name", "category", "version", "installed", "status", "docs", "visible", "path"]
+    fields = [f for f in fields if f in allowed_fields] or ["id", "version", "installed", "status", "docs"]
 
-    header_line = "| " + " | ".join(fields) + " |\n"
-    sep_line = "| " + " | ".join(["---"] * len(fields)) + " |\n"
-    table = header_line + sep_line
-    for r in page:
-        table += "| " + " | ".join([_norm(r.get(f, "")) for f in fields]) + " |\n"
+    def cell(row: dict[str, Any], col: str) -> str:
+        value = _norm(row.get(col, ""))
+        # The docs link is its own column rather than wrapping the id, which
+        # has to stay plain text so it can be copied into pack_id=.
+        if col == "docs":
+            return f"[docs]({value})" if value else ""
+        if col == "display_name" and len(value) > 46:
+            value = value[:45].rstrip() + "…"
+        return value
 
-    summary_lines = [
-        f"using: {(using or '(default)')}",
-        f"catalog_url: {catalog_url}",
-        f"include_hidden: {include_hidden}",
-        f"visible_only: {visible_only}",
-    ]
+    def render_lines(subset: list[dict[str, Any]]) -> str:
+        """One line per pack.
+
+        Deliberately not a markdown list: a bold category heading placed
+        directly after a list item is absorbed into that list as a lazy
+        continuation, which indents every heading after the first. Separating
+        them with blank lines instead would push the entry past the war room's
+        line cap. Tables are avoided for the same reason, plus a single-row
+        table gets transposed into a vertical key/value block.
+        """
+        out = []
+        for r in subset:
+            status = r["status"]
+            if status == "not installed":
+                detail = f"not installed · {r['version']} available"
+            elif status == "update available":
+                detail = f"{r['installed']} → {r['version']} · update available"
+            elif status == "ahead of catalog":
+                detail = f"{r['installed']} · ahead of catalog ({r['version']})"
+            elif status == "unknown":
+                detail = f"{r['version']} · install state unknown"
+            else:
+                detail = f"{r['version']} · up to date"
+            # Pack id stays unlinked so it can be copied into pack_id=.
+            line = f"{r['id']} — {detail}"
+            if r.get("docs"):
+                line += f" · [docs]({r['docs']})"
+            out.append(line)
+        return "\n".join(out)
+
+    def render_table(subset: list[dict[str, Any]], cols: list[str]) -> str:
+        out = "| " + " | ".join(cols) + " |\n"
+        out += "| " + " | ".join(["---"] * len(cols)) + " |\n"
+        for r in subset:
+            out += "| " + " | ".join([cell(r, c) for c in cols]) + " |\n"
+        return out
+
+    # The war room truncates an entry past roughly 25-30 rendered lines, so the
+    # header is one line and the diagnostics only appear when asked for.
+    headline = f"{total} pack(s)"
+    if installed_known:
+        counts: dict[str, int] = {}
+        for r in rows:
+            counts[r["status"]] = counts.get(r["status"], 0) + 1
+        if counts:
+            headline += " · " + " · ".join(f"{v} {k}" for k, v in sorted(counts.items()))
+    else:
+        headline += " · install state unknown"
+    if show_total and (offset or end < total):
+        headline += f" · showing {start}-{end}"
+
+    summary_lines = [headline]
+    if debug:
+        summary_lines += [
+            f"using: {(using or '(default)')}",
+            f"catalog_url: {catalog_url}",
+            f"docs_base_url: {docs_base_url or '(disabled)'}",
+            f"include_hidden: {include_hidden}, visible_only: {visible_only}",
+            f"sort: {sort_by} {sort_dir}, limit: {limit}, offset: {offset}",
+        ]
     if text_filter:
         summary_lines.append(f"filter: `{text_filter}`")
-    summary_lines.append(f"sort: {sort_by} {sort_dir}")
-    summary_lines.append(f"page: limit={limit}, offset={offset}")
-    if show_total:
-        summary_lines.append(f"showing: {start}-{end} of {total}")
 
-    emit_progress("\n".join(summary_lines) + "\n\n" + table, stage="list")
+    if output_format == "table":
+        if group_by_category:
+            cols = [f for f in fields if f != "category"]
+            sections = []
+            for category in sorted({r["category"] for r in page}, key=lambda c: c.lower()):
+                subset = [r for r in page if r["category"] == category]
+                sections.append(f"**{category}**\n\n" + render_table(subset, cols))
+            body = "\n".join(sections)
+        else:
+            body = render_table(page, fields)
+    elif group_by_category:
+        sections = []
+        for category in sorted({r["category"] for r in page}, key=lambda c: c.lower()):
+            subset = [r for r in page if r["category"] == category]
+            sections.append(f"**{category}**\n" + render_lines(subset))
+        body = "\n".join(sections)
+    else:
+        body = render_lines(page)
+
+    emit_progress("\n".join(summary_lines) + "\n\n" + body, stage="list")
 
 
 # ---------------------------
 # Marketplace install
 # ---------------------------
+
+
+MARKETPLACE_API_ROOT = "/contentpacks"
+MAX_DEPENDENCY_ROUNDS = 8
+
+
+CORE_REST_API_BRANDS = ("Core REST API", "DemistoRESTAPI", "Demisto REST API")
+
+
+def find_core_rest_api_instances() -> list[dict[str, str]]:
+    """Enabled Core REST API instances, read from the module list.
+
+    Uses demisto.getModules() rather than an API call, so it still answers when
+    the Core REST API instance is the thing that is missing.
+    """
+    try:
+        modules = demisto.getModules() or {}
+    except Exception as e:
+        demisto.debug(f"getModules unavailable: {e}")
+        return []
+    found = []
+    for name, meta in modules.items():
+        if not isinstance(meta, dict):
+            continue
+        if (meta.get("brand") or "") in CORE_REST_API_BRANDS:
+            found.append({"name": name, "brand": meta.get("brand", ""), "state": meta.get("state", "")})
+    return found
+
+
+def _core_rest_api_hint() -> str:
+    """Points at the missing instance when one is the likely cause."""
+    if find_core_rest_api_instances():
+        return "A Core REST API instance is configured, so this is a route or payload problem."
+    return (
+        "No Core REST API instance is configured on this tenant — that is almost certainly "
+        "the cause. It is this pack's only external dependency."
+    )
+
+
+class DependencyLookupError(Exception):
+    """Raised when the marketplace dependency endpoint is unusable.
+
+    Distinct from a generic failure because the install endpoint requires a
+    complete dependency closure -- without this lookup any install request is
+    guaranteed to be rejected, and the rejection names the install endpoint
+    rather than the real cause.
+    """
+
+
+def _ver_key(value: Any) -> tuple:
+    """Comparable key for an X.Y.Z pack version; non-numeric parts sort as 0."""
+    parts = []
+    for chunk in str(value or "").split("."):
+        digits = "".join(ch for ch in chunk if ch.isdigit())
+        parts.append(int(digits) if digits else 0)
+    while len(parts) < 3:
+        parts.append(0)
+    return tuple(parts[:3])
+
+
+def fetch_installed_packs(using: str) -> dict[str, dict[str, Any]]:
+    """Installed pack id -> {version, update_available}."""
+    out: dict[str, dict[str, Any]] = {}
+    try:
+        res = core_api_get(f"{MARKETPLACE_API_ROOT}/metadata/installed", using=using)
+    except Exception as e:
+        # Degrading quietly here makes every pack look uninstalled, so say so.
+        emit_progress(
+            "\n".join(
+                [
+                    "⚠️ Could not read installed packs.",
+                    f"- endpoint: `GET {MARKETPLACE_API_ROOT}/metadata/installed`",
+                    f"- error: {e}",
+                    "Install state and version comparisons below are unreliable.",
+                ]
+            ),
+            stage="packs.marketplace.warning",
+        )
+        return out
+    packs = (res.get("response") or []) if isinstance(res, dict) else []
+    for pack in packs:
+        pid = pack.get("id")
+        if pid:
+            out[pid] = {
+                "version": pack.get("currentVersion") or "",
+                "update_available": bool(pack.get("updateAvailable")),
+            }
+    return out
+
+
+def fetch_installed_marketplace_pack_ids(using: str) -> list[str]:
+    return sorted(fetch_installed_packs(using).keys())
+
+
+def resolve_latest_version(pack_id: str, using: str) -> str:
+    """Latest published version of a pack.
+
+    The marketplace metadata response embeds the pack's entire content listing
+    and can run to tens of megabytes, so callers should fall back to the
+    installed version wherever that is acceptable.
+    """
+    res = core_api_get(f"{MARKETPLACE_API_ROOT}/marketplace/{pack_id}", using=using)
+    body = (res.get("response") or {}) if isinstance(res, dict) else {}
+    version = body.get("currentVersion")
+    if not version:
+        raise Exception(
+            f"Could not resolve the latest version of '{pack_id}' from the marketplace. "
+            f"Check that the Core REST API instance is configured and the pack exists."
+        )
+    return version
+
+
+def fetch_mandatory_dependencies(packs: list[dict[str, str]], using: str) -> dict[str, dict[str, str]]:
+    """Direct mandatory dependencies per pack, as {pack_id: {dep_id: min_version}}.
+
+    The body must be a bare JSON array; this endpoint rejects an object wrapper,
+    unlike the install endpoint which requires one.
+    """
+    out: dict[str, dict[str, str]] = {}
+    try:
+        res = core_api_post(f"{MARKETPLACE_API_ROOT}/marketplace/search/dependencies", body=packs, using=using)
+    except Exception as e:
+        # A quiet failure here collapses the closure to just the requested
+        # packs, and the install endpoint then rejects it for missing
+        # dependencies -- which points at the wrong endpoint entirely.
+        emit_progress(
+            "\n".join(
+                [
+                    "⚠️ Dependency lookup failed — the install set will be incomplete.",
+                    f"- endpoint: `POST {MARKETPLACE_API_ROOT}/marketplace/search/dependencies`",
+                    f"- requested: {', '.join(p.get('id', '?') for p in packs)}",
+                    f"- error: {e}",
+                    "If the install below reports missing dependencies, this is the cause,",
+                    "not the install endpoint.",
+                    _core_rest_api_hint(),
+                ]
+            ),
+            stage="packs.marketplace.warning",
+        )
+        raise DependencyLookupError(str(e)) from e
+    body = (res.get("response") or {}) if isinstance(res, dict) else {}
+    for entry in body.get("packs") or []:
+        deps = ((entry.get("extras") or {}).get("pack") or {}).get("dependencies") or {}
+        out[entry.get("id")] = {
+            dep_id: (meta.get("minVersion") or "1.0.0") for dep_id, meta in deps.items() if meta.get("mandatory")
+        }
+    return out
+
+
+def resolve_install_closure(
+    seed_packs: list[dict[str, str]],
+    using: str,
+    installed: dict[str, dict[str, Any]],
+    upgrade: bool = False,
+) -> dict[str, str]:
+    """Expand the requested packs into their full transitive mandatory set.
+
+    The install endpoint validates the request as a self-contained graph: every
+    pack listed must also list its mandatory dependencies, whether or not those
+    are already on the tenant. A partial set is rejected outright, so the whole
+    closure has to be resolved before installing anything.
+
+    A requested version of "latest" means "ensure present" by default, so an
+    installed pack keeps the version it has. With upgrade=True it instead means
+    "bring to the newest published version", which is what actually moves a
+    pack forward. Dependencies are never force-upgraded either way -- they only
+    move when a mandatory minVersion demands it.
+    """
+    wanted: dict[str, str] = {}
+    frontier: list[dict[str, str]] = []
+
+    for pack in seed_packs:
+        pid = pack.get("id")
+        if not pid:
+            continue
+        version = _norm(pack.get("version"))
+        if version in ("", "latest", "*"):
+            current = installed.get(pid, {}).get("version") or ""
+            # The marketplace lookup returns the pack's whole content listing
+            # and can be tens of megabytes, so only pay for it when the answer
+            # can actually differ from what is already on the tenant.
+            needs_lookup = not current or (upgrade and installed.get(pid, {}).get("update_available"))
+            version = resolve_latest_version(pid, using) if needs_lookup else current
+        wanted[pid] = version
+        frontier.append({"id": pid, "version": version})
+
+    # Highest minVersion demanded for each dependency so far. Several packs
+    # commonly require the same dependency at different minimums -- Base and
+    # CommonScripts may want Core >= 3.5.75 while CommonPlaybooks only wants
+    # 3.5.73 -- and the install is rejected unless the highest one is used.
+    # Taking the first value seen silently loses the stricter requirement.
+    required_min: dict[str, str] = {}
+    for _ in range(MAX_DEPENDENCY_ROUNDS):
+        if not frontier:
+            break
+        deps_by_pack = fetch_mandatory_dependencies(frontier, using)
+        frontier = []
+        for mandatory in deps_by_pack.values():
+            for dep_id, min_version in mandatory.items():
+                prior = required_min.get(dep_id)
+                if prior is not None and _ver_key(prior) >= _ver_key(min_version):
+                    continue
+                required_min[dep_id] = min_version
+                current = installed.get(dep_id, {}).get("version") or ""
+                version = current if _ver_key(current) >= _ver_key(min_version) else min_version
+                if wanted.get(dep_id) == version:
+                    continue
+                wanted[dep_id] = version
+                # Re-queued because raising a version can change what that
+                # version itself depends on.
+                frontier.append({"id": dep_id, "version": version})
+
+    return wanted
+
+
+def _marketplace_context_rows(
+    requested_ids: set,
+    installed_now: dict[str, str],
+    already_present: dict[str, str],
+    failed: dict[str, str],
+) -> list[dict[str, str]]:
+    """Rows for the ConfigurationSetup.MarketplacePacks context key.
+
+    Field names and status strings intentionally match what
+    XSIAMContentPackInstaller produced, so existing consumers of this key --
+    notably the PoV Companion -- keep working unchanged.
+    """
+    rows = []
+    for pack_id, version in sorted(installed_now.items()):
+        rows.append(
+            {
+                "packid": pack_id,
+                "packversion": str(version),
+                "installationstatus": "Success." if pack_id in requested_ids else "Installed as requirement.",
+            }
+        )
+    for pack_id in sorted(requested_ids):
+        if pack_id in already_present:
+            rows.append(
+                {
+                    "packid": pack_id,
+                    "packversion": str(already_present[pack_id]),
+                    "installationstatus": "Already Installed on the machine.",
+                }
+            )
+        if pack_id in failed:
+            rows.append(
+                {
+                    "packid": pack_id,
+                    "packversion": str(failed[pack_id]),
+                    "installationstatus": "Failed to install.",
+                }
+            )
+    return rows
+
+
+def _emit_marketplace_context(rows: list[dict[str, str]]) -> None:
+    return_results(
+        CommandResults(
+            outputs_prefix="ConfigurationSetup.MarketplacePacks",
+            outputs_key_field="packid",
+            outputs=rows,
+        )
+    )
 
 
 def install_marketplace_packs(
@@ -635,55 +1034,84 @@ def install_marketplace_packs(
     retry_count: int,
     retry_sleep_seconds: int,
     debug: bool,
+    upgrade: bool = False,
 ) -> dict[str, Any]:
+    requested_ids = {p.get("id") for p in marketplace_packs if p.get("id")}
+    installed = fetch_installed_packs(using)
+    try:
+        closure = resolve_install_closure(marketplace_packs, using, installed, upgrade=upgrade)
+    except DependencyLookupError as e:
+        # Sending a knowingly-incomplete set produces a "missing dependencies"
+        # rejection that blames the install endpoint. Stop here instead.
+        failed = {pid: "" for pid in requested_ids}
+        _emit_marketplace_context(_marketplace_context_rows(requested_ids, {}, {}, failed))
+        raise Exception(
+            "Cannot resolve the marketplace dependency set, so the install was not attempted. "
+            "The install endpoint requires every mandatory dependency in one request and would "
+            f"reject an incomplete set. Underlying error: {e}"
+        ) from e
+
+    pending = {
+        pid: ver for pid, ver in closure.items() if _ver_key(ver) > _ver_key(installed.get(pid, {}).get("version"))
+    }
+
     if debug:
         emit_progress(
-            "Installing marketplace packs via **XSIAMContentPackInstaller**…\n"
-            + "\n".join([f'{p.get("id")} @ {p.get("version")}' for p in marketplace_packs]),
+            "\n".join(
+                ["Marketplace install plan:"]
+                + [
+                    f'- {pid} @ {ver}{"" if pid in pending else "  (already satisfied)"}'
+                    for pid, ver in sorted(closure.items())
+                ]
+            ),
             stage="packs.marketplace",
         )
-    else:
+
+    if not pending:
         emit_progress(
-            f"Installing marketplace packs via **XSIAMContentPackInstaller**… ({len(marketplace_packs)} pack(s))",
+            f"Marketplace packs already satisfied ({len(closure)} in dependency set); nothing to install.",
             stage="packs.marketplace",
         )
+        _emit_marketplace_context(_marketplace_context_rows(requested_ids, {}, closure, {}))
+        return {"installed": {}, "already_present": closure, "dependency_set": closure}
 
-    args = {
-        "packs_data": marketplace_packs,
-        "pack_id_key": "id",
-        "pack_version_key": "version",
-        "install_dependencies": "true",
-    }
-    if using:
-        args["using"] = using
-
-    res = exec_with_retry(
-        "XSIAMContentPackInstaller",
-        args,
-        retry_count=retry_count,
-        retry_sleep_seconds=retry_sleep_seconds,
-        context_for_error="Failed installing marketplace packs via XSIAMContentPackInstaller",
-        fail_on_error=True,
+    emit_progress(
+        f"Installing marketplace packs… ({len(pending)} to change, {len(closure)} in dependency set)",
+        stage="packs.marketplace",
     )
-    return get_contents(res) if res else {}
 
-
-def fetch_installed_marketplace_pack_ids(using: str) -> list[str]:
-    """
-    Note: This endpoint returns installed content pack IDs.
-    We'll also use it for custom zip installs polling (best-effort).
-    """
+    payload = [{"id": pid, "version": ver} for pid, ver in sorted(closure.items())]
     try:
-        r = core_api_get("/public/v1/contentpacks/metadata/installed", using=using)
-        packs = (r.get("response") or []) if isinstance(r, dict) else []
-        ids = []
-        for p in packs:
-            pid = p.get("id")
-            if pid:
-                ids.append(pid)
-        return ids
+        exec_with_retry(
+            "core-api-post",
+            {
+                "uri": f"{MARKETPLACE_API_ROOT}/marketplace/install",
+                # ignoreWarnings is required on any tenant that already has
+                # content: an upgrade that re-declares an existing incident
+                # field is otherwise rejected outright ("Field with name X
+                # already exists", possibleResolutions skip/replace). Without
+                # it a single pre-existing field fails the whole install.
+                "body": json.dumps({"packs": payload, "ignoreWarnings": True}),
+                "execution-timeout": "600",
+            },
+            retry_count=retry_count,
+            retry_sleep_seconds=retry_sleep_seconds,
+            context_for_error="Failed installing marketplace packs",
+            fail_on_error=True,
+        )
     except Exception:
-        return []
+        failed = {pid: closure[pid] for pid in requested_ids if pid in closure}
+        _emit_marketplace_context(_marketplace_context_rows(requested_ids, {}, {}, failed))
+        raise
+
+    already = {k: v for k, v in closure.items() if k not in pending}
+    _emit_marketplace_context(_marketplace_context_rows(requested_ids, pending, already, {}))
+
+    emit_progress(
+        "Marketplace packs installed: " + ", ".join(f"{k}@{v}" for k, v in sorted(pending.items())),
+        stage="packs.marketplace.result",
+    )
+    return {"installed": pending, "already_present": already, "dependency_set": closure}
 
 
 # ---------------------------
@@ -749,6 +1177,8 @@ def install_custom_pack_zip(
     retry_count: int,
     retry_sleep_seconds: int,
     debug: bool,
+    poll_seconds: int = 0,
+    poll_interval_seconds: int = 60,
 ):
     """
     Install a custom pack ZIP via the SOCFWPackManager integration instance.
@@ -779,14 +1209,28 @@ def install_custom_pack_zip(
         "filename": asset_filename,
     }
 
-    exec_with_retry(
-        "socfw-install-pack",
-        args,
-        retry_count=retry_count,
-        retry_sleep_seconds=retry_sleep_seconds,
-        context_for_error=f"Failed installing {asset_filename}",
-        fail_on_error=True,
-    )
+    try:
+        exec_with_retry(
+            "socfw-install-pack",
+            args,
+            retry_count=retry_count,
+            retry_sleep_seconds=retry_sleep_seconds,
+            context_for_error=f"Failed installing {asset_filename}",
+            fail_on_error=True,
+        )
+    except Exception:
+        # The system content-bundle endpoint returns 500 on some tenants even
+        # when the bundle was accepted, so an error here is inconclusive.
+        # Confirm against the installed-pack list before reporting a failure.
+        pack_id = _guess_pack_id_from_label(asset_filename)
+        if poll_seconds <= 0 or not pack_id:
+            raise
+        emit_progress(
+            f"Install of **{asset_filename}** reported an error; verifying against installed packs.",
+            stage="packs.custom.verify",
+        )
+        if not wait_for_pack_installed(pack_id, using, poll_seconds, poll_interval_seconds, debug):
+            raise
 
     emit_progress(
         f"Pack **{asset_filename}** installed.",
@@ -1109,7 +1553,9 @@ def configure_lookups_from_xsoar_config(
                 _xql_create_dataset_direct(ds, using=using, debug=debug)
             except Exception as e:
                 summary["failed"] += 1  # type: ignore[operator]
-                summary["failed_items"].append({"name": name, "error": f"Direct create failed: {e}"})  # type: ignore[attr-defined]
+                summary["failed_items"].append(  # type: ignore[attr-defined]
+                    {"name": name, "error": f"Direct create failed: {e}"}
+                )
                 emit_progress(f"Failed creating lookup dataset **{name}**.\nError: {e}", stage="configure.lookups.error")
                 continue
 
@@ -1789,16 +2235,20 @@ def _run_main():
     continue_on_install_timeout = arg_to_bool(args.get("continue_on_install_timeout"), False)
 
     fail_on_marketplace_errors = arg_to_bool(args.get("fail_on_marketplace_errors"), False)
+    upgrade_marketplace = arg_to_bool(args.get("upgrade_marketplace"), False)
 
     debug = arg_to_bool(args.get("debug"), False)
 
     catalog_url = _norm(args.get("catalog_url") or DEFAULT_CATALOG_URL)
 
-    if action not in ("apply", "list", "configure", "sync-tags"):
+    if action not in ("apply", "list", "configure", "sync-tags", "diagnose"):
         raise Exception(f"Unsupported action: {action}")
 
     if action == "list":
         return do_list(args)
+
+    if action == "diagnose":
+        return do_diagnose(args)
 
     if action == "configure":
         return do_configure(args)
@@ -1830,6 +2280,7 @@ def _run_main():
                 f"- post_install_poll_interval_seconds={post_install_poll_interval_seconds}",
                 f"- continue_on_install_timeout={continue_on_install_timeout}",
                 f"- fail_on_marketplace_errors={fail_on_marketplace_errors}",
+                f"- upgrade_marketplace={upgrade_marketplace}",
                 f"- include_doc_content={include_doc_content} "
                 f"(max_chars={doc_content_max_chars}, max_lines={doc_content_max_lines})",
                 f"- pre_config_gate={pre_config_gate}",
@@ -1945,7 +2396,9 @@ def _run_main():
                 mp.append({"id": p.get("id"), "version": p.get("version", "latest")})
 
         try:
-            _ = install_marketplace_packs(mp, using, retry_count, retry_sleep_seconds, debug=debug)
+            _ = install_marketplace_packs(
+                mp, using, retry_count, retry_sleep_seconds, debug=debug, upgrade=upgrade_marketplace
+            )
         except Exception as e:
             marketplace_errors.append(str(e))
             emit_progress(f"Marketplace install failed.\nError: {e}", stage="packs.marketplace.error")
@@ -1976,6 +2429,8 @@ def _run_main():
                 retry_count=retry_count,
                 retry_sleep_seconds=retry_sleep_seconds,
                 debug=debug,
+                poll_seconds=post_install_poll_seconds,
+                poll_interval_seconds=post_install_poll_interval_seconds,
             )
 
     integration_summary = None
@@ -2062,6 +2517,114 @@ def _run_main():
         )
         return None
     return None
+
+
+    main()
+
+
+# ---------------------------
+# diagnose action
+# ---------------------------
+
+
+def do_diagnose(args: dict[str, Any]):
+    """Probe every platform endpoint the marketplace install path depends on.
+
+    Read-only. Exists because a failure in any one of these surfaces later as a
+    confusing error attributed to a different endpoint -- most often a
+    dependency-lookup failure reported as a rejected install.
+    """
+    using = _norm(args.get("using") or "")
+    probe_pack = _norm(args.get("probe_pack")) or "Whois"
+
+    results: list[dict[str, str]] = []
+
+    def record(name: str, endpoint: str, ok: bool, detail: str):
+        results.append({"check": name, "endpoint": endpoint, "result": "pass" if ok else "FAIL", "detail": detail})
+
+    # Checked first and without an API call: every endpoint below runs through
+    # core-api-*, so a missing instance would otherwise surface as an opaque
+    # transport error on each of them.
+    instances = find_core_rest_api_instances()
+    record(
+        "Core REST API instance",
+        "demisto.getModules()",
+        bool(instances),
+        ", ".join(f"{i['name']} ({i['state'] or 'unknown state'})" for i in instances)
+        if instances
+        else "none configured — core-api-* cannot run. Configure the Core REST API "
+        "integration (DemistoRESTAPI pack); it is this pack's only external dependency.",
+    )
+
+    installed: dict[str, dict[str, Any]] = {}
+    endpoint = f"GET {MARKETPLACE_API_ROOT}/metadata/installed"
+    try:
+        res = core_api_get(f"{MARKETPLACE_API_ROOT}/metadata/installed", using=using)
+        packs = (res.get("response") or []) if isinstance(res, dict) else []
+        installed = {p["id"]: p for p in packs if p.get("id")}
+        has_version = any(p.get("currentVersion") for p in packs)
+        record(
+            "installed packs",
+            endpoint,
+            bool(packs) and has_version,
+            f"{len(packs)} pack(s)" + ("" if has_version else " — no currentVersion field present"),
+        )
+    except Exception as e:
+        record("installed packs", endpoint, False, str(e)[:300])
+
+    # Use a version the tenant actually has; the endpoints reject unknown ones.
+    probe_version = (installed.get(probe_pack) or {}).get("currentVersion") or ""
+    if not probe_version and installed:
+        probe_pack = sorted(installed)[0]
+        probe_version = (installed.get(probe_pack) or {}).get("currentVersion") or ""
+
+    endpoint = f"GET {MARKETPLACE_API_ROOT}/marketplace/{probe_pack}"
+    try:
+        res = core_api_get(f"{MARKETPLACE_API_ROOT}/marketplace/{probe_pack}", using=using)
+        latest = ((res.get("response") or {}) if isinstance(res, dict) else {}).get("currentVersion")
+        record(
+            "marketplace metadata (resolves 'latest')",
+            endpoint,
+            bool(latest),
+            f"latest={latest}" if latest else "no currentVersion in response",
+        )
+    except Exception as e:
+        record("marketplace metadata (resolves 'latest')", endpoint, False, str(e)[:300])
+
+    endpoint = f"POST {MARKETPLACE_API_ROOT}/marketplace/search/dependencies"
+    if not probe_version:
+        record("dependency lookup", endpoint, False, "skipped — no installed version available to probe with")
+    else:
+        try:
+            deps = fetch_mandatory_dependencies([{"id": probe_pack, "version": probe_version}], using)
+            found = deps.get(probe_pack) or {}
+            record("dependency lookup", endpoint, True, f"{probe_pack}@{probe_version} → {len(found)} mandatory")
+        except Exception as e:
+            record("dependency lookup", endpoint, False, str(e)[:300])
+
+    header = "| check | result | detail |\n| --- | --- | --- |\n"
+    table = header + "".join(
+        "| {} | {} | {} |\n".format(r["check"], r["result"], r["detail"].replace("|", "/")) for r in results
+    )
+    failed = [r for r in results if r["result"] == "FAIL"]
+    verdict = (
+        "All checks passed — the marketplace install path is usable on this tenant."
+        if not failed
+        else "FAILED: " + ", ".join(r["check"] for r in failed)
+    )
+
+    emit_progress(
+        f"{verdict}\n\nprobe pack: {probe_pack}@{probe_version or 'unknown'}\n\n" + table,
+        stage="diagnose",
+    )
+    return_results(
+        CommandResults(
+            outputs_prefix="SOCFramework.PackManager.Diagnose",
+            outputs_key_field="check",
+            outputs=results,
+        )
+    )
+
 
 
 def main():

--- a/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager.py
+++ b/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager.py
@@ -552,7 +552,7 @@ def _pack_docs_url(pack: dict[str, Any], docs_base_url: str) -> str:
     is resolved against the tenant host and lands the analyst back in XSIAM.
     """
     explicit = _norm(pack.get("docs"))
-    if explicit.startswith("http://") or explicit.startswith("https://"):
+    if explicit.startswith(("http://", "https://")):
         return explicit
 
     base = (docs_base_url or "").rstrip("/")
@@ -1051,18 +1051,13 @@ def install_marketplace_packs(
             f"reject an incomplete set. Underlying error: {e}"
         ) from e
 
-    pending = {
-        pid: ver for pid, ver in closure.items() if _ver_key(ver) > _ver_key(installed.get(pid, {}).get("version"))
-    }
+    pending = {pid: ver for pid, ver in closure.items() if _ver_key(ver) > _ver_key(installed.get(pid, {}).get("version"))}
 
     if debug:
         emit_progress(
             "\n".join(
                 ["Marketplace install plan:"]
-                + [
-                    f'- {pid} @ {ver}{"" if pid in pending else "  (already satisfied)"}'
-                    for pid, ver in sorted(closure.items())
-                ]
+                + [f'- {pid} @ {ver}{"" if pid in pending else "  (already satisfied)"}' for pid, ver in sorted(closure.items())]
             ),
             stage="packs.marketplace",
         )
@@ -2396,9 +2391,7 @@ def _run_main():
                 mp.append({"id": p.get("id"), "version": p.get("version", "latest")})
 
         try:
-            _ = install_marketplace_packs(
-                mp, using, retry_count, retry_sleep_seconds, debug=debug, upgrade=upgrade_marketplace
-            )
+            _ = install_marketplace_packs(mp, using, retry_count, retry_sleep_seconds, debug=debug, upgrade=upgrade_marketplace)
         except Exception as e:
             marketplace_errors.append(str(e))
             emit_progress(f"Marketplace install failed.\nError: {e}", stage="packs.marketplace.error")
@@ -2519,9 +2512,6 @@ def _run_main():
     return None
 
 
-    main()
-
-
 # ---------------------------
 # diagnose action
 # ---------------------------
@@ -2603,9 +2593,7 @@ def do_diagnose(args: dict[str, Any]):
             record("dependency lookup", endpoint, False, str(e)[:300])
 
     header = "| check | result | detail |\n| --- | --- | --- |\n"
-    table = header + "".join(
-        "| {} | {} | {} |\n".format(r["check"], r["result"], r["detail"].replace("|", "/")) for r in results
-    )
+    table = header + "".join("| {} | {} | {} |\n".format(r["check"], r["result"], r["detail"].replace("|", "/")) for r in results)
     failed = [r for r in results if r["result"] == "FAIL"]
     verdict = (
         "All checks passed — the marketplace install path is usable on this tenant."
@@ -2624,7 +2612,6 @@ def do_diagnose(args: dict[str, Any]):
             outputs=results,
         )
     )
-
 
 
 def main():

--- a/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager.py
+++ b/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager.py
@@ -477,7 +477,7 @@ def http_get_json(url: str, timeout: int = 30) -> Any:
 DEFAULT_CATALOG_URL = "https://raw.githubusercontent.com/Palo-Cortex/secops-framework/refs/heads/main/pack_catalog.json"
 
 
-def resolve_catalog_url(explicit: str) -> str:
+def resolve_catalog_url(explicit: Any) -> str:
     """Catalog location, in precedence order.
 
     An explicit argument wins, then the catalog_url configured on the
@@ -1103,7 +1103,7 @@ def install_marketplace_packs(
     debug: bool,
     upgrade: bool = False,
 ) -> dict[str, Any]:
-    requested_ids = {p.get("id") for p in marketplace_packs if p.get("id")}
+    requested_ids = {str(p["id"]) for p in marketplace_packs if p.get("id")}
     installed = fetch_installed_packs(using)
     try:
         closure = resolve_install_closure(marketplace_packs, using, installed, upgrade=upgrade)

--- a/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager.py
+++ b/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager.py
@@ -483,14 +483,14 @@ def resolve_catalog_url(explicit: Any) -> str:
     An explicit argument wins, then the catalog_url configured on the
     SOCFWPackManager integration instance, then the SOC Framework default. A
     script cannot read another integration's instance parameters, so the
-    configured value is read through socfw-get-catalog-url. That command is
+    configured value is read through socfw-catalog-url-get. That command is
     absent on older versions of the integration, so a failure here falls back to
     the default rather than stopping the run.
     """
     explicit = _norm(explicit)
     if explicit:
         return explicit
-    res = exec_cmd("socfw-get-catalog-url", {}, fail_on_error=False)
+    res = exec_cmd("socfw-catalog-url-get", {}, fail_on_error=False)
     contents = get_contents(res)
     configured = _norm(contents.get("catalog_url")) if isinstance(contents, dict) else ""
     return configured or DEFAULT_CATALOG_URL
@@ -879,11 +879,16 @@ class DependencyLookupError(Exception):
 
 
 def _ver_key(value: Any) -> tuple:
-    """Comparable key for an X.Y.Z pack version; non-numeric parts sort as 0."""
+    """Comparable key for an X.Y.Z pack version; non-numeric parts sort as 0.
+
+    Only the leading digits of each part count. Collecting every digit in the
+    part instead would fold a pre-release suffix into the number itself, so
+    "1.0.6-pr1008" would key as (1, 0, 61008) and compare greater than 1.0.7.
+    """
     parts = []
     for chunk in str(value or "").split("."):
-        digits = "".join(ch for ch in chunk if ch.isdigit())
-        parts.append(int(digits) if digits else 0)
+        match = re.match(r"\d+", chunk.strip())
+        parts.append(int(match.group()) if match else 0)
     while len(parts) < 3:
         parts.append(0)
     return tuple(parts[:3])
@@ -1034,7 +1039,13 @@ def resolve_install_closure(
                 required_min[dep_id] = min_version
                 current = installed.get(dep_id, {}).get("version") or ""
                 version = current if _ver_key(current) >= _ver_key(min_version) else min_version
-                if wanted.get(dep_id) == version:
+                # Never lower a version already resolved for this pack. A pack
+                # can be both explicitly requested and pulled in as another
+                # pack's dependency; without this guard the dependency pass
+                # would overwrite an upgrade target with the installed version
+                # and silently undo the upgrade the caller asked for.
+                prior_wanted = wanted.get(dep_id)
+                if prior_wanted and _ver_key(prior_wanted) >= _ver_key(version):
                     continue
                 wanted[dep_id] = version
                 # Re-queued because raising a version can change what that

--- a/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager.py
+++ b/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager.py
@@ -693,35 +693,70 @@ def do_list(args: dict[str, Any]):
             value = value[:45].rstrip() + "…"
         return value
 
-    def render_lines(subset: list[dict[str, Any]]) -> str:
-        """One line per pack.
+    # The war room renders neither HTML nor colored markdown, so status is
+    # carried by an emoji. Every status has one, including the healthy ones, so
+    # each line starts with a marker and the markers form a column the eye can
+    # scan down. Bold on the pack id makes the id the anchor rather than the
+    # status text, which is why the status word is not repeated per line -- the
+    # header states the counts once.
+    #
+    # Nothing here is red. "not installed" is a legitimate end state -- most
+    # tenants only ever want a few of these packs -- so it gets a neutral marker
+    # rather than one that reads as a fault. Amber is reserved for the genuine
+    # anomaly, a tenant running ahead of the catalog.
+    status_markers = {
+        "not installed": "⚪",
+        "update available": "🔵",
+        "ahead of catalog": "🟠",
+        "up to date": "🟢",
+        "unknown": "⚫",
+    }
 
-        Deliberately not a markdown list: a bold category heading placed
-        directly after a list item is absorbed into that list as a lazy
-        continuation, which indents every heading after the first. Separating
-        them with blank lines instead would push the entry past the war room's
-        line cap. Tables are avoided for the same reason, plus a single-row
-        table gets transposed into a vertical key/value block.
+    def emphasize(text: str, status: str) -> str:
+        marker = status_markers.get(status)
+        return f"{marker} **{text}**" if marker else text
+
+    def render_lines(subset: list[dict[str, Any]], id_width: int = 0) -> str:
+        """One line per pack, as `<marker> **id** <versions> · docs`.
+
+        The war room preserves whitespace in a monospace face, so padding the id
+        to a common width puts the versions in a column. Deliberately not a
+        markdown list: a bold category heading placed directly after a list item
+        is absorbed into that list as a lazy continuation, which indents every
+        heading after the first. Tables are avoided because a single-row table
+        gets transposed into a vertical key/value block.
         """
         out = []
         for r in subset:
             status = r["status"]
+            marker = status_markers.get(status, "⚫")
             if status == "not installed":
-                detail = f"not installed · {r['version']} available"
+                versions = f"{r['version']} available"
             elif status == "update available":
-                detail = f"{r['installed']} → {r['version']} · update available"
+                versions = f"{r['installed']} → {r['version']}"
             elif status == "ahead of catalog":
-                detail = f"{r['installed']} · ahead of catalog ({r['version']})"
+                versions = f"{r['installed']} installed · catalog {r['version']}"
             elif status == "unknown":
-                detail = f"{r['version']} · install state unknown"
+                versions = f"{r['version']} · install state unknown"
             else:
-                detail = f"{r['version']} · up to date"
+                versions = r["version"]
             # Pack id stays unlinked so it can be copied into pack_id=.
-            line = f"{r['id']} — {detail}"
+            pad = " " * max(0, id_width - len(r["id"]))
+            line = f"{marker} **{r['id']}**{pad}  {versions}"
             if r.get("docs"):
                 line += f" · [docs]({r['docs']})"
             out.append(line)
         return "\n".join(out)
+
+    def render_category(category: str) -> str:
+        """Category as a plain uppercase label.
+
+        No rule and no emoji: a drawn line across every section is more ink than
+        the content it separates, and the first column belongs to the status
+        markers, so a glyph there would break that scan. Separation comes from a
+        blank line when the line budget allows one.
+        """
+        return f"**{category.upper()}**"
 
     def render_table(subset: list[dict[str, Any]], cols: list[str]) -> str:
         out = "| " + " | ".join(cols) + " |\n"
@@ -737,8 +772,15 @@ def do_list(args: dict[str, Any]):
         counts: dict[str, int] = {}
         for r in rows:
             counts[r["status"]] = counts.get(r["status"], 0) + 1
-        if counts:
-            headline += " · " + " · ".join(f"{v} {k}" for k, v in sorted(counts.items()))
+        # Needs-action first, healthy last, so the header reads as a worklist and
+        # doubles as the legend for the markers used on each line.
+        # Actionable first, informational last. "not installed" sits low because
+        # it usually needs no action at all.
+        order = ["update available", "ahead of catalog", "unknown", "not installed", "up to date"]
+        parts = [emphasize(f"{counts[s]} {s}", s) for s in order if counts.get(s)]
+        parts += [emphasize(f"{v} {k}", k) for k, v in sorted(counts.items()) if k not in order]
+        if parts:
+            headline += " · " + " · ".join(parts)
     else:
         headline += " · install state unknown"
     if show_total and (offset or end < total):
@@ -767,13 +809,19 @@ def do_list(args: dict[str, Any]):
         else:
             body = render_table(page, fields)
     elif group_by_category:
+        categories = sorted({r["category"] for r in page}, key=lambda c: c.lower())
+        # A blank line between sections is the lightest separator there is, but
+        # it costs a line and the war room truncates a long entry. Spend them
+        # only when the whole listing still fits.
+        id_width = max((len(r["id"]) for r in page), default=0)
+        airy = (len(page) + 2 * len(categories)) <= 30
         sections = []
-        for category in sorted({r["category"] for r in page}, key=lambda c: c.lower()):
+        for category in categories:
             subset = [r for r in page if r["category"] == category]
-            sections.append(f"**{category}**\n" + render_lines(subset))
-        body = "\n".join(sections)
+            sections.append(render_category(category) + "\n" + render_lines(subset, id_width))
+        body = ("\n\n" if airy else "\n").join(sections)
     else:
-        body = render_lines(page)
+        body = render_lines(page, max((len(r["id"]) for r in page), default=0))
 
     emit_progress("\n".join(summary_lines) + "\n\n" + body, stage="list")
 

--- a/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager.py
+++ b/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager.py
@@ -2008,7 +2008,7 @@ def do_configure(args):
     overwrite = arg_to_bool(args.get("overwrite_lookup"), False)
     cfg_jobs = arg_to_bool(args.get("configure_jobs"), True)
     cfg_integrations = arg_to_bool(args.get("configure_integrations"), True)
-    cfg_lookups = arg_to_bool(args.get("configure_lookups"), True)
+    cfg_lookups = arg_to_bool(args.get("configure_lookups"), False)
     debug = arg_to_bool(args.get("debug"), False)
     include_doc_content = arg_to_bool(args.get("include_doc_content"), False)
     doc_content_max_chars = to_int(args.get("doc_content_max_chars"), 6000)
@@ -2305,7 +2305,7 @@ def _run_main():
     apply_configure = arg_to_bool(args.get("apply_configure"), True)
     configure_jobs = arg_to_bool(args.get("configure_jobs"), True)
     configure_integrations = arg_to_bool(args.get("configure_integrations"), True)
-    configure_lookups = arg_to_bool(args.get("configure_lookups"), True)
+    configure_lookups = arg_to_bool(args.get("configure_lookups"), False)
     overwrite_lookup = arg_to_bool(args.get("overwrite_lookup"), False)
 
     include_doc_content = arg_to_bool(args.get("include_doc_content"), False)

--- a/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager.py
+++ b/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager.py
@@ -477,6 +477,25 @@ def http_get_json(url: str, timeout: int = 30) -> Any:
 DEFAULT_CATALOG_URL = "https://raw.githubusercontent.com/Palo-Cortex/secops-framework/refs/heads/main/pack_catalog.json"
 
 
+def resolve_catalog_url(explicit: str) -> str:
+    """Catalog location, in precedence order.
+
+    An explicit argument wins, then the catalog_url configured on the
+    SOCFWPackManager integration instance, then the SOC Framework default. A
+    script cannot read another integration's instance parameters, so the
+    configured value is read through socfw-get-catalog-url. That command is
+    absent on older versions of the integration, so a failure here falls back to
+    the default rather than stopping the run.
+    """
+    explicit = _norm(explicit)
+    if explicit:
+        return explicit
+    res = exec_cmd("socfw-get-catalog-url", {}, fail_on_error=False)
+    contents = get_contents(res)
+    configured = _norm(contents.get("catalog_url")) if isinstance(contents, dict) else ""
+    return configured or DEFAULT_CATALOG_URL
+
+
 def fetch_pack_catalog(catalog_url: str = DEFAULT_CATALOG_URL) -> dict[str, Any]:
     data = http_get_json(catalog_url)
     if not isinstance(data, dict):
@@ -583,7 +602,7 @@ def do_list(args: dict[str, Any]):
     output_format = (_norm(args.get("output_format")) or "list").strip().lower()
     debug = arg_to_bool(args.get("debug"), False)
 
-    catalog_url = _norm(args.get("catalog_url") or DEFAULT_CATALOG_URL)
+    catalog_url = resolve_catalog_url(args.get("catalog_url"))
     # An explicitly empty docs_base_url disables linking, so distinguish it
     # from the argument being absent.
     docs_base_arg = args.get("docs_base_url")
@@ -1901,7 +1920,7 @@ def configure_jobs_from_xsoar_config(
 
 def do_configure(args):
     pack_id = (args.get("pack_id") or "").strip()
-    catalog_url = _norm(args.get("catalog_url") or DEFAULT_CATALOG_URL)
+    catalog_url = resolve_catalog_url(args.get("catalog_url"))
     using = (args.get("using") or "").strip()
     retry_count = to_int(args.get("retry_count"), 5)
     retry_sleep = to_int(args.get("retry_sleep_seconds"), 15)
@@ -2234,7 +2253,7 @@ def _run_main():
 
     debug = arg_to_bool(args.get("debug"), False)
 
-    catalog_url = _norm(args.get("catalog_url") or DEFAULT_CATALOG_URL)
+    catalog_url = resolve_catalog_url(args.get("catalog_url"))
 
     if action not in ("apply", "list", "configure", "sync-tags", "diagnose"):
         raise Exception(f"Unsupported action: {action}")

--- a/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager.yml
+++ b/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager.yml
@@ -41,7 +41,7 @@ args:
   description: diagnose probes every platform endpoint the marketplace install path depends on and reports which one fails; run it first when an install misbehaves. list shows the catalog. apply installs and configures a pack. configure re-runs configuration only (no pack install). sync-tags is a backward-compat action that updates the legacy value_tags lookup; modern SOC Framework deployments use SOCActionTimeMap_V3 and do not need it.
 - name: probe_pack
   defaultValue: Whois
-  description: action=diagnose only. Pack id used to probe the marketplace metadata and dependency endpoints. Falls back to an installed pack if this one is absent.
+  description: action=diagnose only. Pack id used to probe the marketplace metadata and dependency endpoints. Defaults to Whois because it is a stock Marketplace pack present on effectively every tenant, which makes it a dependable read-only probe target; nothing is installed or modified. Falls back to an installed pack if this one is absent.
 - name: pack_id
   description: The pack ID from pack_catalog.json (for example, soc-optimization-unified). Required for action=apply.
 - name: catalog_url

--- a/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager.yml
+++ b/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager.yml
@@ -1,9 +1,11 @@
 comment: |-
-  SOC Framework bootloader. Lists the SOC Framework pack catalog, installs
-  and configures packs from xsoar_config.json, and re-runs configuration
-  only. Also includes sync-tags, a backward-compat action for older SOC
-  Framework deployments still using the value_tags lookup; modern versions
-  use the SOCActionTimeMap_V3 list and do not require it.
+  The SOC Framework bootloader for Cortex XSIAM. Lists the SOC Framework pack
+  catalog with the installed version and update status of each pack, installs
+  and configures packs from xsoar_config.json, re-runs configuration only, and
+  diagnoses the platform endpoints the install path depends on. Also includes
+  sync-tags, a backward-compatible action for older SOC Framework deployments
+  still using the value_tags lookup; modern versions use the
+  SOCActionTimeMap_V3 list and do not require it.
 commonfields:
   id: SOCFWPackManager
   version: -1
@@ -38,10 +40,11 @@ args:
   - configure
   - sync-tags
   - diagnose
-  description: diagnose probes every platform endpoint the marketplace install path depends on and reports which one fails; run it first when an install misbehaves. list shows the catalog. apply installs and configures a pack. configure re-runs configuration only (no pack install). sync-tags is a backward-compat action that updates the legacy value_tags lookup; modern SOC Framework deployments use SOCActionTimeMap_V3 and do not need it.
+  description: The action to run. The diagnose action probes every platform endpoint the marketplace install path depends on and reports which one fails; run it first when an install misbehaves. The list action shows the catalog. The apply action installs and configures a pack. The configure action re-runs configuration only, without installing a pack. The sync-tags action is a backward-compatible action that updates the legacy value_tags lookup; modern SOC Framework deployments use SOCActionTimeMap_V3 and do not need it.
 - name: probe_pack
+  type: shortText
   defaultValue: Whois
-  description: action=diagnose only. Pack id used to probe the marketplace metadata and dependency endpoints. Defaults to Whois because it is a stock Marketplace pack present on effectively every tenant, which makes it a dependable read-only probe target; nothing is installed or modified. Falls back to an installed pack if this one is absent.
+  description: The pack ID used to probe the marketplace metadata and dependency endpoints, for the diagnose action only. Whois is a stock Marketplace pack present on effectively every tenant, which makes it a dependable read-only probe target; nothing is installed or modified. Falls back to an installed pack if this one is absent.
 - name: pack_id
   description: The pack ID from pack_catalog.json (for example, soc-optimization-unified). Required for action=apply.
 - name: catalog_url
@@ -144,12 +147,13 @@ args:
   - 'False'
   description: Continue with configuration steps if a custom-pack install times out and polling does not confirm installation.
 - name: upgrade_marketplace
+  type: boolean
   auto: PREDEFINED
   defaultValue: 'False'
   predefined:
   - 'True'
   - 'False'
-  description: action=apply only. Controls what a marketplace_packs entry of "latest" means. False (default) means ensure present - an already-installed pack keeps its current version. True means bring each requested pack to the newest published version. Mandatory dependencies are never force-upgraded either way; they move only when a minVersion requires it. Upgrading resolves versions from the marketplace, which returns large responses, so it is slower than the default.
+  description: Whether a marketplace_packs entry of "latest" brings each requested pack to the newest published version, for the apply action only. When false, an already-installed pack keeps its current version. Mandatory dependencies are never force-upgraded either way; they move only when a minVersion requires it. Upgrading resolves versions from the marketplace, which returns large responses, so it is slower.
 - name: fail_on_marketplace_errors
   auto: PREDEFINED
   defaultValue: 'False'
@@ -184,7 +188,7 @@ args:
   - status
   - visible
   - path
-  description: action=list only. Column to sort by. Ignored for ordering between categories when group_by_category is true.
+  description: The column to sort by, for the list action only. Ignored for ordering between categories when group_by_category is true.
 - name: sort_dir
   auto: PREDEFINED
   defaultValue: asc
@@ -201,24 +205,27 @@ args:
   description: action=list only. Hide packs marked visible=false in the catalog. Implied false when include_hidden=true.
 - name: fields
   defaultValue: id,version,installed,status,docs
-  description: action=list only. Comma-separated list of columns to show. Available columns are id, display_name, category, version, installed, status, docs, visible and path. Unknown fields are ignored.
+  description: The comma-separated list of columns to show, for the list action only. Available columns are id, display_name, category, version, installed, status, docs, visible and path. Unknown fields are ignored.
 - name: group_by_category
+  type: boolean
   auto: PREDEFINED
   defaultValue: 'True'
   predefined:
   - 'True'
   - 'False'
-  description: action=list only. Group packs under their catalog category, one table per category. Set to false for a single flat table.
+  description: Whether to group packs under their catalog category, one section per category, for the list action only. When false, a single flat list is rendered.
 - name: docs_base_url
+  type: shortText
   defaultValue: https://palo-cortex.github.io/secops-framework
-  description: action=list only. Absolute base URL of the documentation site. Each pack id is rendered as a link to its overview page. Must be absolute, otherwise the link resolves against the tenant host. Set to an empty value to disable linking.
+  description: The absolute base URL of the documentation site, for the list action only. The catalog supplies each pack's relative documentation path and this value supplies the host, so each pack links to its overview page. Must be absolute, otherwise the link resolves against the tenant host. Set to an empty value to disable linking.
 - name: output_format
+  type: shortText
   auto: PREDEFINED
   defaultValue: list
   predefined:
   - list
   - table
-  description: action=list only. list renders one line per pack and is the default because the war room transposes single-row tables and truncates long ones. table renders the columns named in fields.
+  description: The output style for the list action only. The list style renders one line per pack, because the War Room transposes single-row tables and truncates long ones. The table style renders the columns named in fields.
 - name: show_total
   auto: PREDEFINED
   defaultValue: 'True'

--- a/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager.yml
+++ b/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager.yml
@@ -37,7 +37,11 @@ args:
   - apply
   - configure
   - sync-tags
-  description: list shows the catalog. apply installs and configures a pack. configure re-runs configuration only (no pack install). sync-tags is a backward-compat action that updates the legacy value_tags lookup; modern SOC Framework deployments use SOCActionTimeMap_V3 and do not need it.
+  - diagnose
+  description: diagnose probes every platform endpoint the marketplace install path depends on and reports which one fails; run it first when an install misbehaves. list shows the catalog. apply installs and configures a pack. configure re-runs configuration only (no pack install). sync-tags is a backward-compat action that updates the legacy value_tags lookup; modern SOC Framework deployments use SOCActionTimeMap_V3 and do not need it.
+- name: probe_pack
+  defaultValue: Whois
+  description: action=diagnose only. Pack id used to probe the marketplace metadata and dependency endpoints. Falls back to an installed pack if this one is absent.
 - name: pack_id
   description: The pack ID from pack_catalog.json (for example, soc-optimization-unified). Required for action=apply.
 - name: catalog_url
@@ -139,6 +143,13 @@ args:
   - 'True'
   - 'False'
   description: Continue with configuration steps if a custom-pack install times out and polling does not confirm installation.
+- name: upgrade_marketplace
+  auto: PREDEFINED
+  defaultValue: 'False'
+  predefined:
+  - 'True'
+  - 'False'
+  description: action=apply only. Controls what a marketplace_packs entry of "latest" means. False (default) means ensure present - an already-installed pack keeps its current version. True means bring each requested pack to the newest published version. Mandatory dependencies are never force-upgraded either way; they move only when a minVersion requires it. Upgrading resolves versions from the marketplace, which returns large responses, so it is slower than the default.
 - name: fail_on_marketplace_errors
   auto: PREDEFINED
   defaultValue: 'False'
@@ -167,10 +178,13 @@ args:
   predefined:
   - id
   - display_name
+  - category
   - version
+  - installed
+  - status
   - visible
   - path
-  description: action=list only. Column to sort by.
+  description: action=list only. Column to sort by. Ignored for ordering between categories when group_by_category is true.
 - name: sort_dir
   auto: PREDEFINED
   defaultValue: asc
@@ -186,8 +200,25 @@ args:
   - 'False'
   description: action=list only. Hide packs marked visible=false in the catalog. Implied false when include_hidden=true.
 - name: fields
-  defaultValue: id,display_name,version,visible,path
-  description: action=list only. Comma-separated list of columns to show. Unknown fields are ignored.
+  defaultValue: id,version,installed,status,docs
+  description: action=list only. Comma-separated list of columns to show. Available columns are id, display_name, category, version, installed, status, docs, visible and path. Unknown fields are ignored.
+- name: group_by_category
+  auto: PREDEFINED
+  defaultValue: 'True'
+  predefined:
+  - 'True'
+  - 'False'
+  description: action=list only. Group packs under their catalog category, one table per category. Set to false for a single flat table.
+- name: docs_base_url
+  defaultValue: https://palo-cortex.github.io/secops-framework
+  description: action=list only. Absolute base URL of the documentation site. Each pack id is rendered as a link to its overview page. Must be absolute, otherwise the link resolves against the tenant host. Set to an empty value to disable linking.
+- name: output_format
+  auto: PREDEFINED
+  defaultValue: list
+  predefined:
+  - list
+  - table
+  description: action=list only. list renders one line per pack and is the default because the war room transposes single-row tables and truncates long ones. table renders the columns named in fields.
 - name: show_total
   auto: PREDEFINED
   defaultValue: 'True'

--- a/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager.yml
+++ b/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager.yml
@@ -115,12 +115,13 @@ args:
   - 'False'
   description: When action=apply, create or update integration instances from xsoar_config.json. Ignored if apply_configure=false.
 - name: configure_lookups
+  type: boolean
   auto: PREDEFINED
-  defaultValue: 'True'
+  defaultValue: 'False'
   predefined:
   - 'True'
   - 'False'
-  description: When action=apply, create or update lookup datasets from xsoar_config.json. Ignored if apply_configure=false.
+  description: Whether to create or update lookup datasets from xsoar_config.json, for the apply and configure actions. A pack that ships a Lookup directory already brings its dataset with it, so configuring it again is redundant. Ignored when apply_configure is false.
 - name: retry_count
   defaultValue: '5'
   description: Number of retry attempts for install or configure operations that fail transiently.

--- a/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager_test.py
+++ b/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager_test.py
@@ -1292,3 +1292,41 @@ def test_guess_pack_id_leaves_embedded_dash_v_alone():
     script, _ = load_script()
     assert script._guess_pack_id_from_label("soc-vendor-thing.zip") == "soc-vendor-thing"
     assert script._guess_pack_id_from_label("soc-vendor-thing-v1.2.3.zip") == "soc-vendor-thing"
+
+
+# ---------------------------
+# catalog URL resolution
+# ---------------------------
+
+
+def test_resolve_catalog_url_explicit_arg_wins():
+    script, demisto_mock = load_script()
+    demisto_mock._command_responses["socfw-get-catalog-url"] = [
+        {"Type": 1, "Contents": {"catalog_url": "https://instance.example/catalog.json"}}
+    ]
+
+    assert script.resolve_catalog_url("https://explicit.example/catalog.json") == "https://explicit.example/catalog.json"
+    # The instance is not consulted when an explicit value is supplied.
+    assert not [c for c in demisto_mock._commands if c[0] == "socfw-get-catalog-url"]
+
+
+def test_resolve_catalog_url_uses_instance_value():
+    script, demisto_mock = load_script()
+    demisto_mock._command_responses["socfw-get-catalog-url"] = [
+        {"Type": 1, "Contents": {"catalog_url": "https://instance.example/catalog.json"}}
+    ]
+
+    assert script.resolve_catalog_url("") == "https://instance.example/catalog.json"
+
+
+def test_resolve_catalog_url_falls_back_when_command_missing():
+    script, _ = load_script()
+    # No response registered: the command does not exist on this tenant.
+    assert script.resolve_catalog_url("") == script.DEFAULT_CATALOG_URL
+
+
+def test_resolve_catalog_url_falls_back_on_error_entry():
+    script, demisto_mock = load_script()
+    demisto_mock._command_responses["socfw-get-catalog-url"] = [{"Type": 4, "Contents": "Unsupported command (23)"}]
+
+    assert script.resolve_catalog_url("") == script.DEFAULT_CATALOG_URL

--- a/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager_test.py
+++ b/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager_test.py
@@ -1301,18 +1301,18 @@ def test_guess_pack_id_leaves_embedded_dash_v_alone():
 
 def test_resolve_catalog_url_explicit_arg_wins():
     script, demisto_mock = load_script()
-    demisto_mock._command_responses["socfw-get-catalog-url"] = [
+    demisto_mock._command_responses["socfw-catalog-url-get"] = [
         {"Type": 1, "Contents": {"catalog_url": "https://instance.example/catalog.json"}}
     ]
 
     assert script.resolve_catalog_url("https://explicit.example/catalog.json") == "https://explicit.example/catalog.json"
     # The instance is not consulted when an explicit value is supplied.
-    assert not [c for c in demisto_mock._commands if c[0] == "socfw-get-catalog-url"]
+    assert not [c for c in demisto_mock._commands if c[0] == "socfw-catalog-url-get"]
 
 
 def test_resolve_catalog_url_uses_instance_value():
     script, demisto_mock = load_script()
-    demisto_mock._command_responses["socfw-get-catalog-url"] = [
+    demisto_mock._command_responses["socfw-catalog-url-get"] = [
         {"Type": 1, "Contents": {"catalog_url": "https://instance.example/catalog.json"}}
     ]
 
@@ -1327,6 +1327,83 @@ def test_resolve_catalog_url_falls_back_when_command_missing():
 
 def test_resolve_catalog_url_falls_back_on_error_entry():
     script, demisto_mock = load_script()
-    demisto_mock._command_responses["socfw-get-catalog-url"] = [{"Type": 4, "Contents": "Unsupported command (23)"}]
+    demisto_mock._command_responses["socfw-catalog-url-get"] = [{"Type": 4, "Contents": "Unsupported command (23)"}]
 
     assert script.resolve_catalog_url("") == script.DEFAULT_CATALOG_URL
+
+
+# ---------------------------
+# version comparison and install closure
+# ---------------------------
+
+
+def test_ver_key_ignores_prerelease_suffix():
+    """A pre-release suffix must not inflate the patch number.
+
+    Collecting every digit in the part folded the suffix into the number, so
+    1.0.6-pr1008 keyed as (1, 0, 61008) and compared greater than 1.0.7.
+    """
+    script, _ = load_script()
+    assert script._ver_key("1.0.6-pr1008") == (1, 0, 6)
+    assert script._ver_key("1.0.6-rc1") == (1, 0, 6)
+    assert script._ver_key("1.0.6") < script._ver_key("1.0.7")
+    assert script._ver_key("1.0.6-pr1008") < script._ver_key("1.0.7")
+    assert script._ver_key("3.11.2") == (3, 11, 2)
+    assert script._ver_key("1.0") == (1, 0, 0)
+    assert script._ver_key("") == (0, 0, 0)
+    assert script._ver_key(None) == (0, 0, 0)
+
+
+def test_ver_key_orders_double_digit_minor_correctly():
+    script, _ = load_script()
+    assert script._ver_key("3.9.0") < script._ver_key("3.11.0")
+
+
+def test_resolve_install_closure_does_not_downgrade_an_upgrade_target(mocker):
+    """A pack that is both requested and a dependency keeps its upgrade target.
+
+    The dependency pass computes the installed version when it already
+    satisfies minVersion. Writing that unconditionally overwrote the seed's
+    resolved upgrade target and silently undid the upgrade.
+    """
+    script, _ = load_script()
+    installed = {
+        "PackA": {"version": "1.0.0", "update_available": True},
+        "Shared": {"version": "3.0.0", "update_available": True},
+    }
+    mocker.patch.object(
+        script, "resolve_latest_version", side_effect=lambda pid, using: {"PackA": "2.0.0", "Shared": "4.0.0"}[pid]
+    )
+    # PackA depends on Shared at a minimum far below what is installed.
+    mocker.patch.object(
+        script,
+        "fetch_mandatory_dependencies",
+        side_effect=[{"PackA": {"Shared": "1.0.0"}}, {}],
+    )
+
+    wanted = script.resolve_install_closure(
+        [{"id": "PackA", "version": "latest"}, {"id": "Shared", "version": "latest"}],
+        using="",
+        installed=installed,
+        upgrade=True,
+    )
+
+    assert wanted["PackA"] == "2.0.0"
+    # Shared was requested for upgrade to 4.0.0; the dependency pass must not
+    # drag it back to the installed 3.0.0.
+    assert wanted["Shared"] == "4.0.0"
+
+
+def test_resolve_install_closure_still_raises_a_dependency_to_min_version(mocker):
+    script, _ = load_script()
+    installed = {"PackA": {"version": "1.0.0"}, "Dep": {"version": "1.0.0"}}
+    mocker.patch.object(script, "resolve_latest_version", side_effect=lambda pid, using: "1.0.0")
+    mocker.patch.object(
+        script,
+        "fetch_mandatory_dependencies",
+        side_effect=[{"PackA": {"Dep": "2.5.0"}}, {}],
+    )
+
+    wanted = script.resolve_install_closure([{"id": "PackA", "version": "latest"}], using="", installed=installed, upgrade=False)
+
+    assert wanted["Dep"] == "2.5.0"

--- a/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager_test.py
+++ b/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager_test.py
@@ -728,8 +728,8 @@ def test_do_list_groups_by_category_and_drops_visible_and_path(mocker):
     script.do_list({})
     out = "\n".join(str(r.get("Contents", "")) for r in demisto_mock._results if isinstance(r, dict))
 
-    assert "**Endpoint**" in out
-    assert "**Identity**" in out
+    assert "**ENDPOINT**" in out
+    assert "**IDENTITY**" in out
     # visible/path are not rendered; "visible_only" in the summary line is fine.
     assert "| visible" not in out
     assert "Packs/soc-a" not in out
@@ -745,8 +745,8 @@ def test_do_list_defaults_to_list_not_table(mocker):
 
     # A markdown table gets transposed when a category has a single pack.
     assert "| --- |" not in out
-    assert "\nsoc-a — " in out
-    assert "1.0.4 → 1.0.5 · update available" in out
+    assert "**soc-a**" in out
+    assert "🔵 **soc-a**  1.0.4 → 1.0.5" in out
 
 
 def test_do_list_table_format_still_available(mocker):
@@ -773,9 +773,9 @@ def test_do_list_line_wording_per_status(mocker):
     script.do_list({})
     out = "\n".join(str(r.get("Contents", "")) for r in demisto_mock._results if isinstance(r, dict))
 
-    assert "1.0.5 · up to date" in out
-    assert "ahead of catalog (2.0.0)" in out
-    assert "not installed · 1.0.0 available" in out
+    assert "🟢 **soc-a**  1.0.5" in out
+    assert "🟠 **soc-b**  9.9.9 installed · catalog 2.0.0" in out
+    assert "⚪ **soc-c**  1.0.0 available" in out
 
 
 def test_do_list_flat_when_grouping_disabled(mocker):
@@ -851,7 +851,7 @@ def test_do_list_links_pack_id_to_docs(mocker):
     script.do_list({})
     out = "\n".join(str(r.get("Contents", "")) for r in demisto_mock._results if isinstance(r, dict))
 
-    assert "\nsoc-a — " in out
+    assert "**soc-a**" in out
     assert "[docs](https://palo-cortex.github.io/secops-framework/soc-a/overview/)" in out
     # Never emit a relative href -- XSIAM resolves it against the tenant host.
     assert "](/" not in out
@@ -896,7 +896,7 @@ def test_do_list_leaves_pack_id_unlinked_for_copy_paste(mocker):
     out = "\n".join(str(r.get("Contents", "")) for r in demisto_mock._results if isinstance(r, dict))
 
     # The id has to be plain text so it can be pasted into pack_id=.
-    assert "\nsoc-a — " in out
+    assert "**soc-a**" in out
     assert "[soc-a](" not in out
     assert "[docs](https://palo-cortex.github.io/secops-framework/soc-a/overview/)" in out
 

--- a/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager_test.py
+++ b/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager_test.py
@@ -610,9 +610,7 @@ def test_install_marketplace_packs_sends_full_closure_in_object_body():
     }
     demisto_mock._command_responses["core-api-post"] = [{"Type": 1, "Contents": {"response": []}}]
 
-    result = script.install_marketplace_packs(
-        [{"id": "CommonScripts", "version": "latest"}], "", 0, 0, debug=False
-    )
+    result = script.install_marketplace_packs([{"id": "CommonScripts", "version": "latest"}], "", 0, 0, debug=False)
 
     posts = [c for c in demisto_mock._commands if c[0] == "core-api-post"]
     assert len(posts) == 1
@@ -629,14 +627,10 @@ def test_install_marketplace_packs_sends_full_closure_in_object_body():
 
 def test_install_marketplace_packs_skips_when_already_satisfied():
     script, demisto_mock = load_script()
-    script.fetch_installed_packs = lambda using: {
-        "CommonScripts": {"version": "1.22.28", "update_available": False}
-    }
+    script.fetch_installed_packs = lambda using: {"CommonScripts": {"version": "1.22.28", "update_available": False}}
     script.resolve_install_closure = lambda seeds, using, installed, upgrade=False: {"CommonScripts": "1.22.28"}
 
-    result = script.install_marketplace_packs(
-        [{"id": "CommonScripts", "version": "latest"}], "", 0, 0, debug=False
-    )
+    result = script.install_marketplace_packs([{"id": "CommonScripts", "version": "latest"}], "", 0, 0, debug=False)
 
     assert [c for c in demisto_mock._commands if c[0] == "core-api-post"] == []
     assert result["installed"] == {}
@@ -676,14 +670,13 @@ def test_install_marketplace_packs_emits_legacy_context_on_failure():
         script.install_marketplace_packs([{"id": "CommonScripts", "version": "latest"}], "", 0, 0, debug=False)
 
     ctx = [r for r in demisto_mock._results if getattr(r, "outputs_prefix", None) == "ConfigurationSetup.MarketplacePacks"]
-    assert ctx and ctx[-1].outputs[0]["installationstatus"] == "Failed to install."
+    assert ctx
+    assert ctx[-1].outputs[0]["installationstatus"] == "Failed to install."
 
 
 def test_marketplace_context_rows_match_legacy_shape():
     script, _ = load_script()
-    rows = script._marketplace_context_rows(
-        {"A", "B", "C"}, {"A": "1.0.0", "D": "2.0.0"}, {"B": "3.0.0"}, {"C": "4.0.0"}
-    )
+    rows = script._marketplace_context_rows({"A", "B", "C"}, {"A": "1.0.0", "D": "2.0.0"}, {"B": "3.0.0"}, {"C": "4.0.0"})
     by_id = {r["packid"]: r for r in rows}
     assert set(by_id["A"]) == {"packid", "packversion", "installationstatus"}
     assert by_id["A"]["installationstatus"] == "Success."
@@ -1139,9 +1132,7 @@ def test_closure_upgrade_resolves_newest_published_version():
     script.fetch_mandatory_dependencies = lambda packs, using: {}
     script.resolve_latest_version = lambda pack_id, using: "1.22.39"
     installed = {"CommonScripts": {"version": "1.22.28", "update_available": True}}
-    closure = script.resolve_install_closure(
-        [{"id": "CommonScripts", "version": "latest"}], "", installed, upgrade=True
-    )
+    closure = script.resolve_install_closure([{"id": "CommonScripts", "version": "latest"}], "", installed, upgrade=True)
     assert closure == {"CommonScripts": "1.22.39"}
 
 
@@ -1176,16 +1167,12 @@ def test_closure_upgrade_does_not_force_upgrade_dependencies():
 
 def test_install_marketplace_packs_upgrade_produces_pending_install():
     script, demisto_mock = load_script()
-    script.fetch_installed_packs = lambda using: {
-        "CommonScripts": {"version": "1.22.28", "update_available": True}
-    }
+    script.fetch_installed_packs = lambda using: {"CommonScripts": {"version": "1.22.28", "update_available": True}}
     script.fetch_mandatory_dependencies = lambda packs, using: {}
     script.resolve_latest_version = lambda pack_id, using: "1.22.39"
     demisto_mock._command_responses["core-api-post"] = [{"Type": 1, "Contents": {"response": []}}]
 
-    result = script.install_marketplace_packs(
-        [{"id": "CommonScripts", "version": "latest"}], "", 0, 0, debug=False, upgrade=True
-    )
+    result = script.install_marketplace_packs([{"id": "CommonScripts", "version": "latest"}], "", 0, 0, debug=False, upgrade=True)
 
     posts = [c for c in demisto_mock._commands if c[0] == "core-api-post"]
     assert len(posts) == 1
@@ -1243,13 +1230,9 @@ def test_closure_highest_minversion_regardless_of_requirer_order():
 def test_closure_keeps_installed_version_when_it_exceeds_all_minimums():
     script, _ = load_script()
     graph = {"A": {"Dep": "1.0.0"}, "B": {"Dep": "2.0.0"}, "Dep": {}}
-    script.fetch_mandatory_dependencies = lambda packs, using: {
-        p["id"]: graph.get(p["id"], {}) for p in packs
-    }
+    script.fetch_mandatory_dependencies = lambda packs, using: {p["id"]: graph.get(p["id"], {}) for p in packs}
     installed = {"Dep": {"version": "9.9.9", "update_available": False}}
-    closure = script.resolve_install_closure(
-        [{"id": "A", "version": "1.0.0"}, {"id": "B", "version": "1.0.0"}], "", installed
-    )
+    closure = script.resolve_install_closure([{"id": "A", "version": "1.0.0"}, {"id": "B", "version": "1.0.0"}], "", installed)
     assert closure["Dep"] == "9.9.9"
 
 
@@ -1261,9 +1244,7 @@ def test_closure_raising_a_dependency_pulls_its_own_new_dependencies():
         "Mid": {"Deep": "1.0.0"},
         "Deep": {},
     }
-    script.fetch_mandatory_dependencies = lambda packs, using: {
-        p["id"]: graph.get(p["id"], {}) for p in packs
-    }
+    script.fetch_mandatory_dependencies = lambda packs, using: {p["id"]: graph.get(p["id"], {}) for p in packs}
     closure = script.resolve_install_closure([{"id": "A", "version": "1.0.0"}], "", {})
     assert closure["Mid"] == "2.0.0"
     assert closure["Deep"] == "1.0.0"

--- a/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager_test.py
+++ b/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager_test.py
@@ -37,6 +37,8 @@ def load_script():
     demisto_mock.debug = lambda x: None
     demisto_mock.info = lambda x: None
     demisto_mock.context = lambda: demisto_mock._context
+    demisto_mock._modules = {}
+    demisto_mock.getModules = lambda: demisto_mock._modules
 
     sys.modules["demistomock"] = demisto_mock
 
@@ -46,6 +48,15 @@ def load_script():
     common.argToList = lambda v: (
         v if isinstance(v, list) else [x.strip() for x in str(v).split(",") if x.strip()] if v not in (None, "") else []
     )
+
+    class _CommandResults:
+        def __init__(self, outputs_prefix=None, outputs_key_field=None, outputs=None, readable_output=None):
+            self.outputs_prefix = outputs_prefix
+            self.outputs_key_field = outputs_key_field
+            self.outputs = outputs
+            self.readable_output = readable_output
+
+    common.CommandResults = _CommandResults
     sys.modules["CommonServerPython"] = common
 
     if SCRIPT_MODULE_NAME in sys.modules:
@@ -208,7 +219,7 @@ def test_do_list_renders_table(mocker):
     output = " ".join(str(r) for r in demisto._results)
     assert "soc-optimization-unified" in output
     assert "SocFrameworkTrendMicroVisionOne" in output
-    assert "showing: 1-2 of 2" in output
+    assert "2 pack(s)" in output
 
 
 def test_do_list_filter(mocker):
@@ -237,7 +248,7 @@ def test_do_list_filter(mocker):
 
     output = " ".join(str(r) for r in demisto._results)
     assert "SocFrameworkTrendMicroVisionOne" in output
-    assert "showing: 1-1 of 1" in output
+    assert "1 pack(s)" in output
 
 
 # ── action=sync-tags ──────────────────────────────────────────────────────────
@@ -463,3 +474,840 @@ def test_main_apply_pre_config_gate_stops_when_docs_present(mocker):
 
     results_flat = json.dumps(demisto._results)
     assert "stopped_after_pre_docs" in results_flat or "pre_config" in results_flat
+
+
+# ── Marketplace install ───────────────────────────────────────────────────────
+
+
+def test_ver_key_orders_versions():
+    script, _ = load_script()
+    assert script._ver_key("1.2.3") == (1, 2, 3)
+    assert script._ver_key("1.22.28") > script._ver_key("1.9.99")
+    assert script._ver_key("") == (0, 0, 0)
+    assert script._ver_key(None) == (0, 0, 0)
+    assert script._ver_key("2.0") == (2, 0, 0)
+
+
+def test_fetch_installed_packs_parses_version_and_update_flag():
+    script, demisto_mock = load_script()
+    demisto_mock._command_responses["core-api-get"] = [
+        {
+            "Type": 1,
+            "Contents": {
+                "response": [
+                    {"id": "Base", "currentVersion": "1.42.2", "updateAvailable": True},
+                    {"id": "Whois", "currentVersion": "1.5.42", "updateAvailable": False},
+                    {"currentVersion": "9.9.9"},
+                ]
+            },
+        }
+    ]
+    out = script.fetch_installed_packs("")
+    assert out["Base"] == {"version": "1.42.2", "update_available": True}
+    assert out["Whois"] == {"version": "1.5.42", "update_available": False}
+    assert len(out) == 2
+
+
+def test_fetch_installed_packs_returns_empty_on_error():
+    script, demisto_mock = load_script()
+
+    def boom(args):
+        raise RuntimeError("500")
+
+    demisto_mock._command_responses["core-api-get"] = boom
+    assert script.fetch_installed_packs("") == {}
+
+
+def test_fetch_mandatory_dependencies_filters_optional():
+    script, _ = load_script()
+    payload = {
+        "response": {
+            "packs": [
+                {
+                    "id": "CommonScripts",
+                    "extras": {
+                        "pack": {
+                            "dependencies": {
+                                "Base": {"mandatory": True, "minVersion": "1.42.1"},
+                                "Core": {"mandatory": True, "minVersion": "3.5.65"},
+                                "Optional": {"mandatory": False, "minVersion": "1.0.0"},
+                            }
+                        }
+                    },
+                }
+            ]
+        }
+    }
+    script.core_api_post = lambda path, body, using="": payload
+    out = script.fetch_mandatory_dependencies([{"id": "CommonScripts", "version": "1.0.0"}], "")
+    assert out == {"CommonScripts": {"Base": "1.42.1", "Core": "3.5.65"}}
+
+
+def test_resolve_install_closure_expands_transitive_dependencies():
+    script, _ = load_script()
+    graph = {
+        "CommonScripts": {"Base": "1.42.1", "DemistoRESTAPI": "1.4.5"},
+        "Base": {"Core": "3.5.65"},
+        "Core": {"CommonPlaybooks": "2.8.0"},
+        "CommonPlaybooks": {"rasterize": "2.1.30"},
+    }
+
+    def fake_deps(packs, using):
+        return {p["id"]: graph.get(p["id"], {}) for p in packs}
+
+    script.fetch_mandatory_dependencies = fake_deps
+    closure = script.resolve_install_closure([{"id": "CommonScripts", "version": "1.22.28"}], "", {})
+
+    assert set(closure) == {
+        "CommonScripts",
+        "Base",
+        "DemistoRESTAPI",
+        "Core",
+        "CommonPlaybooks",
+        "rasterize",
+    }
+    assert closure["CommonScripts"] == "1.22.28"
+    assert closure["Core"] == "3.5.65"
+
+
+def test_resolve_install_closure_prefers_installed_version_for_latest():
+    script, _ = load_script()
+    script.fetch_mandatory_dependencies = lambda packs, using: {}
+
+    def should_not_be_called(pack_id, using):
+        raise AssertionError("marketplace lookup should be skipped when the pack is installed")
+
+    script.resolve_latest_version = should_not_be_called
+    installed = {"Whois": {"version": "1.5.42", "update_available": True}}
+    closure = script.resolve_install_closure([{"id": "Whois", "version": "latest"}], "", installed)
+    assert closure == {"Whois": "1.5.42"}
+
+
+def test_resolve_install_closure_resolves_latest_when_not_installed():
+    script, _ = load_script()
+    script.fetch_mandatory_dependencies = lambda packs, using: {}
+    script.resolve_latest_version = lambda pack_id, using: "9.9.9"
+    closure = script.resolve_install_closure([{"id": "Whois", "version": "latest"}], "", {})
+    assert closure == {"Whois": "9.9.9"}
+
+
+def test_resolve_install_closure_upgrades_dependency_below_min_version():
+    script, _ = load_script()
+    script.fetch_mandatory_dependencies = lambda packs, using: (
+        {"A": {"Base": "2.0.0"}} if packs and packs[0]["id"] == "A" else {}
+    )
+    installed = {"Base": {"version": "1.0.0", "update_available": True}}
+    closure = script.resolve_install_closure([{"id": "A", "version": "1.0.0"}], "", installed)
+    assert closure["Base"] == "2.0.0"
+
+
+def test_install_marketplace_packs_sends_full_closure_in_object_body():
+    script, demisto_mock = load_script()
+    script.fetch_installed_packs = lambda using: {}
+    script.resolve_install_closure = lambda seeds, using, installed, upgrade=False: {
+        "CommonScripts": "1.22.28",
+        "Base": "1.42.2",
+    }
+    demisto_mock._command_responses["core-api-post"] = [{"Type": 1, "Contents": {"response": []}}]
+
+    result = script.install_marketplace_packs(
+        [{"id": "CommonScripts", "version": "latest"}], "", 0, 0, debug=False
+    )
+
+    posts = [c for c in demisto_mock._commands if c[0] == "core-api-post"]
+    assert len(posts) == 1
+    args = posts[0][1]
+    assert args["uri"] == "/contentpacks/marketplace/install"
+    body = json.loads(args["body"])
+    # Object wrapper, and the dependency has to ride along with the requested pack.
+    assert sorted(body["packs"], key=lambda p: p["id"]) == [
+        {"id": "Base", "version": "1.42.2"},
+        {"id": "CommonScripts", "version": "1.22.28"},
+    ]
+    assert result["installed"] == {"CommonScripts": "1.22.28", "Base": "1.42.2"}
+
+
+def test_install_marketplace_packs_skips_when_already_satisfied():
+    script, demisto_mock = load_script()
+    script.fetch_installed_packs = lambda using: {
+        "CommonScripts": {"version": "1.22.28", "update_available": False}
+    }
+    script.resolve_install_closure = lambda seeds, using, installed, upgrade=False: {"CommonScripts": "1.22.28"}
+
+    result = script.install_marketplace_packs(
+        [{"id": "CommonScripts", "version": "latest"}], "", 0, 0, debug=False
+    )
+
+    assert [c for c in demisto_mock._commands if c[0] == "core-api-post"] == []
+    assert result["installed"] == {}
+    assert result["already_present"] == {"CommonScripts": "1.22.28"}
+
+
+def test_install_marketplace_packs_emits_legacy_context_on_success():
+    script, demisto_mock = load_script()
+    script.fetch_installed_packs = lambda using: {}
+    script.resolve_install_closure = lambda seeds, using, installed, upgrade=False: {
+        "CommonScripts": "1.22.28",
+        "Base": "1.42.2",
+    }
+    demisto_mock._command_responses["core-api-post"] = [{"Type": 1, "Contents": {"response": []}}]
+
+    script.install_marketplace_packs([{"id": "CommonScripts", "version": "latest"}], "", 0, 0, debug=False)
+
+    ctx = [r for r in demisto_mock._results if getattr(r, "outputs_prefix", None) == "ConfigurationSetup.MarketplacePacks"]
+    assert len(ctx) == 1
+    assert ctx[0].outputs_key_field == "packid"
+    rows = {r["packid"]: r["installationstatus"] for r in ctx[0].outputs}
+    assert rows["CommonScripts"] == "Success."
+    assert rows["Base"] == "Installed as requirement."
+
+
+def test_install_marketplace_packs_emits_legacy_context_on_failure():
+    script, demisto_mock = load_script()
+    script.fetch_installed_packs = lambda using: {}
+    script.resolve_install_closure = lambda seeds, using, installed, upgrade=False: {"CommonScripts": "1.22.28"}
+
+    def boom(args):
+        raise RuntimeError("dependency missing")
+
+    demisto_mock._command_responses["core-api-post"] = boom
+
+    with pytest.raises(Exception):
+        script.install_marketplace_packs([{"id": "CommonScripts", "version": "latest"}], "", 0, 0, debug=False)
+
+    ctx = [r for r in demisto_mock._results if getattr(r, "outputs_prefix", None) == "ConfigurationSetup.MarketplacePacks"]
+    assert ctx and ctx[-1].outputs[0]["installationstatus"] == "Failed to install."
+
+
+def test_marketplace_context_rows_match_legacy_shape():
+    script, _ = load_script()
+    rows = script._marketplace_context_rows(
+        {"A", "B", "C"}, {"A": "1.0.0", "D": "2.0.0"}, {"B": "3.0.0"}, {"C": "4.0.0"}
+    )
+    by_id = {r["packid"]: r for r in rows}
+    assert set(by_id["A"]) == {"packid", "packversion", "installationstatus"}
+    assert by_id["A"]["installationstatus"] == "Success."
+    assert by_id["D"]["installationstatus"] == "Installed as requirement."
+    assert by_id["B"]["installationstatus"] == "Already Installed on the machine."
+    assert by_id["C"]["installationstatus"] == "Failed to install."
+    assert by_id["A"]["packversion"] == "1.0.0"
+
+
+# ── list: drift + category grouping ───────────────────────────────────────────
+
+
+def _list_catalog():
+    return {
+        "packs": [
+            {"id": "soc-a", "display_name": "A", "category": "Endpoint", "version": "1.0.5", "visible": True},
+            {"id": "soc-b", "display_name": "B", "category": "Endpoint", "version": "2.0.0", "visible": True},
+            {"id": "soc-c", "display_name": "C", "category": "Identity", "version": "1.0.0", "visible": True},
+        ]
+    }
+
+
+def test_do_list_reports_install_status_per_pack(mocker):
+    script, demisto_mock = load_script()
+    mocker.patch.object(script, "fetch_pack_catalog", return_value=_list_catalog())
+    mocker.patch.object(
+        script,
+        "fetch_installed_packs",
+        return_value={
+            "soc-a": {"version": "1.0.4", "update_available": True},
+            "soc-b": {"version": "2.0.0", "update_available": False},
+        },
+    )
+
+    script.do_list({})
+    out = "\n".join(str(r.get("Contents", "")) for r in demisto_mock._results if isinstance(r, dict))
+
+    assert "update available" in out
+    assert "up to date" in out
+    assert "not installed" in out
+    assert "1.0.4" in out
+
+
+def test_do_list_groups_by_category_and_drops_visible_and_path(mocker):
+    script, demisto_mock = load_script()
+    mocker.patch.object(script, "fetch_pack_catalog", return_value=_list_catalog())
+    mocker.patch.object(script, "fetch_installed_packs", return_value={"soc-a": {"version": "1.0.5"}})
+
+    script.do_list({})
+    out = "\n".join(str(r.get("Contents", "")) for r in demisto_mock._results if isinstance(r, dict))
+
+    assert "**Endpoint**" in out
+    assert "**Identity**" in out
+    # visible/path are not rendered; "visible_only" in the summary line is fine.
+    assert "| visible" not in out
+    assert "Packs/soc-a" not in out
+
+
+def test_do_list_defaults_to_list_not_table(mocker):
+    script, demisto_mock = load_script()
+    mocker.patch.object(script, "fetch_pack_catalog", return_value=_list_catalog())
+    mocker.patch.object(script, "fetch_installed_packs", return_value={"soc-a": {"version": "1.0.4"}})
+
+    script.do_list({})
+    out = "\n".join(str(r.get("Contents", "")) for r in demisto_mock._results if isinstance(r, dict))
+
+    # A markdown table gets transposed when a category has a single pack.
+    assert "| --- |" not in out
+    assert "\nsoc-a — " in out
+    assert "1.0.4 → 1.0.5 · update available" in out
+
+
+def test_do_list_table_format_still_available(mocker):
+    script, demisto_mock = load_script()
+    mocker.patch.object(script, "fetch_pack_catalog", return_value=_list_catalog())
+    mocker.patch.object(script, "fetch_installed_packs", return_value={"soc-a": {"version": "1.0.5"}})
+
+    script.do_list({"output_format": "table"})
+    out = "\n".join(str(r.get("Contents", "")) for r in demisto_mock._results if isinstance(r, dict))
+
+    assert "| --- |" in out
+    assert "| installed" in out
+
+
+def test_do_list_line_wording_per_status(mocker):
+    script, demisto_mock = load_script()
+    mocker.patch.object(script, "fetch_pack_catalog", return_value=_list_catalog())
+    mocker.patch.object(
+        script,
+        "fetch_installed_packs",
+        return_value={"soc-a": {"version": "1.0.5"}, "soc-b": {"version": "9.9.9"}},
+    )
+
+    script.do_list({})
+    out = "\n".join(str(r.get("Contents", "")) for r in demisto_mock._results if isinstance(r, dict))
+
+    assert "1.0.5 · up to date" in out
+    assert "ahead of catalog (2.0.0)" in out
+    assert "not installed · 1.0.0 available" in out
+
+
+def test_do_list_flat_when_grouping_disabled(mocker):
+    script, demisto_mock = load_script()
+    mocker.patch.object(script, "fetch_pack_catalog", return_value=_list_catalog())
+    mocker.patch.object(script, "fetch_installed_packs", return_value={})
+
+    script.do_list({"group_by_category": "false"})
+    out = "\n".join(str(r.get("Contents", "")) for r in demisto_mock._results if isinstance(r, dict))
+
+    assert "**Endpoint**" not in out
+    assert "soc-a" in out
+
+
+def test_do_list_marks_status_unknown_when_installed_lookup_fails(mocker):
+    script, demisto_mock = load_script()
+    mocker.patch.object(script, "fetch_pack_catalog", return_value=_list_catalog())
+    mocker.patch.object(script, "fetch_installed_packs", return_value={})
+
+    script.do_list({})
+    out = "\n".join(str(r.get("Contents", "")) for r in demisto_mock._results if isinstance(r, dict))
+
+    assert "unknown" in out
+    assert "not installed" not in out
+
+
+def test_do_list_flags_pack_ahead_of_catalog(mocker):
+    script, demisto_mock = load_script()
+    mocker.patch.object(script, "fetch_pack_catalog", return_value=_list_catalog())
+    mocker.patch.object(script, "fetch_installed_packs", return_value={"soc-a": {"version": "9.9.9"}})
+
+    script.do_list({})
+    out = "\n".join(str(r.get("Contents", "")) for r in demisto_mock._results if isinstance(r, dict))
+
+    assert "ahead of catalog" in out
+
+
+def test_pack_docs_url_uses_docs_path_basename():
+    script, _ = load_script()
+    url = script._pack_docs_url(
+        {"id": "soc-wiz-cloud", "docs_path": "docs/soc-wiz-cloud"},
+        "https://palo-cortex.github.io/secops-framework",
+    )
+    assert url == "https://palo-cortex.github.io/secops-framework/soc-wiz-cloud/overview/"
+
+
+def test_pack_docs_url_is_absolute_and_tolerates_trailing_slash():
+    script, _ = load_script()
+    url = script._pack_docs_url(
+        {"id": "soc-a", "docs_path": "docs/soc-a/"},
+        "https://example.com/site/",
+    )
+    assert url.startswith("https://")
+    assert url == "https://example.com/site/soc-a/overview/"
+
+
+def test_pack_docs_url_falls_back_to_pack_id():
+    script, _ = load_script()
+    url = script._pack_docs_url({"id": "soc-b"}, "https://example.com")
+    assert url == "https://example.com/soc-b/overview/"
+
+
+def test_pack_docs_url_empty_when_base_disabled():
+    script, _ = load_script()
+    assert script._pack_docs_url({"id": "soc-b", "docs_path": "docs/soc-b"}, "") == ""
+
+
+def test_do_list_links_pack_id_to_docs(mocker):
+    script, demisto_mock = load_script()
+    mocker.patch.object(script, "fetch_pack_catalog", return_value=_list_catalog())
+    mocker.patch.object(script, "fetch_installed_packs", return_value={"soc-a": {"version": "1.0.5"}})
+
+    script.do_list({})
+    out = "\n".join(str(r.get("Contents", "")) for r in demisto_mock._results if isinstance(r, dict))
+
+    assert "\nsoc-a — " in out
+    assert "[docs](https://palo-cortex.github.io/secops-framework/soc-a/overview/)" in out
+    # Never emit a relative href -- XSIAM resolves it against the tenant host.
+    assert "](/" not in out
+
+
+def test_do_list_omits_link_when_docs_base_url_blank(mocker):
+    script, demisto_mock = load_script()
+    mocker.patch.object(script, "fetch_pack_catalog", return_value=_list_catalog())
+    mocker.patch.object(script, "fetch_installed_packs", return_value={})
+
+    script.do_list({"docs_base_url": ""})
+    out = "\n".join(str(r.get("Contents", "")) for r in demisto_mock._results if isinstance(r, dict))
+
+    assert "soc-a" in out
+    assert "](http" not in out
+
+
+def test_pack_docs_url_prefers_explicit_absolute_docs_field():
+    script, _ = load_script()
+    url = script._pack_docs_url(
+        {"id": "soc-a", "docs_path": "docs/soc-a", "docs": "https://example.com/custom/page/"},
+        "https://palo-cortex.github.io/secops-framework",
+    )
+    assert url == "https://example.com/custom/page/"
+
+
+def test_pack_docs_url_treats_relative_docs_field_as_a_path():
+    script, _ = load_script()
+    url = script._pack_docs_url(
+        {"id": "soc-a", "docs": "docs/soc-a"},
+        "https://example.com",
+    )
+    assert url == "https://example.com/soc-a/overview/"
+
+
+def test_do_list_leaves_pack_id_unlinked_for_copy_paste(mocker):
+    script, demisto_mock = load_script()
+    mocker.patch.object(script, "fetch_pack_catalog", return_value=_list_catalog())
+    mocker.patch.object(script, "fetch_installed_packs", return_value={"soc-a": {"version": "1.0.4"}})
+
+    script.do_list({})
+    out = "\n".join(str(r.get("Contents", "")) for r in demisto_mock._results if isinstance(r, dict))
+
+    # The id has to be plain text so it can be pasted into pack_id=.
+    assert "\nsoc-a — " in out
+    assert "[soc-a](" not in out
+    assert "[docs](https://palo-cortex.github.io/secops-framework/soc-a/overview/)" in out
+
+
+def test_do_list_table_puts_docs_in_its_own_column(mocker):
+    script, demisto_mock = load_script()
+    mocker.patch.object(script, "fetch_pack_catalog", return_value=_list_catalog())
+    mocker.patch.object(script, "fetch_installed_packs", return_value={"soc-a": {"version": "1.0.5"}})
+
+    script.do_list({"output_format": "table"})
+    out = "\n".join(str(r.get("Contents", "")) for r in demisto_mock._results if isinstance(r, dict))
+
+    assert "| docs |" in out
+    assert "[soc-a](" not in out
+    assert "[docs](" in out
+
+
+def test_do_list_headings_are_not_absorbed_into_a_markdown_list(mocker):
+    script, demisto_mock = load_script()
+    mocker.patch.object(script, "fetch_pack_catalog", return_value=_list_catalog())
+    mocker.patch.object(script, "fetch_installed_packs", return_value={"soc-a": {"version": "1.0.4"}})
+
+    script.do_list({})
+    out = "\n".join(str(r.get("Contents", "")) for r in demisto_mock._results if isinstance(r, dict))
+
+    # A bold heading directly after a list item becomes a lazy continuation of
+    # that list, which indents every heading after the first.
+    assert "\n- " not in out
+    for line in out.splitlines():
+        if line.startswith("**") and line.endswith("**"):
+            continue
+        assert not line.lstrip().startswith("- ")
+
+
+# ── diagnose + loud degradation ───────────────────────────────────────────────
+
+
+def test_dependency_lookup_failure_raises_typed_error():
+    script, demisto_mock = load_script()
+
+    def boom(args):
+        raise RuntimeError("404 route not found")
+
+    demisto_mock._command_responses["core-api-post"] = boom
+    with pytest.raises(script.DependencyLookupError):
+        script.fetch_mandatory_dependencies([{"id": "CommonScripts", "version": "1.0.0"}], "")
+
+    out = "\n".join(str(r.get("Contents", "")) for r in demisto_mock._results if isinstance(r, dict))
+    assert "Dependency lookup failed" in out
+    assert "404 route not found" in out
+    assert "not the install endpoint" in out
+
+
+def test_install_does_not_attempt_when_dependencies_unresolvable():
+    script, demisto_mock = load_script()
+    script.fetch_installed_packs = lambda using: {}
+
+    def raise_lookup(seeds, using, installed, upgrade=False):
+        raise script.DependencyLookupError("dependency endpoint returned 500")
+
+    script.resolve_install_closure = raise_lookup
+
+    with pytest.raises(Exception) as exc:
+        script.install_marketplace_packs([{"id": "CommonScripts", "version": "latest"}], "", 0, 0, debug=False)
+
+    assert "was not attempted" in str(exc.value)
+    assert "dependency endpoint returned 500" in str(exc.value)
+    # Nothing should have been sent to the install endpoint.
+    assert [c for c in demisto_mock._commands if c[0] == "core-api-post"] == []
+
+
+def test_installed_packs_failure_is_announced():
+    script, demisto_mock = load_script()
+
+    def boom(args):
+        raise RuntimeError("500 internal")
+
+    demisto_mock._command_responses["core-api-get"] = boom
+    assert script.fetch_installed_packs("") == {}
+
+    out = "\n".join(str(r.get("Contents", "")) for r in demisto_mock._results if isinstance(r, dict))
+    assert "Could not read installed packs" in out
+    assert "500 internal" in out
+
+
+def test_diagnose_reports_pass_and_fail_per_endpoint():
+    script, demisto_mock = load_script()
+    script.fetch_installed_packs = lambda using: {}
+
+    def get_ok(args):
+        uri = args.get("uri", "")
+        if uri.endswith("/metadata/installed"):
+            return [{"Type": 1, "Contents": {"response": [{"id": "Whois", "currentVersion": "1.5.42"}]}}]
+        raise RuntimeError("boom on marketplace metadata")
+
+    def post_fail(args):
+        raise RuntimeError("dependency endpoint unavailable")
+
+    demisto_mock._command_responses["core-api-get"] = get_ok
+    demisto_mock._command_responses["core-api-post"] = post_fail
+
+    script.do_diagnose({})
+    out = "\n".join(str(r.get("Contents", "")) for r in demisto_mock._results if isinstance(r, dict))
+
+    assert "installed packs" in out
+    assert "pass" in out
+    assert "FAIL" in out
+    assert "dependency endpoint unavailable" in out
+
+
+def test_diagnose_all_pass_verdict():
+    script, demisto_mock = load_script()
+    demisto_mock._modules = {"Core REST API_instance_1": {"brand": "Core REST API", "state": "active"}}
+
+    def get_ok(args):
+        uri = args.get("uri", "")
+        if uri.endswith("/metadata/installed"):
+            return [{"Type": 1, "Contents": {"response": [{"id": "Whois", "currentVersion": "1.5.42"}]}}]
+        return [{"Type": 1, "Contents": {"response": {"currentVersion": "1.5.43"}}}]
+
+    def post_ok(args):
+        return [
+            {
+                "Type": 1,
+                "Contents": {
+                    "response": {
+                        "packs": [
+                            {
+                                "id": "Whois",
+                                "extras": {"pack": {"dependencies": {"Base": {"mandatory": True, "minVersion": "1.0.0"}}}},
+                            }
+                        ]
+                    }
+                },
+            }
+        ]
+
+    demisto_mock._command_responses["core-api-get"] = get_ok
+    demisto_mock._command_responses["core-api-post"] = post_ok
+
+    script.do_diagnose({})
+    out = "\n".join(str(r.get("Contents", "")) for r in demisto_mock._results if isinstance(r, dict))
+
+    assert "All checks passed" in out
+    assert "FAIL" not in out
+
+
+def test_find_core_rest_api_instances_matches_known_brands():
+    script, demisto_mock = load_script()
+    demisto_mock._modules = {
+        "Core REST API_instance_1": {"brand": "Core REST API", "state": "active"},
+        "SOCFWPackManager_instance_1": {"brand": "SOCFWPackManager", "state": "active"},
+        "Something": {"brand": "Whois", "state": "active"},
+    }
+    found = script.find_core_rest_api_instances()
+    assert [f["name"] for f in found] == ["Core REST API_instance_1"]
+
+
+def test_find_core_rest_api_instances_empty_when_absent():
+    script, demisto_mock = load_script()
+    demisto_mock._modules = {"SOCFWPackManager_instance_1": {"brand": "SOCFWPackManager", "state": "active"}}
+    assert script.find_core_rest_api_instances() == []
+
+
+def test_diagnose_names_missing_core_rest_api_instance_first():
+    script, demisto_mock = load_script()
+    demisto_mock._modules = {}
+
+    def boom(args):
+        raise RuntimeError("connection refused")
+
+    demisto_mock._command_responses["core-api-get"] = boom
+    demisto_mock._command_responses["core-api-post"] = boom
+
+    script.do_diagnose({})
+    out = "\n".join(str(r.get("Contents", "")) for r in demisto_mock._results if isinstance(r, dict))
+
+    # The missing instance is the real cause; it must be named rather than
+    # leaving three opaque transport errors to interpret.
+    assert "Core REST API instance" in out
+    assert "none configured" in out
+    assert out.index("Core REST API instance") < out.index("installed packs")
+
+
+def test_dependency_failure_hint_names_missing_instance():
+    script, demisto_mock = load_script()
+    demisto_mock._modules = {}
+
+    def boom(args):
+        raise RuntimeError("500")
+
+    demisto_mock._command_responses["core-api-post"] = boom
+    with pytest.raises(script.DependencyLookupError):
+        script.fetch_mandatory_dependencies([{"id": "CommonScripts", "version": "1.0.0"}], "")
+
+    out = "\n".join(str(r.get("Contents", "")) for r in demisto_mock._results if isinstance(r, dict))
+    assert "No Core REST API instance is configured" in out
+
+
+def test_dependency_failure_hint_when_instance_present():
+    script, demisto_mock = load_script()
+    demisto_mock._modules = {"Core REST API_instance_1": {"brand": "Core REST API", "state": "active"}}
+
+    def boom(args):
+        raise RuntimeError("404")
+
+    demisto_mock._command_responses["core-api-post"] = boom
+    with pytest.raises(script.DependencyLookupError):
+        script.fetch_mandatory_dependencies([{"id": "CommonScripts", "version": "1.0.0"}], "")
+
+    out = "\n".join(str(r.get("Contents", "")) for r in demisto_mock._results if isinstance(r, dict))
+    assert "route or payload problem" in out
+
+
+# ── upgrade_marketplace ───────────────────────────────────────────────────────
+
+
+def test_closure_default_keeps_installed_version_and_skips_lookup():
+    script, _ = load_script()
+    script.fetch_mandatory_dependencies = lambda packs, using: {}
+
+    def should_not_run(pack_id, using):
+        raise AssertionError("marketplace lookup must be skipped when not upgrading")
+
+    script.resolve_latest_version = should_not_run
+    installed = {"CommonScripts": {"version": "1.22.28", "update_available": True}}
+    closure = script.resolve_install_closure([{"id": "CommonScripts", "version": "latest"}], "", installed)
+    assert closure == {"CommonScripts": "1.22.28"}
+
+
+def test_closure_upgrade_resolves_newest_published_version():
+    script, _ = load_script()
+    script.fetch_mandatory_dependencies = lambda packs, using: {}
+    script.resolve_latest_version = lambda pack_id, using: "1.22.39"
+    installed = {"CommonScripts": {"version": "1.22.28", "update_available": True}}
+    closure = script.resolve_install_closure(
+        [{"id": "CommonScripts", "version": "latest"}], "", installed, upgrade=True
+    )
+    assert closure == {"CommonScripts": "1.22.39"}
+
+
+def test_closure_upgrade_skips_lookup_when_no_update_available():
+    script, _ = load_script()
+    script.fetch_mandatory_dependencies = lambda packs, using: {}
+
+    def should_not_run(pack_id, using):
+        raise AssertionError("no update available, so the large lookup is wasted")
+
+    script.resolve_latest_version = should_not_run
+    installed = {"Whois": {"version": "1.5.43", "update_available": False}}
+    closure = script.resolve_install_closure([{"id": "Whois", "version": "latest"}], "", installed, upgrade=True)
+    assert closure == {"Whois": "1.5.43"}
+
+
+def test_closure_upgrade_does_not_force_upgrade_dependencies():
+    script, _ = load_script()
+    script.resolve_latest_version = lambda pack_id, using: "2.0.0"
+    script.fetch_mandatory_dependencies = lambda packs, using: (
+        {"A": {"Base": "1.0.0"}} if packs and packs[0]["id"] == "A" else {}
+    )
+    installed = {
+        "A": {"version": "1.0.0", "update_available": True},
+        "Base": {"version": "1.42.2", "update_available": True},
+    }
+    closure = script.resolve_install_closure([{"id": "A", "version": "latest"}], "", installed, upgrade=True)
+    assert closure["A"] == "2.0.0"
+    # Dependency already satisfies minVersion, so it stays put.
+    assert closure["Base"] == "1.42.2"
+
+
+def test_install_marketplace_packs_upgrade_produces_pending_install():
+    script, demisto_mock = load_script()
+    script.fetch_installed_packs = lambda using: {
+        "CommonScripts": {"version": "1.22.28", "update_available": True}
+    }
+    script.fetch_mandatory_dependencies = lambda packs, using: {}
+    script.resolve_latest_version = lambda pack_id, using: "1.22.39"
+    demisto_mock._command_responses["core-api-post"] = [{"Type": 1, "Contents": {"response": []}}]
+
+    result = script.install_marketplace_packs(
+        [{"id": "CommonScripts", "version": "latest"}], "", 0, 0, debug=False, upgrade=True
+    )
+
+    posts = [c for c in demisto_mock._commands if c[0] == "core-api-post"]
+    assert len(posts) == 1
+    body = json.loads(posts[0][1]["body"])
+    assert body["packs"] == [{"id": "CommonScripts", "version": "1.22.39"}]
+    assert result["installed"] == {"CommonScripts": "1.22.39"}
+
+
+def test_closure_takes_highest_minversion_across_requirers():
+    """Regression: Base and CommonScripts want Core >= 3.5.75 while
+    CommonPlaybooks only wants 3.5.73. Taking the first value seen resolved
+    Core to 3.5.73 and the platform rejected the whole install with
+    'Mismatching dependency contentpack with ID Core'.
+    """
+    script, _ = load_script()
+    graph = {
+        "Base": {"Core": "3.5.75"},
+        "CommonPlaybooks": {"Core": "3.5.73"},
+        "CommonScripts": {"Core": "3.5.75"},
+        "Core": {},
+    }
+
+    def fake_deps(packs, using):
+        return {p["id"]: graph.get(p["id"], {}) for p in packs}
+
+    script.fetch_mandatory_dependencies = fake_deps
+    closure = script.resolve_install_closure(
+        [
+            {"id": "CommonPlaybooks", "version": "2.8.5"},
+            {"id": "Base", "version": "1.42.13"},
+            {"id": "CommonScripts", "version": "1.22.39"},
+        ],
+        "",
+        {},
+    )
+    assert closure["Core"] == "3.5.75"
+
+
+def test_closure_highest_minversion_regardless_of_requirer_order():
+    script, _ = load_script()
+    graph = {"A": {"Dep": "1.0.0"}, "B": {"Dep": "5.0.0"}, "Dep": {}}
+
+    def fake_deps(packs, using):
+        return {p["id"]: graph.get(p["id"], {}) for p in packs}
+
+    script.fetch_mandatory_dependencies = fake_deps
+    for seeds in (
+        [{"id": "A", "version": "1.0.0"}, {"id": "B", "version": "1.0.0"}],
+        [{"id": "B", "version": "1.0.0"}, {"id": "A", "version": "1.0.0"}],
+    ):
+        closure = script.resolve_install_closure(seeds, "", {})
+        assert closure["Dep"] == "5.0.0", f"order-dependent result for {seeds}"
+
+
+def test_closure_keeps_installed_version_when_it_exceeds_all_minimums():
+    script, _ = load_script()
+    graph = {"A": {"Dep": "1.0.0"}, "B": {"Dep": "2.0.0"}, "Dep": {}}
+    script.fetch_mandatory_dependencies = lambda packs, using: {
+        p["id"]: graph.get(p["id"], {}) for p in packs
+    }
+    installed = {"Dep": {"version": "9.9.9", "update_available": False}}
+    closure = script.resolve_install_closure(
+        [{"id": "A", "version": "1.0.0"}, {"id": "B", "version": "1.0.0"}], "", installed
+    )
+    assert closure["Dep"] == "9.9.9"
+
+
+def test_closure_raising_a_dependency_pulls_its_own_new_dependencies():
+    script, _ = load_script()
+    graph = {
+        "A": {"Mid": "2.0.0"},
+        # Mid only gains this dependency at 2.0.0.
+        "Mid": {"Deep": "1.0.0"},
+        "Deep": {},
+    }
+    script.fetch_mandatory_dependencies = lambda packs, using: {
+        p["id"]: graph.get(p["id"], {}) for p in packs
+    }
+    closure = script.resolve_install_closure([{"id": "A", "version": "1.0.0"}], "", {})
+    assert closure["Mid"] == "2.0.0"
+    assert closure["Deep"] == "1.0.0"
+
+
+def test_install_sends_ignore_warnings():
+    """Regression: without ignoreWarnings a pre-existing incident field makes
+    the platform reject the entire install ("Field with name 'Email
+    Classification' already exists"), which is guaranteed on any tenant that
+    already has content.
+    """
+    script, demisto_mock = load_script()
+    script.fetch_installed_packs = lambda using: {}
+    script.resolve_install_closure = lambda seeds, using, installed, upgrade=False: {"CommonScripts": "1.22.39"}
+    demisto_mock._command_responses["core-api-post"] = [{"Type": 1, "Contents": {"response": []}}]
+
+    script.install_marketplace_packs([{"id": "CommonScripts", "version": "latest"}], "", 0, 0, debug=False)
+
+    posts = [c for c in demisto_mock._commands if c[0] == "core-api-post"]
+    body = json.loads(posts[0][1]["body"])
+    assert body["ignoreWarnings"] is True
+    assert body["packs"] == [{"id": "CommonScripts", "version": "1.22.39"}]
+
+
+# ── pack id / directory naming ─────────────────────────────────────────────────
+
+
+def test_guess_pack_id_strips_version_and_prerelease_suffix():
+    script, _ = load_script()
+    cases = {
+        "soc-optimization-unified.zip": "soc-optimization-unified",
+        "soc-optimization-unified-v3.11.2.zip": "soc-optimization-unified",
+        "soc-optimization-unified-v3.11.2": "soc-optimization-unified",
+        "soc-optimization-unified-v3.11.1-pr1008.zip": "soc-optimization-unified",
+        "soc-common-playbooks-unified": "soc-common-playbooks-unified",
+        "SocFrameworkAbnormalSecurity-v1.0.4.zip": "SocFrameworkAbnormalSecurity",
+        "": "",
+    }
+    for given, expected in cases.items():
+        assert script._guess_pack_id_from_label(given) == expected, given
+
+
+def test_guess_pack_id_leaves_embedded_dash_v_alone():
+    """A naive split on "-v" truncated any pack whose own name contains it."""
+    script, _ = load_script()
+    assert script._guess_pack_id_from_label("soc-vendor-thing.zip") == "soc-vendor-thing"
+    assert script._guess_pack_id_from_label("soc-vendor-thing-v1.2.3.zip") == "soc-vendor-thing"

--- a/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager_test.py
+++ b/Packs/SocFrameworkManager/Scripts/SOCFWPackManager/SOCFWPackManager_test.py
@@ -355,7 +355,7 @@ def test_do_configure_missing_pack_id_raises():
         script.do_configure({})
 
 
-def test_do_configure_calls_all_sections(mocker):
+def test_do_configure_skips_lookups_by_default(mocker):
     script, _ = load_script()
 
     xsoar_cfg = {
@@ -376,6 +376,11 @@ def test_do_configure_calls_all_sections(mocker):
 
     mock_integ.assert_called_once()
     mock_jobs.assert_called_once()
+    # configure_lookups defaults to false: a pack that ships a Lookup directory
+    # already brings its dataset with it.
+    mock_lookups.assert_not_called()
+
+    script.do_configure({"pack_id": "my-pack", "configure_lookups": "true"})
     mock_lookups.assert_called_once()
 
 

--- a/Packs/SocFrameworkManager/pack_metadata.json
+++ b/Packs/SocFrameworkManager/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "SOC Framework Pack Manager",
     "description": "Installs and configures SOC Framework content packs directly from the XSIAM Playground. Manages the foundation layer, NIST IR orchestration, and vendor enhancement packs through a single bootloader script.",
     "support": "community",
-    "currentVersion": "1.0.0",
+    "currentVersion": "1.0.1",
     "author": "Palo Alto Networks",
     "url": "https://github.com/Palo-Cortex/secops-framework/tree/main/Packs/soc-framework-manager",
     "email": "",

--- a/Packs/SocFrameworkManager/pack_metadata.json
+++ b/Packs/SocFrameworkManager/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "SOC Framework Pack Manager",
     "description": "Installs and configures SOC Framework content packs directly from the XSIAM Playground. Manages the foundation layer, NIST IR orchestration, and vendor enhancement packs through a single bootloader script.",
     "support": "community",
-    "currentVersion": "1.0.1",
+    "currentVersion": "1.1.0",
     "author": "Palo Alto Networks",
     "url": "https://github.com/Palo-Cortex/secops-framework/tree/main/Packs/soc-framework-manager",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold

## Related Issues
N/A

## Description
Updates the SOC Framework Pack Manager pack to 1.1.0. All changes are confined to `Packs/SocFrameworkManager`.

**Fixes**
- Each release installed as a separate pack instead of upgrading in place. The extracted pack directory name becomes the pack ID on the tenant and retained the release version suffix, so `soc-optimization-unified-v3.11.2` installed alongside `soc-optimization-unified`. Verified on a development tenant: repeated installs now leave a single entry.
- A failed pack upload reported no reason. The demisto-sdk console threshold was `CRITICAL`, which suppressed the FAILED-UPLOADS report that carries the actual cause.
- An install that completed successfully but returned HTTP 500 was reported as a failure. The existing installed-state poll is now wired into the install path.

**Changes**
- Marketplace installation no longer requires the `XSIAMContentPackInstaller` automation. Packs and their mandatory dependencies install through the platform marketplace endpoints. The `ConfigurationSetup.MarketplacePacks` context output is unchanged, so existing consumers are unaffected.
- New `action=diagnose` probes each platform endpoint the install path depends on and reports which one fails. Read-only; nothing is installed or modified.
- New **Pack catalog URL** instance parameter and `socfw-get-catalog-url` command, so the catalog location is set once on the instance rather than passed on every invocation. A script cannot read another integration instance's parameters, which is why the value is surfaced through a command.
- `action=list` now reports the installed version and update status per pack, grouped by catalog category with documentation links.
- Adds the integration description file, which the pack was missing.

## Must have
- [x] Tests — 109 unit tests (89 script, 20 integration)
- [x] Documentation — pack, script and integration READMEs, integration description file, release notes


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-17504