### PR TITLE
alert events fields from json string to top level

### DIFF
--- a/Packs/Vega/.secrets-ignore
+++ b/Packs/Vega/.secrets-ignore
@@ -2,3 +2,4 @@ https://api.vega.com
 example.com
 ::123
 ::8901
+10.0.0.1

--- a/Packs/Vega/Integrations/Vega/README.md
+++ b/Packs/Vega/Integrations/Vega/README.md
@@ -61,6 +61,7 @@ Fetch all aggregated alert events for a Vega alert using internal API pagination
 | Vega.AlertEvents.Count | Number | Number of alert events returned in the current page. |
 | Vega.AlertEvents.HasAlertEvents | Boolean | Whether the alert returned real alert events instead of aggregated parse-field summary rows. |
 | Vega.AlertEvents.Cached | Boolean | Whether the response was served from cached incident data. |
+| Vega.AlertEvents.Events | Unknown | Enriched alert events for the current page. JSON `fields` are parsed and `fields._raw` contents are promoted to top-level keys under `fields`. |
 | Vega.AlertEvents.CustomFields | Unknown | Incident custom fields to persist for the Alert Events layout section. |
 
 ### vega-set-detections-state

--- a/Packs/Vega/Integrations/Vega/Vega.py
+++ b/Packs/Vega/Integrations/Vega/Vega.py
@@ -1134,6 +1134,216 @@ def _try_parse_json_value(value: Any) -> Any:
         return value
 
 
