### PR TITLE
[feedly] Add support for tags configuration

### DIFF
--- a/Packs/FeedFeedly/Integrations/FeedFeedly/FeedFeedly.py
+++ b/Packs/FeedFeedly/Integrations/FeedFeedly/FeedFeedly.py
@@ -115,6 +115,10 @@ THREAT_INTEL_TYPE_TO_DEMISTO_TYPES = {
 
 
 class Client(BaseClient):
+    def __init__(self, *args, feed_tags: Optional[list] = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.feed_tags = feed_tags or []
+
     def fetch_indicators_from_stream(self, stream_id: str, newer_than: float, *, limit: Optional[int] = None) -> list:
         params = {
             "streamId": stream_id,
@@ -145,8 +149,15 @@ class Client(BaseClient):
         for indicator in indicators:
             indicator["type"] = indicator.get("indicator_type", "")
             indicator["fields"] = indicator.get("customFields", {})
+            self._add_tags(indicator)
 
         return indicators
+
+    def _add_tags(self, indicator: dict[str, Any]) -> None:
+        if not self.feed_tags:
+            return
+        fields = indicator["fields"]
+        fields["tags"] = list(set(fields.get("tags", []) + self.feed_tags))
 
 
 class STIX2Parser:
@@ -993,6 +1004,7 @@ def main():  # pragma: no cover
     try:
         client = Client(
             base_url=FEEDLY_BASE_URL,
+            feed_tags=argToList(params.get("feedTags")),
             verify=not params.get("insecure", False),
             proxy=params.get("proxy", False),
             headers={"Authorization": f"Bearer {params['credentials']['password']}"},

--- a/Packs/FeedFeedly/Integrations/FeedFeedly/FeedFeedly_test.py
+++ b/Packs/FeedFeedly/Integrations/FeedFeedly/FeedFeedly_test.py
@@ -49,3 +49,28 @@ def test_build_iterator(requests_mock):
     ttp_tags = {"T1112", "T1125", "T1132.001", "T1566", "T1566.001"}
 
     assert set(report["fields"]["tags"]) == feedly_tags | threat_tags | ttp_tags
+
+
+def test_build_iterator_with_instance_tags(requests_mock):
+    """
+    Given:
+        - An instance configured with feed_tags
+    When:
+        - Fetching indicators from the stream
+    Then:
+        - The instance-level tags are merged onto every fetched indicator
+    """
+    with open("test_data/api_call_mock.txt") as file:
+        response = file.read()
+    requests_mock.get(URL, text=response)
+    client = Client(
+        base_url=URL,
+        verify=False,
+        proxy=False,
+        feed_tags=["incoming_feed", "source_feedly"],
+    )
+    indicators = client.fetch_indicators_from_stream("tag/enterpriseName/category/uuid", 0)
+
+    for indicator in indicators:
+        tags = set(indicator["fields"].get("tags", []))
+        assert {"incoming_feed", "source_feedly"} <= tags

--- a/Packs/FeedFeedly/ReleaseNotes/1_0_10.md
+++ b/Packs/FeedFeedly/ReleaseNotes/1_0_10.md
@@ -1,0 +1,5 @@
+#### Integrations
+
+##### Feedly Feed
+
+Fixed an issue where the instance-level **Tags** configuration was not applied to indicators ingested from the feed.

--- a/Packs/FeedFeedly/pack_metadata.json
+++ b/Packs/FeedFeedly/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Feedly",
     "description": "Import Articles from Feedly with enriched IOCs",
     "support": "partner",
-    "currentVersion": "1.0.9",
+    "currentVersion": "1.0.10",
     "author": "Feedly",
     "url": "https://feedly.com/i/landing/threatIntelligence",
     "email": "support@feedly.com",


### PR DESCRIPTION
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
Internal ticket

## Description
The "Tags" value configured on a Feedly Feed integration instance in Cortex XSIAM was not applied to indicators when they are ingested. 

## Must have
- [x] Tests
- [x] Documentation


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-17510