### PR TITLE
Add threatmon_request_data_removal command for Black Market Monitoring

### DIFF
--- a/Packs/ThreatMon/CONTRIBUTORS.json
+++ b/Packs/ThreatMon/CONTRIBUTORS.json
@@ -1,0 +1,3 @@
+[
+    "Ugur Kircicek"
+]

--- a/Packs/ThreatMon/Integrations/ThreatMon/ThreatMon.py
+++ b/Packs/ThreatMon/Integrations/ThreatMon/ThreatMon.py
@@ -42,6 +42,18 @@ class Client(BaseClient):
             resp_type="response",
         )
 
+    def request_data_removal(self, finding_id: int, finding: str):
+        """Submits a Black Market Monitoring data removal request for a specific finding (alarm row)."""
+
+        payload = {"findingId": finding_id, "finding": finding}
+        return self._http_request(
+            method="POST",
+            url_suffix="/blackMarket/dataRemoval",
+            json_data=payload,
+            ok_codes=(200, 400, 403, 404, 409),
+            resp_type="response",
+        )
+
     def get_cve_list(self, page: int = 0, cvss: str | None = None):
         """Fetches a paginated list of all CVEs monitored by ThreatMon."""
 
@@ -232,6 +244,37 @@ def request_takedown_command(client: Client, args: dict[str, Any]) -> CommandRes
         raise DemistoException(f"API Error: {status_code} - {response.text}")
 
 
+def request_data_removal_command(client: Client, args: dict[str, Any]) -> CommandResults:
+    finding_id_raw = args.get("findingId")
+    finding = args.get("finding")
+
+    if not finding_id_raw:
+        raise ValueError("findingId argument is required.")
+    if not finding:
+        raise ValueError("finding argument is required.")
+
+    try:
+        finding_id = int(finding_id_raw)
+    except (ValueError, TypeError):
+        raise ValueError(f"findingId must be a valid integer, got: {finding_id_raw}")
+
+    response = client.request_data_removal(finding_id=finding_id, finding=finding)
+
+    status_code = response.status_code
+    if status_code == 200:
+        return CommandResults(readable_output="Data removal request submitted successfully.")
+    elif status_code == 404:
+        raise DemistoException(f"Finding not found: findingId={finding_id}")
+    elif status_code == 409:
+        raise DemistoException(f"A data removal request already exists for findingId={finding_id}")
+    elif status_code == 403:
+        raise DemistoException("Data removal quota exceeded or insufficient rights. Please contact ThreatMon.")
+    elif status_code == 400:
+        raise DemistoException("This finding is not eligible for a data removal request.")
+    else:
+        raise DemistoException(f"API Error: {status_code} - {response.text}")
+
+
 def format_cve_vendors(vendors: dict[str, list[str]]) -> str:
     """Formats a vendor-to-products map into a human-readable string for the markdown table."""
 
@@ -324,6 +367,8 @@ def main():
             return_results(change_incident_status(client, demisto.args()))
         elif command == "threatmon_request_takedown":
             return_results(request_takedown_command(client, demisto.args()))
+        elif command == "threatmon_request_data_removal":
+            return_results(request_data_removal_command(client, demisto.args()))
         elif command == "threatmon_list_cves":
             return_results(list_cves_command(client, demisto.args()))
         elif command == "threatmon_list_subscribed_cves":

--- a/Packs/ThreatMon/Integrations/ThreatMon/ThreatMon.yml
+++ b/Packs/ThreatMon/Integrations/ThreatMon/ThreatMon.yml
@@ -3,7 +3,6 @@ commonfields:
   version: -1
 name: Threatmon
 display: Threatmon
-provider: ThreatMon
 sectionorder:
 - Connect
 - Collect
@@ -38,24 +37,15 @@ configuration:
   type: 0
   required: false
   section: Collect
-  supportedModules:
-  - xsiam
-  - agentix
 - display: Incident type
   name: incidentType
   type: 13
   required: false
