### PR TITLE
XSUP-74527 - fix vCenter VmPoweredOff mapping and scope envoy-access filter

### DIFF
--- a/Packs/VMwareVCenter/ModelingRules/VMwareVcenter_2_9/VMwareVcenter_2_9.xif
+++ b/Packs/VMwareVCenter/ModelingRules/VMwareVcenter_2_9/VMwareVcenter_2_9.xif
@@ -160,11 +160,11 @@ alter
                  description ~= "^Renamed ", coalesce(arrayindex(regextract(description, "^Renamed\s(.+?)\s+from\s"), 0), arrayindex(regextract(description, "^Renamed\s([^\s]+)"), 0)), // Extract vm name from raw start with Renamed (space-aware extraction added, original kept as fallback)
                  description ~= "^Reconfigured ", coalesce(arrayindex(regextract(description, "Reconfigured (.+?) on\s"), 0), arrayindex(regextract(description, "Reconfigured ([^\s]+)"), 0)), // Extract vm name from raw start with Reconfigured (space-aware extraction added, original kept as fallback)
                  description ~= "^\S+\s+\-", arrayindex(regextract(description, "^([^\s]+) - "), 0), //Extract vm name from the start of the string (before " - ")
-                 description ~= "^\S+\s+on", coalesce(arrayindex(regextract(description, "^(.+?)\s+on\s+\S+\s+in\s"), 0), arrayindex(regextract(description, "^([^\s]+)\s+on\s+\S+\s+in\s"), 0), arrayindex(regextract(description, "^(.+?) on \S+\s+in "), 0), arrayindex(regextract(description, "^([^\s]+) on \S+\s+in "), 0))), //Extract vm name from the start of the string (before " on ") - tolerates multiple spaces between tokens (XSUP-74527), original patterns kept as fallback
+                 description ~= "^\S+\s+on", coalesce(arrayindex(regextract(description, "^(.+?)\s+on\s+\S+\s+in\s"), 0), arrayindex(regextract(description, "^([^\s]+)\s+on\s+\S+\s+in\s"), 0), arrayindex(regextract(description, "^(.+?) on \S+\s+in "), 0), arrayindex(regextract(description, "^([^\s]+) on \S+\s+in "), 0))), //Extract vm name from the start of the string (before " on ") (space-aware extraction added, original kept as fallback)
     target_vm_name = coalesce(arrayindex(regextract(description, "cloned to (.+?) on"), 0), arrayindex(regextract(description, "cloned to ([^\s]+) on"), 0)),
     target_hostname = if(description ~= "^Removed", arrayindex(regextract(description, "Removed\s+\S+\s+on\s+([^\s]+)"), 0), // Extract target host from raw start with Removed
                          description ~= "^Guest OS", arrayindex(regextract(description, "on\s+([^\s]+)\s+in"), 0), // Extract target host from raw start with Guest OS                     
-                         coalesce(arrayindex(regextract(description, " to ([^\s]+),"), 0), arrayindex(regextract(description, "\s+on\s+(\S+)\s+in\s"), 0))), // Fallback extracts the ESXi host from "<vm> on <host> in <datacenter>" descriptions, e.g. vim.event.VmPoweredOffEvent (XSUP-74527)
+                         coalesce(arrayindex(regextract(description, " to ([^\s]+),"), 0), arrayindex(regextract(description, "\s+on\s+(\S+)\s+in\s"), 0))),
     target_datacenter = coalesce(arrayindex(regextract(description, ",\s+\S+\s+in ([^\s]+)$"), 0), arrayindex(regextract(description, "\sin\s+(.+?)\.?$"), 0)),
     original_esxi_name = if(description ~= "relocated from\s+\S+", arrayindex(regextract(description, "relocated from\s+([^\,]+)"), 0),
                             description ~= "Creating ([^\s]+) on", arrayindex(regextract(description, "Creating ([^\s]+) on"), 0)),
@@ -665,9 +665,6 @@ call vmware_vcenter_virtualization_classification
 // envoy-access events 
 call vmware_vcenter_virtualization_classification
 | alter event_type = arrayindex(regextract(_raw_log, "^\<\d{1,3}\>\d+\s+\S+\s+\S+\s+(\S+)"), 0)
-// This block parses the classic quoted envoy access log format ("<METHOD> <PATH> HTTP/<ver>") by token position.
-// Newer vCenter builds also emit an extended, unquoted envoy access log with a different field layout; those
-// records are excluded here so their tokens are not mapped into the wrong XDM fields (XSUP-74527).
 | filter event_type = "envoy-access" and not is_virtualization and _raw_log ~= "\"[A-Z]+\s+\S+\s+HTTP/\d"
 | alter 
     syslog_priority = to_integer(arrayindex(regextract(_raw_log, "^\<(\d{1,3})\>\S+"), 0)),