+def _is_empty_alert_event_field_value(value: Any) -> bool:
+    """Return True when a field value should be treated as empty for _raw promotion."""
+    return value is None or value == "" or value == {} or value == []
+
+
+def _deep_merge_alert_event_dicts(
+    base: dict[str, Any],
+    incoming: dict[str, Any],
+    *,
+    prefer_existing: bool = True,
+) -> dict[str, Any]:
+    """Deep-merge dictionaries used while promoting alert-event fields."""
+    merged = dict(base)
+    for key, incoming_value in incoming.items():
+        if key not in merged or _is_empty_alert_event_field_value(merged.get(key)):
+            merged[key] = incoming_value
+            continue
+        existing_value = merged[key]
+        if isinstance(existing_value, dict) and isinstance(incoming_value, dict):
+            merged[key] = _deep_merge_alert_event_dicts(
+                existing_value,
+                incoming_value,
+                prefer_existing=prefer_existing,
+            )
+        elif isinstance(existing_value, list) and isinstance(incoming_value, list):
+            merged[key] = _merge_alert_event_object_lists(
+                existing_value,
+                incoming_value,
+                prefer_existing=prefer_existing,
+            )
+        elif not prefer_existing and not _is_empty_alert_event_field_value(incoming_value):
+            merged[key] = incoming_value
+    return merged
+
+
+def _merge_alert_event_object_lists(
+    left: list[Any],
+    right: list[Any],
+    *,
+    prefer_existing: bool = True,
+) -> list[Any]:
+    """Merge list values by index so Splunk multivalue object fields combine cleanly."""
+    length = max(len(left), len(right))
+    merged: list[Any] = []
+    for index in range(length):
+        left_value = left[index] if index < len(left) else None
+        right_value = right[index] if index < len(right) else None
+        if isinstance(left_value, dict) and isinstance(right_value, dict):
+            merged.append(_deep_merge_alert_event_dicts(left_value, right_value, prefer_existing=prefer_existing))
+        elif _is_empty_alert_event_field_value(left_value):
+            merged.append(right_value)
+        elif _is_empty_alert_event_field_value(right_value):
+            merged.append(left_value)
+        else:
+            merged.append(left_value if prefer_existing else right_value)
+    return merged
+
+
+def _parse_splunk_style_field_path(key: str) -> list[tuple[str, bool]]:
+    """
+    Parse Splunk-style field names into path segments.
+
+    Examples:
+        vendorInformation.provider -> [("vendorInformation", False), ("provider", False)]
+        securityResources{}.resourceType -> [("securityResources", True), ("resourceType", False)]
+    """
+    segments: list[tuple[str, bool]] = []
+    for part in str(key).split("."):
+        if not part:
+            continue
+        if part.endswith("{}"):
+            name = part[:-2]
+            if name:
+                segments.append((name, True))
+            continue
+        segments.append((part, False))
+    return segments
+
+
+def _assign_splunk_style_segments(
+    current: dict[str, Any],
+    segments: list[tuple[str, bool]],
+    value: Any,
+) -> None:
+    """Assign a value into current using parsed Splunk path segments."""
+    if not segments:
+        return
+
+    name, is_array = segments[0]
+    rest = segments[1:]
+    is_last = not rest
+
+    if is_array:
+        existing = current.get(name)
+        if not isinstance(existing, list):
+            existing = [] if _is_empty_alert_event_field_value(existing) else [existing]
+            current[name] = existing
+        arr: list[Any] = current[name]
+        values = value if isinstance(value, list) else [value]
+
+        if is_last:
+            for item_index, item_value in enumerate(values):
+                while len(arr) <= item_index:
+                    arr.append(None)
+                if _is_empty_alert_event_field_value(arr[item_index]):
+                    arr[item_index] = item_value
+            return
+
+        for item_index, item_value in enumerate(values):
+            while len(arr) <= item_index:
+                arr.append({})
+            if not isinstance(arr[item_index], dict):
+                if not _is_empty_alert_event_field_value(arr[item_index]):
+                    continue
+                arr[item_index] = {}
+            _assign_splunk_style_segments(arr[item_index], rest, item_value)
+        return
+
+    if is_last:
+        existing_value = current.get(name)
+        if _is_empty_alert_event_field_value(existing_value):
+            current[name] = value
+        elif isinstance(existing_value, dict) and isinstance(value, dict):
+            current[name] = _deep_merge_alert_event_dicts(existing_value, value, prefer_existing=True)
+        return
+
+    nested = current.get(name)
+    if not isinstance(nested, dict):
+        if not _is_empty_alert_event_field_value(nested):
+            return
+        nested = {}
+        current[name] = nested
+    _assign_splunk_style_segments(nested, rest, value)
+
+
+def _assign_splunk_style_path(root: dict[str, Any], key: str, value: Any) -> None:
+    """Assign a value into root using Splunk dotted / {}-array field naming."""
+    segments = _parse_splunk_style_field_path(key)
+    if segments:
+        _assign_splunk_style_segments(root, segments, value)
+
+
+def _expand_flat_raw_fields(raw_fields: dict[str, Any]) -> dict[str, Any]:
+    """
+    Expand flat Splunk-style keys into nested objects/arrays.
+
+    Keys without '.' or '{}' are copied as-is. Already-nested values are preserved.
+    """
+    expanded: dict[str, Any] = {}
+    for key, value in raw_fields.items():
+        key_name = str(key)
+        if key_name in ALERT_EVENT_JSON_TRUNCATE_KEYS:
+            continue
+        if "{}" in key_name or "." in key_name:
+            _assign_splunk_style_path(expanded, key_name, value)
+            continue
+        if key_name not in expanded or _is_empty_alert_event_field_value(expanded.get(key_name)):
+            expanded[key_name] = value
+        elif isinstance(expanded[key_name], dict) and isinstance(value, dict):
+            expanded[key_name] = _deep_merge_alert_event_dicts(expanded[key_name], value, prefer_existing=True)
+    return expanded
+
+
+def _promote_raw_into_alert_event_fields(fields: dict[str, Any]) -> dict[str, Any]:
+    """
+    Parse fields._raw and promote its contents to top-level keys under fields.
+
+    Existing non-empty schema values win on conflict. `_raw` is retained for fidelity.
+    """
+    raw_value = fields.get("_raw")
+    if raw_value is None:
+        return fields
+
+    parsed_raw = _try_parse_json_value(raw_value)
+    if not isinstance(parsed_raw, dict):
+        return fields
+
+    promoted = _expand_flat_raw_fields(parsed_raw)
+    if not promoted:
+        return fields
+
+    # Keep original _raw payload; merge promoted keys without wiping schema fields.
+    original_raw = fields.get("_raw")
+    merged = _deep_merge_alert_event_dicts(fields, promoted, prefer_existing=True)
+    if original_raw is not None:
+        merged["_raw"] = original_raw
+    return merged
+
+
+def _enrich_alert_event(event: dict[str, Any]) -> dict[str, Any]:
+    """
+    Return an alert event with fields JSON-parsed and `_raw` promoted for automation use.
+
+    Dynamic per event: only transforms when `fields` / `fields._raw` are present and parseable.
+    """
+    enriched = dict(event)
+    fields_value = enriched.get("fields")
+    parsed_fields = _try_parse_json_value(fields_value)
+    if not isinstance(parsed_fields, dict):
+        return enriched
+
+    enriched["fields"] = _promote_raw_into_alert_event_fields(dict(parsed_fields))
+    return enriched
+
+
+def _enrich_alert_events(events: list[dict]) -> list[dict]:
+    """Enrich a list of Vega alert events for searchable/filterable context usage."""
+    return [_enrich_alert_event(event) for event in events]
+
+
 def _format_alert_events_cell_value(value: Any) -> str:
     """Format a single alert-event table cell for markdown display."""
     if value is None:
@@ -1169,6 +1379,10 @@ def _flatten_alert_event_value(
             return
         for key, nested_value in value.items():
             nested_key = f"{prefix}.{key}" if prefix else str(key)
+            # Keep raw payloads as a single cell; promoted fields already expose usable keys.
+            if str(key) in ALERT_EVENT_JSON_TRUNCATE_KEYS:
+                flattened[nested_key] = nested_value
+                continue
             _flatten_alert_event_value(nested_key, nested_value, flattened, depth=depth + 1)
         return
 
@@ -1222,7 +1436,7 @@ def _collect_alert_event_columns(normalized_events: list[dict[str, Any]]) -> lis
         return []
 
     ordered = sorted(discovered, key=_alert_event_column_sort_key)
-    return ordered[:ALERT_EVENT_MAX_COLUMNS]
+    return ordered
 
 
 def _alert_events_table_rows(events: list[dict]) -> tuple[list[str], list[dict[str, str]]]:
@@ -1314,7 +1528,7 @@ def fetch_alert_events_page(
     except (TypeError, ValueError):
         total = 0
 
-    events = _parse_alert_events_results(response.get("results"))
+    events = _enrich_alert_events(_parse_alert_events_results(response.get("results")))
     if total == 0 and events:
         total = len(events)
     return events, total
@@ -1501,6 +1715,7 @@ def fetch_alert_events_command(client: Client, args: dict[str, Any]) -> CommandR
             "Count": len(page_events),
             "HasAlertEvents": has_alert_events,
             "Cached": False,
+            "Events": page_events,
             "CustomFields": persisted_fields,
         },
     )