-  supportedModules:
-  - xsiam
-  - agentix
   section: Collect
 - display: Fetch incidents
   name: isFetch
   type: 8
   required: false
-  supportedModules:
-  - xsiam
-  - agentix
   section: Collect
 - display: Fetch Interval (minutes)
   name: fetchInterval
@@ -63,18 +53,12 @@ configuration:
   type: 0
   required: false
   section: Collect
-  supportedModules:
-  - xsiam
-  - agentix
 - display: Incidents Fetch Interval
   name: incidentFetchInterval
   defaultvalue: "1"
   type: 19
   required: false
   section: Collect
-  supportedModules:
-  - xsiam
-  - agentix
 script:
   script: ''
   type: python
@@ -108,11 +92,11 @@ script:
   - name: threatmon_request_data_removal
     arguments:
     - name: findingId
-      required: true
       description: The ID of the finding (alarm row) to submit a data removal request for.
-    - name: finding
       required: true
+    - name: finding
       description: The URL or content identifier of the finding to be removed from Black Market Monitoring results.
+      required: true
     description: Submits a Black Market Monitoring data removal request for a specific ThreatMon finding. Requires the company to have remaining Black Market Data Removal credits. Returns 403 if the quota is exceeded or rights are insufficient.
   - name: threatmon_list_cves
     arguments:

--- a/Packs/ThreatMon/Integrations/ThreatMon/ThreatMon.yml
+++ b/Packs/ThreatMon/Integrations/ThreatMon/ThreatMon.yml
@@ -105,6 +105,15 @@ script:
       required: true
       description: Description of the finding that justifies the takedown request.
     description: Submits a takedown request for a specific Threatmon finding. Eligible finding types include Phishing Domain Detected, Rogue Mobile App Detected, Fake SM Account Detected, and similar alarm types.
+  - name: threatmon_request_data_removal
+    arguments:
+    - name: findingId
+      required: true
+      description: The ID of the finding (alarm row) to submit a data removal request for.
+    - name: finding
+      required: true
+      description: The URL or content identifier of the finding to be removed from Black Market Monitoring results.
+    description: Submits a Black Market Monitoring data removal request for a specific ThreatMon finding. Requires the company to have remaining Black Market Data Removal credits. Returns 403 if the quota is exceeded or rights are insufficient.
   - name: threatmon_list_cves
     arguments:
     - name: page

--- a/Packs/ThreatMon/Integrations/ThreatMon/ThreatMon.yml
+++ b/Packs/ThreatMon/Integrations/ThreatMon/ThreatMon.yml
@@ -37,15 +37,24 @@ configuration:
   type: 0
   required: false
   section: Collect
+  supportedModules:
+  - xsiam
+  - agentix
 - display: Incident type
   name: incidentType
   type: 13
   required: false
+  supportedModules:
+  - xsiam
+  - agentix
   section: Collect
 - display: Fetch incidents
   name: isFetch
   type: 8
   required: false
+  supportedModules:
+  - xsiam
+  - agentix
   section: Collect
 - display: Fetch Interval (minutes)
   name: fetchInterval
@@ -53,12 +62,18 @@ configuration:
   type: 0
   required: false
   section: Collect
+  supportedModules:
+  - xsiam
+  - agentix
 - display: Incidents Fetch Interval
   name: incidentFetchInterval
   defaultvalue: "1"
   type: 19
   required: false
   section: Collect
+  supportedModules:
+  - xsiam
+  - agentix
 script:
   script: ''
   type: python

--- a/Packs/ThreatMon/Integrations/ThreatMon/ThreatMon_description.md
+++ b/Packs/ThreatMon/Integrations/ThreatMon/ThreatMon_description.md
@@ -5,20 +5,30 @@ The Threatmon integration allows Cortex XSOAR to connect with the Threatmon plat
 ### Use Cases
 - Automatically fetch and ingest Threatmon alarms as XSOAR incidents.
 - Update the status of Threatmon incidents from within XSOAR.