--- a/Packs/VMwareVCenter/ModelingRules/VMwareVcenter_2_9/VMwareVcenter_2_9.xif
+++ b/Packs/VMwareVCenter/ModelingRules/VMwareVcenter_2_9/VMwareVcenter_2_9.xif
@@ -160,11 +160,11 @@ alter
                  description ~= "^Renamed ", coalesce(arrayindex(regextract(description, "^Renamed\s(.+?)\s+from\s"), 0), arrayindex(regextract(description, "^Renamed\s([^\s]+)"), 0)), // Extract vm name from raw start with Renamed (space-aware extraction added, original kept as fallback)
                  description ~= "^Reconfigured ", coalesce(arrayindex(regextract(description, "Reconfigured (.+?) on\s"), 0), arrayindex(regextract(description, "Reconfigured ([^\s]+)"), 0)), // Extract vm name from raw start with Reconfigured (space-aware extraction added, original kept as fallback)
                  description ~= "^\S+\s+\-", arrayindex(regextract(description, "^([^\s]+) - "), 0), //Extract vm name from the start of the string (before " - ")
-                 description ~= "^\S+\s+on", coalesce(arrayindex(regextract(description, "^(.+?) on \S+\s+in "), 0), arrayindex(regextract(description, "^([^\s]+) on \S+\s+in "), 0))), //Extract vm name from the start of the string (before " on ") (space-aware extraction added, original kept as fallback)
+                 description ~= "^\S+\s+on", coalesce(arrayindex(regextract(description, "^(.+?)\s+on\s+\S+\s+in\s"), 0), arrayindex(regextract(description, "^([^\s]+)\s+on\s+\S+\s+in\s"), 0), arrayindex(regextract(description, "^(.+?) on \S+\s+in "), 0), arrayindex(regextract(description, "^([^\s]+) on \S+\s+in "), 0))), //Extract vm name from the start of the string (before " on ") - tolerates multiple spaces between tokens (XSUP-74527), original patterns kept as fallback
     target_vm_name = coalesce(arrayindex(regextract(description, "cloned to (.+?) on"), 0), arrayindex(regextract(description, "cloned to ([^\s]+) on"), 0)),
     target_hostname = if(description ~= "^Removed", arrayindex(regextract(description, "Removed\s+\S+\s+on\s+([^\s]+)"), 0), // Extract target host from raw start with Removed
                          description ~= "^Guest OS", arrayindex(regextract(description, "on\s+([^\s]+)\s+in"), 0), // Extract target host from raw start with Guest OS                     
-                         arrayindex(regextract(description, " to ([^\s]+),"), 0)),
+                         coalesce(arrayindex(regextract(description, " to ([^\s]+),"), 0), arrayindex(regextract(description, "\s+on\s+(\S+)\s+in\s"), 0))), // Fallback extracts the ESXi host from "<vm> on <host> in <datacenter>" descriptions, e.g. vim.event.VmPoweredOffEvent (XSUP-74527)
     target_datacenter = coalesce(arrayindex(regextract(description, ",\s+\S+\s+in ([^\s]+)$"), 0), arrayindex(regextract(description, "\sin\s+(.+?)\.?$"), 0)),
     original_esxi_name = if(description ~= "relocated from\s+\S+", arrayindex(regextract(description, "relocated from\s+([^\,]+)"), 0),
                             description ~= "Creating ([^\s]+) on", arrayindex(regextract(description, "Creating ([^\s]+) on"), 0)),
@@ -665,7 +665,10 @@ call vmware_vcenter_virtualization_classification
 // envoy-access events 
 call vmware_vcenter_virtualization_classification
 | alter event_type = arrayindex(regextract(_raw_log, "^\<\d{1,3}\>\d+\s+\S+\s+\S+\s+(\S+)"), 0)
-| filter event_type = "envoy-access" and not is_virtualization
+// This block parses the classic quoted envoy access log format ("<METHOD> <PATH> HTTP/<ver>") by token position.
+// Newer vCenter builds also emit an extended, unquoted envoy access log with a different field layout; those
+// records are excluded here so their tokens are not mapped into the wrong XDM fields (XSUP-74527).
+| filter event_type = "envoy-access" and not is_virtualization and _raw_log ~= "\"[A-Z]+\s+\S+\s+HTTP/\d"
 | alter 
     syslog_priority = to_integer(arrayindex(regextract(_raw_log, "^\<(\d{1,3})\>\S+"), 0)),
     syslog_hostname = arrayindex(regextract(_raw_log, "\<\d{1,3}\>\S+\s+\S+\s+(\S+)"), 0), 

--- a/Packs/VMwareVCenter/ReleaseNotes/1_0_23.md
+++ b/Packs/VMwareVCenter/ReleaseNotes/1_0_23.md
@@ -1,0 +1,7 @@
+
+#### Modeling Rules
+
+##### VMware Vcenter 2.9 Modeling Rule
+
+- Fixed an issue where the source VM hostname and target ESXi hostname were not mapped for VM Operations events whose description contains multiple spaces between tokens (for example, `vim.event.VmPoweredOffEvent`).
+- Fixed an issue where records from the extended envoy access log format were mapped by the classic envoy access log field positions, which populated IP and port fields with non-address values.

