### PR TITLE
Fix ODS detection in incoming mirroring

### DIFF
--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.py
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.py
@@ -2893,7 +2893,17 @@ def get_remote_detection_data_for_multiple_types(remote_incident_id):
     detection_type = ""
     mirroring_fields = ["status"]
     updated_object: dict[str, Any] = {}
-    if "idp" in mirrored_data["product"]:
+    # Check type-based conditions first (more specific) before product-based conditions (more generic).
+    # ODS and OFP detections carry product=epp but must be classified by their type, not their product.
+    if "ofp" in mirrored_data["type"]:
+        updated_object = {"incident_type": OFP_DETECTION}
+        detection_type = "ofp"
+        mirroring_fields = CS_FALCON_DETECTION_INCOMING_ARGS
+    elif "ods" in mirrored_data["type"]:
+        updated_object = {"incident_type": ON_DEMAND_SCANS_DETECTION}
+        detection_type = "ods"
+        mirroring_fields = CS_FALCON_DETECTION_INCOMING_ARGS
+    elif "idp" in mirrored_data["product"]:
         updated_object = {"incident_type": IDP_DETECTION}
         detection_type = "IDP"
         mirroring_fields = CS_FALCON_DETECTION_INCOMING_ARGS_IDP
@@ -2904,14 +2914,6 @@ def get_remote_detection_data_for_multiple_types(remote_incident_id):
     elif "epp" in mirrored_data["product"]:
         updated_object = {"incident_type": ENDPOINT_DETECTION}
         detection_type = "Detection"
-        mirroring_fields = CS_FALCON_DETECTION_INCOMING_ARGS
-    elif "ofp" in mirrored_data["type"]:
-        updated_object = {"incident_type": OFP_DETECTION}
-        detection_type = "ofp"
-        mirroring_fields = CS_FALCON_DETECTION_INCOMING_ARGS
-    elif "ods" in mirrored_data["type"]:
-        updated_object = {"incident_type": ON_DEMAND_SCANS_DETECTION}
-        detection_type = "ods"
         mirroring_fields = CS_FALCON_DETECTION_INCOMING_ARGS
     elif "ngsiem" in mirrored_data["product"]:
         updated_object = {"incident_type": NGSIEM_DETECTION}

--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon_test.py
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon_test.py
@@ -4038,6 +4038,7 @@ def test_get_remote_detection_data_for_multiple_types__endpoint_detection(mocker
         ("ngsiem", "ngsiem_detection", {}),
         ("Detection", "detection", {"type": "ldt", "product": "epp"}),
         ("ofp", "OFP detection", {"type": "ofp"}),
+        ("ods", "On-Demand Scans detection", {"type": "ods", "product": "epp"}),
     ],
 )
 def test_get_remote_detection_data_for_multiple_types(mocker, detection_type, incident_type, entity_modifications):

--- a/Packs/CrowdStrikeFalcon/ReleaseNotes/2_12_6.md
+++ b/Packs/CrowdStrikeFalcon/ReleaseNotes/2_12_6.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### CrowdStrike Falcon
+
+- Fixed an issue where ODS (On-Demand Scans) and OFP detections with *product=epp* were incorrectly classified as generic Endpoint Detection incidents during incoming mirroring, instead of their correct detection types.

--- a/Packs/CrowdStrikeFalcon/pack_metadata.json
+++ b/Packs/CrowdStrikeFalcon/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CrowdStrike Falcon",
     "description": "The CrowdStrike Falcon OAuth 2 API (formerly the Falcon Firehose API), enables fetching and resolving detections, searching devices, getting behaviors by ID, containing hosts, and lifting host containment.",
     "support": "xsoar",
-    "currentVersion": "2.12.5",
+    "currentVersion": "2.12.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-74315

## Description
Fixed an issue where ODS (On-Demand Scans) and OFP detections with *product=epp* were incorrectly classified as generic Endpoint Detection incidents during incoming mirroring, instead of their correct detection types.