+- Submit takedown requests for eligible findings (Phishing Domains, Rogue Mobile Apps, Fake Social Media Accounts).
+- Request data removal for Black Market Monitoring findings directly from XSOAR playbooks.
 - Maintain a consistent incident lifecycle between Threatmon and XSOAR.
 
 ### Key Features
 - Fetch Threatmon alarms into Cortex XSOAR.
 - Update the status of existing Threatmon incidents (e.g., Open, In Progress, Resolved).
+- Submit takedown requests for eligible threat findings.
+- Submit Black Market Monitoring data removal requests — checks company credit rights and returns an appropriate error if the quota is exceeded.
+- Query all CVEs monitored by ThreatMon, including CVSS v2, v3, v3.1, and v4 scores.
+- Query CVEs affecting products the company is subscribed to.
 - Supports automated playbooks for streamlined response.
 
 ### Commands
-- **threatmon-update-incident-status**  
-  - Update the status of a specific Threatmon incident using its unique ID.
+- **threatmon_update_incident_status** — Update the status of a specific Threatmon incident using its unique ID.
+- **threatmon_request_takedown** — Submit a takedown request for an eligible Threatmon finding.
+- **threatmon_request_data_removal** — Submit a Black Market Monitoring data removal request for a specific finding.
+- **threatmon_list_cves** — Retrieve a paginated list of all CVEs monitored by ThreatMon.
+- **threatmon_list_subscribed_cves** — Retrieve CVEs affecting products the company is subscribed to.
 
 ### Requirements
 - Threatmon API credentials (API key).
-- Access to Threatmon’s incident management endpoints.
+- Access to Threatmon’s external API endpoints.
+- For data removal: the authenticated company must have remaining Black Market Data Removal credits.
 
 ### Additional Information
 Threatmon is a threat intelligence and monitoring platform that provides actionable alerts to security teams. Integrating Threatmon with XSOAR enables more efficient triage, faster response times, and better visibility into your security operations.

--- a/Packs/ThreatMon/ReleaseNotes/1_0_5.md
+++ b/Packs/ThreatMon/ReleaseNotes/1_0_5.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Threatmon
+
+- Added the **threatmon_request_data_removal** command to submit a Black Market Monitoring data removal request for a specific finding. The command checks whether the company has remaining Black Market Data Removal credits and returns an appropriate error if the quota is exceeded.

--- a/Packs/ThreatMon/pack_metadata.json
+++ b/Packs/ThreatMon/pack_metadata.json
@@ -1,8 +1,8 @@
 {
     "name": "ThreatMon",
-    "description": "This integration pulls data from the ThreatMon API and updates XSOAR incidents. You can also update the status of your Incedents in the ThreatMon dashboard from the XSOAR interface with this integration.",
+    "description": "This integration pulls data from the ThreatMon API and updates XSOAR incidents. You can also update the status of your incidents, submit takedown requests, and request data removal for Black Market Monitoring findings directly from the XSOAR interface.",
     "support": "community",
-    "currentVersion": "1.0.4",
+    "currentVersion": "1.0.5",
     "author": "ThreatMon",
     "url": "https://www.threatmon.io",
     "email": "integration@threatmonit.io",

--- a/Packs/ThreatMon/pack_metadata.json
+++ b/Packs/ThreatMon/pack_metadata.json
@@ -22,6 +22,5 @@
         "xsoar",
         "marketplacev2",
         "platform"
-        
     ]
 }


### PR DESCRIPTION
## Summary
- Added the **threatmon_request_data_removal** command to submit a Black Market Monitoring data removal request for a specific finding
- The command checks whether the company has remaining Black Market Data Removal credits and returns an appropriate error if the quota is exceeded (403)
- Pack version bumped from 1.0.4 to 1.0.5
- Updated **ThreatMon_description.md** to cover all available commands

relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-17577