--- a/Packs/VMwareVCenter/pack_metadata.json
+++ b/Packs/VMwareVCenter/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "VMware vCenter",
     "description": "Modeling Rules for the VMware vCenter logs collector",
     "support": "xsoar",
-    "currentVersion": "1.0.22",
+    "currentVersion": "1.0.23",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Summary

Two defects in the VMware vCenter 2.9 modeling rule, both reported in XSUP-74527 (tenant `xdr-eu-2006294842005`, Mellitah Oil & Gas). Verified against live tenant data.

## Defect 1 - VM Operations fields NULL when the description has multiple spaces

Production `vim.event.VmPoweredOffEvent` descriptions contain a double space between tokens:

```
HQT0PAW01 on  hq-esxi-mgmt-4.mog.ly in HQ Datacenter is powered off
```

The branch guard `description ~= "^\S+\s+on"` matches, so the rule commits to that branch, but both extraction patterns hardcode a single literal space (`" on "`), so they return NULL. `xdm.source.virtualization.vm.hostname` and `xdm.target.host.hostname` are left empty.

Patterns now use `\s+` between tokens. A `target_hostname` fallback for the `<vm> on <host> in <datacenter>` shape was added, since the previous fallback only handled `" to <host>,"`.

Both changes are additive: the original patterns are retained as `coalesce` fallbacks, so every description that extracted correctly before still yields the identical value.

| description | vm_name before | vm_name after | target_hostname before | after |
|---|---|---|---|---|
| `HQT0PAW01 on  hq-esxi-4 in HQ Datacenter is powered off` | NULL | `HQT0PAW01` | NULL | `hq-esxi-4` |
| `HQT0PAW01 on hq-esxi-4 in HQ Datacenter is powered on` | `HQT0PAW01` | `HQT0PAW01` | NULL | `hq-esxi-4` |
| `My Test VM on  hq-esxi-2 in HQ Datacenter is powered off` | NULL | `My Test VM` | NULL | `hq-esxi-2` |
| `VM01 relocated from esxi-1, ds1 to hq-esxi-9, ds2 in HQ DC` | unchanged | unchanged | `hq-esxi-9` | `hq-esxi-9` |

## Defect 2 - envoy-access block applied to an unsupported log format

The `envoy-access` block extracts fields by fixed token position, built for the classic quoted envoy access log:

```
[2026-08-08T22:49:54.019Z] "GET /server_info HTTP/1.1" 200 - 0 43906 1 - "-" "-" "-" "localhost" "-"
```

The `ltrim`/`rtrim` of `"` on tokens 1 and 3 confirms that intent. Newer vCenter builds also emit an extended, unquoted access log with a different layout:

```
2026-08-07T21:21:57.656Z POST /sdk 200 via_upstream - 4ms 3ms 10.100.11.32:58530 357b 0ms TLSv1.3 HTTP/2 452+312b 137+255+0b gzip ...
```

The filter only checked `event_type = "envoy-access"`, so both formats entered the same block and the extended format was parsed with the wrong indices:

| index | expected | actual in extended format |
|---|---|---|
| 12 `client_ip` | client IP:port | `HTTP/2` |
| 13 `server_ip` | server IP:port | `452+312b` |
| 14 `client2_ip` | IP | `137+255+0b` |

Because `client_ip` uses `regextract(..., "(\d+[^\:]+)")` with no address validation, the byte-count string `137+255+0b` was written into `xdm.source.ipv4`. The classic format was unaffected only because its junk tokens (`"-"`, `"localhost"`) contain no digits.

The filter now requires the quoted request line, so only the format this block was written for reaches it. The extended format is excluded rather than mis-mapped; dedicated support for it is a separate enhancement.

Sampled 3,000 `envoy-access` records from the reporting tenant (24h): 42 classic (15 tokens) kept, 2,958 excluded (34/35 tokens extended, plus 9 `ps`-output lines from `envoy-accesslogwriter` that were also being parsed as access logs).

## Not addressed here (enhancement requests)

- `vim.event.RemoteTSMEnabledEvent` / `RemoteTSMDisabledEvent` are not in any classification list.
- `vim.event.EventEx` is not in any classification list, so file download/upload events are not modeled. Note for whoever implements it: the datastore name arrives as a nested bracket (`[HQ-SAN-FSSH]`), so the generic `\[([^\]]*)\]` description extractor truncates. The nesting-aware pattern already used by the `Deletion of file or directory` branch should be reused.
- Dedicated support for the extended envoy access log format.

## Testing

- Extraction changes replayed against real raw logs from the reporting tenant and against the existing description shapes (cloned / relocated / created / removed / Guest OS) to confirm no regression.
- Filter guard validated against 3,000 live `envoy-access` records: clean split, no classic-format record dropped.
