### PR TITLE
SpyCloud Enterprise Protection: add Severity 30 (SpyCloud Access Data) support

### DIFF
--- a/Packs/SpyCloudEnterpriseProtection/Classifiers/classifier-SpyCloud_Classifier.json
+++ b/Packs/SpyCloudEnterpriseProtection/Classifiers/classifier-SpyCloud_Classifier.json
@@ -6,7 +6,8 @@
         "2": "SpyCloud Informative Data",
         "20": "SpyCloud Breach Data",
         "25": "SpyCloud Malware Data",
-        "5": "SpyCloud Informative Data"
+        "5": "SpyCloud Informative Data",
+        "30": "SpyCloud Access Data"
     },
     "name": "SpyCloud - Classifier",
     "propagationLabels": [

--- a/Packs/SpyCloudEnterpriseProtection/IncidentTypes/incidenttype-SpyCloudAccessData.json
+++ b/Packs/SpyCloudEnterpriseProtection/IncidentTypes/incidenttype-SpyCloudAccessData.json
@@ -1,0 +1,49 @@
+{
+    "id": "SpyCloud Access Data",
+    "version": -1,
+    "vcShouldIgnore": false,
+    "locked": false,
+    "name": "SpyCloud Access Data",
+    "prevName": "SpyCloud Access Data",
+    "color": "#FFA05C",
+    "hours": 0,
+    "days": 0,
+    "weeks": 0,
+    "hoursR": 0,
+    "daysR": 0,
+    "weeksR": 0,
+    "system": false,
+    "readonly": false,
+    "default": false,
+    "autorun": false,
+    "disabled": false,
+    "reputationCalc": 0,
+    "onChangeRepAlg": 0,
+    "detached": false,
+    "extractSettings": {
+        "mode": "Specific",
+        "fieldCliNameToExtractSettings": {
+            "sourceip": {
+                "extractAsIsIndicatorTypeId": "ipRep",
+                "isExtractingAllIndicatorTypes": false,
+                "extractIndicatorTypesIDs": []
+            },
+            "spyclouddomain": {
+                "extractAsIsIndicatorTypeId": "domainRepUnified",
+                "isExtractingAllIndicatorTypes": false,
+                "extractIndicatorTypesIDs": []
+            },
+            "spycloudemail": {
+                "extractAsIsIndicatorTypeId": "emailRep",
+                "isExtractingAllIndicatorTypes": false,
+                "extractIndicatorTypesIDs": []
+            },
+            "spycloudtargetdomain": {
+                "extractAsIsIndicatorTypeId": "domainRepUnified",
+                "isExtractingAllIndicatorTypes": false,
+                "extractIndicatorTypesIDs": []
+            }
+        }
+    },
+    "fromVersion": "6.10.0"
+}

--- a/Packs/SpyCloudEnterpriseProtection/Integrations/SpyCloudEnterpriseProtectionFeed/README.md
+++ b/Packs/SpyCloudEnterpriseProtection/Integrations/SpyCloudEnterpriseProtectionFeed/README.md
@@ -1,6 +1,6 @@
 ## SpyCloud Enterprise Protection Feed
 
-Create breach and malware incidents in Cortex® XSOAR™ using the SpyCloud Enterprise Protection API.
+Create breach, malware and access incidents in Cortex® XSOAR™ using the SpyCloud Enterprise Protection API.
 This integration was integrated and tested with version 3.5 of SpyCloud Enterprise Protection API
 
 ## Configure SpyCloud Enterprise Protection Feed in Cortex

--- a/Packs/SpyCloudEnterpriseProtection/Integrations/SpyCloudEnterpriseProtectionFeed/SpyCloudEnterpriseProtectionFeed.py
+++ b/Packs/SpyCloudEnterpriseProtection/Integrations/SpyCloudEnterpriseProtectionFeed/SpyCloudEnterpriseProtectionFeed.py
@@ -41,18 +41,21 @@ INCIDENT_TYPE = {
     5: "SpyCloud Informative Data",
     20: "SpyCloud Breach Data",
     25: "SpyCloud Malware Data",
+    30: "SpyCloud Access Data",
 }
 INCIDENT_NAME = {
     2: "SpyCloud Informative Alert on",
     5: "SpyCloud Informative Alert on",
     20: "SpyCloud Breach Alert on",
     25: "SpyCloud Malware Alert on",
+    30: "SpyCloud Access Alert on",
 }
 SEVERITY_VALUE = {
     2: IncidentSeverity.INFO,
     5: IncidentSeverity.INFO,
     20: IncidentSeverity.HIGH,
     25: IncidentSeverity.CRITICAL,
+    30: IncidentSeverity.CRITICAL,
 }
 
 
@@ -172,9 +175,9 @@ def create_spycloud_args(args: dict, client: Client) -> dict:
         until_modification_date = until
 
     severity_list = argToList(args.get("severity", []))
-    supported_severities = {"2", "5", "25", "20"}
+    supported_severities = {"2", "5", "25", "20", "30"}
     if any(sev not in supported_severities for sev in severity_list):
-        raise DemistoException("Invalid input error: supported values for severity are: 2, 5, 20, 25")
+        raise DemistoException("Invalid input error: supported values for severity are: 2, 5, 20, 25, 30")
 
     return {
         "type": args.get("type", ""),

--- a/Packs/SpyCloudEnterpriseProtection/Integrations/SpyCloudEnterpriseProtectionFeed/SpyCloudEnterpriseProtectionFeed.yml
+++ b/Packs/SpyCloudEnterpriseProtection/Integrations/SpyCloudEnterpriseProtectionFeed/SpyCloudEnterpriseProtectionFeed.yml
@@ -72,6 +72,7 @@ configuration:
   hidden: false
   name: severity
   options:
+  - '30'
   - '25'
   - '20'
   - '5'

--- a/Packs/SpyCloudEnterpriseProtection/Integrations/SpyCloudEnterpriseProtectionFeed/SpyCloudEnterpriseProtectionFeed_description.md
+++ b/Packs/SpyCloudEnterpriseProtection/Integrations/SpyCloudEnterpriseProtectionFeed/SpyCloudEnterpriseProtectionFeed_description.md
@@ -1,6 +1,6 @@
 # SpyCloud Enterprise Protection Feed
 
-Integrate the SpyCloud Enterprise Protection API to create breach and malware incidents in Cortex® XSOAR™ using the SpyCloud Enterprise Protection API. Data for malware-infected
+Integrate the SpyCloud Enterprise Protection API to create breach, malware and access incidents in Cortex® XSOAR™ using the SpyCloud Enterprise Protection API. Data for malware-infected
 devices and exposed corporate applications are available for SpyCloud Compass users. 
 
 # How to get a SpyCloud Enterprise Protection API Key

--- a/Packs/SpyCloudEnterpriseProtection/Integrations/SpyCloudEnterpriseProtectionFeed/SpyCloudEnterpriseProtectionFeed_test.py
+++ b/Packs/SpyCloudEnterpriseProtection/Integrations/SpyCloudEnterpriseProtectionFeed/SpyCloudEnterpriseProtectionFeed_test.py
@@ -7,10 +7,14 @@ from SpyCloudEnterpriseProtectionFeed import (
     create_spycloud_args,
     fetch_incident,
     fetch_domain_or_watchlist_data,
+    INCIDENT_NAME,
+    INCIDENT_TYPE,
+    SEVERITY_VALUE,
     LIMIT_EXCEED,
     MONTHLY_QUOTA_EXCEED_MSG,
     TOO_MANY_REQUESTS,
 )
+from CommonServerPython import IncidentSeverity
 
 
 def util_load_json(path):
@@ -124,3 +128,21 @@ def test_create_spycloud_args():
     args = {"severity": "2, 1"}
     with pytest.raises(DemistoException):
         create_spycloud_args(args, client)
+
+
+def test_create_spycloud_args_accepts_severity_30(mocker):
+    # Severity 30 (SpyCloud Access Data) must be accepted, not rejected as invalid.
+    mocker.patch.object(client, "get_last_run", return_value="2023-05-30")
+    result = create_spycloud_args({"severity": "30"}, client)
+    assert result["severity"] == "30"
+
+    # The full set of supported severities, including 30, passes validation.
+    result = create_spycloud_args({"severity": "2, 5, 20, 25, 30"}, client)
+    assert result["severity"] == "2,5,20,25,30"
+
+
+def test_severity_30_mappings():
+    # Severity 30 maps to the SpyCloud Access Data incident type at CRITICAL severity.
+    assert INCIDENT_TYPE[30] == "SpyCloud Access Data"
+    assert INCIDENT_NAME[30] == "SpyCloud Access Alert on"
+    assert SEVERITY_VALUE[30] == IncidentSeverity.CRITICAL

--- a/Packs/SpyCloudEnterpriseProtection/ReleaseNotes/1_0_11.md
+++ b/Packs/SpyCloudEnterpriseProtection/ReleaseNotes/1_0_11.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### SpyCloud Enterprise Protection Feed
+
+- Adding Severity 30 (SpyCloud Access Data) support.

--- a/Packs/SpyCloudEnterpriseProtection/pack_metadata.json
+++ b/Packs/SpyCloudEnterpriseProtection/pack_metadata.json
@@ -1,8 +1,8 @@
 {
     "name": "SpyCloud Enterprise Protection",
-    "description": "Create breach and malware incidents in Cortex® XSOAR™ using the SpyCloud Enterprise Protection API. Provide enrichment for domains, IPs, emails, usernames, and passwords.",
+    "description": "Create breach, malware and access incidents in Cortex® XSOAR™ using the SpyCloud Enterprise Protection API. Provide enrichment for domains, IPs, emails, usernames, and passwords.",
     "support": "partner",
-    "currentVersion": "1.0.10",
+    "currentVersion": "1.0.11",
     "author": "SpyCloud",
     "url": "https://portal.spycloud.com",
     "email": "integrations@spycloud.com",


### PR DESCRIPTION
## Summary

Adds support for SpyCloud **Severity 30 (Access Data)** records to the SpyCloud Enterprise Protection pack.

## Changes

- **Classifier** — map severity `30` to the new `SpyCloud Access Data` incident type.
- **Incident type** — new `SpyCloud Access Data` type (Critical, indicator extraction for source IP / domain / email / target domain). No playbook attached, consistent with the Informative type.
- **Feed integration** — wire severity `30` into `INCIDENT_TYPE`, `INCIDENT_NAME`, `SEVERITY_VALUE` (→ CRITICAL), and the command severity validation; add `30` to the Severity configuration dropdown.
- **Docs** — integration README, integration description, and pack description updated to reference access incidents.
- **Tests** — added unit tests covering severity-30 acceptance and the type/name/severity mappings.

## Release notes

`Adding Severity 30 (SpyCloud Access Data) support.` — pack bumped to `1.0.11`.

## Testing

- `demisto-sdk validate` — passing
- `ruff` + `mypy` (py3.12) — passing
- Unit tests — 8 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-17515