--- a/Packs/Vega/Integrations/Vega/Vega_test.py
+++ b/Packs/Vega/Integrations/Vega/Vega_test.py
@@ -11,10 +11,14 @@ import pytest
 from Vega import (
     ALERT_EVENTS_NOT_AVAILABLE_MARKDOWN,
     _alert_events_command_results,
+    _enrich_alert_event,
+    _enrich_alert_events,
     _event_has_bad_alert_events_shape,
     _events_have_bad_alert_events_shape,
+    _expand_flat_raw_fields,
     _format_alert_events_markdown,
     _format_mitre_attack,
+    _promote_raw_into_alert_event_fields,
     Client,
     GET_ALERT_MIRROR_QUERY,
     GET_INCIDENT_MIRROR_QUERY,
@@ -1812,6 +1816,229 @@ def test_format_alert_events_markdown_handles_dynamic_eks_shape():
     assert "eks-prod-cluster" in formatted
     assert "aws-iam-authenticator:890123456789:AIDASDRANJTZJUR47VREC" in formatted
     assert "raw" in formatted
+
+
+def test_expand_flat_raw_fields_expands_dotted_and_array_keys():
+    expanded = _expand_flat_raw_fields(
+        {
+            "date_year": "2026",
+            "vendorInformation.provider": "ASC",
+            "securityResources{}.resourceType": "attacked",
+            "userStates{}.logonIp": "10.0.0.1",
+            "userStates{}.userPrincipalName": "user@example.com",
+        }
+    )
+
+    assert expanded["date_year"] == "2026"
+    assert expanded["vendorInformation"] == {"provider": "ASC"}
+    assert expanded["securityResources"] == [{"resourceType": "attacked"}]
+    assert expanded["userStates"] == [{"logonIp": "10.0.0.1", "userPrincipalName": "user@example.com"}]
+
+
+def test_promote_raw_into_fields_keeps_schema_and_promotes_splunk_raw():
+    fields = {
+        "app_uid": None,
+        "http_response": {"code": None},
+        "request": {"uri": None},
+        "auth_type": None,
+        "risk_score": "medium",
+        "_raw": json.dumps(
+            {
+                "date_year": "2026",
+                "createdDateTime": "2026-07-21T14:23:19.063Z",
+                "vendorInformation.provider": "ASC",
+                "securityResources{}.resourceType": "attacked",
+                "userStates{}.logonIp": "10.0.0.1",
+                "userStates{}.userPrincipalName": "user@example.com",
+                "splunk_server": "idx-example.splunkcloud.com",
+                "risk_score": "should-not-overwrite",
+            }
+        ),
+    }
+
+    promoted = _promote_raw_into_alert_event_fields(fields)
+
+    assert promoted["risk_score"] == "medium"
+    assert promoted["app_uid"] is None
+    assert promoted["date_year"] == "2026"
+    assert promoted["createdDateTime"] == "2026-07-21T14:23:19.063Z"
+    assert promoted["vendorInformation"] == {"provider": "ASC"}
+    assert promoted["securityResources"] == [{"resourceType": "attacked"}]
+    assert promoted["userStates"] == [{"logonIp": "10.0.0.1", "userPrincipalName": "user@example.com"}]
+    assert promoted["splunk_server"] == "idx-example.splunkcloud.com"
+    assert isinstance(promoted["_raw"], str)
+    assert "date_year" in promoted["_raw"]
+
+
+def test_enrich_alert_event_promotes_nested_eks_raw_object():
+    raw_event = {
+        "_index_timestamp": 1774447926000,
+        "account_id": "890123456789",
+        "auditID": "c6dcb49b-90fd-4ec8-ac88-a58990cf7dc4",
+        "cluster_name": "eks-prod-cluster",
+        "verb": "get",
+        "user": {
+            "uid": "8a75b43c-5278-4abb-91e1-eea07ad04ea6",
+            "username": "system:serviceaccount:stratus-red-team-np-name-fatnmkvw:stratus-red-team-np-sa",
+        },
+        "sourceIPs": ["10.0.0.1"],
+    }
+    fields_payload = {
+        "container": {"uid": None, "name": None},
+        "cluster": {"name": "eks-prod-cluster"},
+        "request": {
+            "data": None,
+            "uri": "/api/v1/nodes/ip-192-168-20-125.ec2.internal/proxy/runningpods/",
+        },
+        "status_code": "200",
+        "operation": "get",
+        "account": {"uid": "890123456789"},
+        "_raw": raw_event,
+    }
+    event = {
+        "catalog": "amazoneksaudit",
+        "class": "Network Activity",
+        "data_source": "amazon_eks_events",
+        "fields": json.dumps(fields_payload),
+        "raw": json.dumps(raw_event),
+        "source": "EKS",
+        "storage": "AWS S3",
+        "timestamp": "2026-03-24 17:26:20.000",
+    }
+
+    enriched = _enrich_alert_event(event)
+    fields = enriched["fields"]
+
+    assert isinstance(fields, dict)
+    assert fields["cluster"] == {"name": "eks-prod-cluster"}
+    assert fields["status_code"] == "200"
+    assert fields["auditID"] == "c6dcb49b-90fd-4ec8-ac88-a58990cf7dc4"
+    assert fields["verb"] == "get"
+    assert fields["account_id"] == "890123456789"
+    assert fields["user"]["username"].startswith("system:serviceaccount:")
+    assert fields["sourceIPs"] == ["10.0.0.1"]
+    assert fields["_raw"] == raw_event
+    assert enriched["raw"] == json.dumps(raw_event)
+
+
+def test_enrich_alert_event_noop_without_fields_or_raw():
+    event = {
+        "actor.user.uid": "arn:aws:iam::890123456789:root",
+        "event_count": "23",
+        "timeframe": "2026-05-12 00:40:00.000",
+    }
+    assert _enrich_alert_event(event) == event
+
+
+def test_enrich_alert_events_leaves_summary_rows_unchanged():
+    events = [
+        {
+            "actor.user.uid": "arn:aws:iam::890123456789:root",
+            "event_count": "23",
+            "unique_events_count": "6",
+        }
+    ]
+    assert _enrich_alert_events(events) == events
+
+
+def test_fetch_alert_events_page_enriches_fields_from_raw(mocker):
+    mock_client = mocker.Mock(spec=Client)
+    mock_client.get_alert_events.return_value = {
+        "total": 1,
+        "results": [
+            {
+                "catalog": "splunk_cloud__sandbox",
+                "data_source": "microsoft_graph_events",
+                "fields": json.dumps(
+                    {
+                        "app_uid": None,
+                        "risk_score": "medium",
+                        "_raw": {
+                            "date_year": "2026",
+                            "vendorInformation.provider": "ASC",
+                            "securityResources{}.resourceType": "attacked",
+                        },
+                    }
+                ),
+                "raw": '{"date_year":"2026"}',
+                "source": "Graph",
+                "timestamp": "2026-07-21 14:23:55.887",
+            }
+        ],
+    }
+
+    events, total = fetch_alert_events_page(mock_client, "alert-1")
+
+    assert total == 1
+    assert events[0]["fields"]["date_year"] == "2026"
+    assert events[0]["fields"]["vendorInformation"] == {"provider": "ASC"}
+    assert events[0]["fields"]["securityResources"] == [{"resourceType": "attacked"}]
+    assert events[0]["fields"]["risk_score"] == "medium"
+    assert events[0]["fields"]["app_uid"] is None
+
+
+def test_fetch_alert_events_command_outputs_enriched_events(mocker):
+    mocker.patch(
+        "Vega.load_current_incident",
+        return_value={"CustomFields": {"vegaalertid": "alert-1"}},
+    )
+    mock_client = mocker.Mock(spec=Client)
+    mock_client.get_alert_events.return_value = {
+        "total": 1,
+        "results": [
+            {
+                "catalog": "amazoneksaudit",
+                "fields": json.dumps(
+                    {
+                        "operation": "get",
+                        "_raw": {"auditID": "abc-123", "verb": "get"},
+                    }
+                ),
+                "source": "EKS",
+                "timestamp": "2026-03-24 17:26:20.000",
+            }
+        ],
+    }
+
+    result = fetch_alert_events_command(mock_client, {"alert_id": "alert-1"})
+
+    assert result.outputs["Count"] == 1
+    assert result.outputs["Events"][0]["fields"]["auditID"] == "abc-123"
+    assert result.outputs["Events"][0]["fields"]["operation"] == "get"
+    assert "auditID" in result.readable_output or "operation" in result.readable_output
+
+
+def test_alert_to_incident_stores_enriched_alert_events(mocker):
+    mock_client = mocker.Mock(spec=Client)
+    mock_client.get_alert_events.return_value = {
+        "total": 1,
+        "results": [
+            {
+                "catalog": "splunk_cloud__sandbox",
+                "fields": json.dumps(
+                    {
+                        "risk_score": "medium",
+                        "_raw": '{"createdDateTime":"2026-07-21T14:23:19.063Z","vendorInformation.provider":"ASC"}',
+                    }
+                ),
+                "source": "Graph",
+            }
+        ],
+    }
+    alert = {
+        "id": "alert-1",
+        "name": "Test Alert",
+        "severity": "HIGH",
+        "createdAt": TIMESTAMP_T1,
+    }
+
+    xsoar_incident = alert_to_incident(alert, client=mock_client)
+    raw = json.loads(xsoar_incident["rawJSON"])
+    fields = raw["alertEvents"][0]["fields"]
+
+    assert fields["createdDateTime"] == "2026-07-21T14:23:19.063Z"
+    assert fields["vendorInformation"] == {"provider": "ASC"}
+    assert fields["risk_score"] == "medium"
 
 
 def test_build_alert_events_custom_fields():

--- a/Packs/Vega/ReleaseNotes/1_0_2.md
+++ b/Packs/Vega/ReleaseNotes/1_0_2.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Vega
+
+Improved alert event field handling so JSON *fields* are parsed and contents of *fields._raw* are promoted to top-level keys under *fields*, including expansion of dotted keys and *{}*-suffixed keys into nested objects and arrays. Added the *Vega.AlertEvents.Events* context output so enriched alert events are searchable, filterable, and usable in playbooks without a manual parse step. Retained the original *_raw* / *raw* payloads for fidelity and preserved existing non-empty schema field values on conflict.

--- a/Packs/Vega/pack_metadata.json
+++ b/Packs/Vega/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Vega",
     "description": "The Vega integration allows you to ingest alerts and incidents from the Vega platform into Cortex XSOAR.",
     "support": "partner",
-    "currentVersion": "1.0.1",
+    "currentVersion": "1.0.2",
     "created": "2026-05-21T14:22:24Z",
     "author": "Vega",
     "url": "https://vega.io/",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
<!-- To link a Jira ticket use fixes/related: link to the issue, for example fixes: CIAC-XXXX -->

## Description
Improved Vega alert event field handling so JSON `fields` are parsed and contents of `fields._raw` are promoted to top-level keys under `fields`. Dotted keys and `{}`-suffixed keys are expanded into nested objects and arrays. Added the `Vega.AlertEvents.Events` context output so enriched alert events are searchable, filterable, and usable in playbooks without a manual parse step. Original `_raw` / `raw` payloads are retained for fidelity, and existing non-empty schema field values are preserved on conflict.

## Must have
- [x] Tests
- [x] Documentation

relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-17578