### PR TITLE
Cortex Core - IOC: document that enable/disable apply only to TIM-managed indicators

### DIFF
--- a/Packs/Core/Integrations/CoreIOCs/CoreIOCs.yml
+++ b/Packs/Core/Integrations/CoreIOCs/CoreIOCs.yml
@@ -77,11 +77,11 @@ script:
   - description: Creates the sync file for the manual process. Run this command when instructed by the Cortex support team.
     name: core-iocs-create-sync-file
   - arguments:
-    - description: The indicator to enable. Only indicators managed by TIM (indicators that were synced/pushed to the Cortex server by this integration) can be enabled. Indicators created in the UI, via the API, or by other sources are not affected.
+    - description: The indicator to enable. Only indicators managed by TIM (indicators that were synced/pushed to the Cortex tenant by this integration) can be enabled. Indicators created in the tenant, via the API, or by other sources are not affected.
       isArray: true
       name: indicator
       required: true
-    description: Enables IOCs in the Cortex server. Applies only to TIM-managed indicators (indicators synced/pushed by this integration); indicators from other sources are not affected.
+    description: Enables IOCs in the Cortex tenant. Applies only to TIM-managed indicators (indicators synced/pushed by this integration); indicators from other sources are not affected.
     name: core-iocs-enable
   - arguments:
     - description: The indicator to disable. Only indicators managed by TIM (indicators that were synced/pushed to the Cortex server by this integration) can be disabled. Indicators created in the UI, via the API, or by other sources are not affected.

--- a/Packs/Core/Integrations/CoreIOCs/CoreIOCs.yml
+++ b/Packs/Core/Integrations/CoreIOCs/CoreIOCs.yml
@@ -77,18 +77,18 @@ script:
   - description: Creates the sync file for the manual process. Run this command when instructed by the Cortex support team.
     name: core-iocs-create-sync-file
   - arguments:
-    - description: The indicator to enable.
+    - description: The indicator to enable. Only indicators managed by TIM (indicators that were synced/pushed to the Cortex server by this integration) can be enabled. Indicators created in the UI, via the API, or by other sources are not affected.
       isArray: true
       name: indicator
       required: true
-    description: Enables IOCs in the Cortex server.
+    description: Enables IOCs in the Cortex server. Applies only to TIM-managed indicators (indicators synced/pushed by this integration); indicators from other sources are not affected.
     name: core-iocs-enable
   - arguments:
-    - description: The indicator to disable.
+    - description: The indicator to disable. Only indicators managed by TIM (indicators that were synced/pushed to the Cortex server by this integration) can be disabled. Indicators created in the UI, via the API, or by other sources are not affected.
       isArray: true
       name: indicator
       required: true
-    description: Disables IOCs in the Cortex server.
+    description: Disables IOCs in the Cortex server. Applies only to TIM-managed indicators (indicators synced/pushed by this integration); indicators from other sources are not affected.
     name: core-iocs-disable
   dockerimage: demisto/google-cloud-storage:1.0.0.10120494
   runonce: false

--- a/Packs/Core/Integrations/CoreIOCs/README.md
+++ b/Packs/Core/Integrations/CoreIOCs/README.md
@@ -102,6 +102,8 @@ There is no context output for this command.
 ***
 Enables IOCs in the Cortex server.
 
+> **Note:** This command applies only to TIM-managed indicators (indicators that were synced/pushed to the Cortex server by this integration). Enabling an indicator that is not managed by TIM has no effect.
+
 #### Base Command
 
 `core-iocs-enable`
@@ -110,7 +112,7 @@ Enables IOCs in the Cortex server.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| indicator | The indicator to enable. | Required |
+| indicator | The indicator to enable. Only TIM-managed indicators (synced/pushed by this integration) can be enabled; indicators from other sources are not affected. | Required |
 
 #### Context Output
 
@@ -129,6 +131,8 @@ There is no context output for this command.
 ***
 Disables IOCs in the Cortex server.
 
+> **Note:** This command applies only to TIM-managed indicators (indicators that were synced/pushed to the Cortex server by this integration). Disabling an indicator that is not managed by TIM has no effect.
+
 #### Base Command
 
 `core-iocs-disable`
@@ -137,7 +141,7 @@ Disables IOCs in the Cortex server.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| indicator | The indicator to disable. | Required |
+| indicator | The indicator to disable. Only TIM-managed indicators (synced/pushed by this integration) can be disabled; indicators from other sources are not affected. | Required |
 
 #### Context Output
 

--- a/Packs/Core/Integrations/CoreIOCs/README.md
+++ b/Packs/Core/Integrations/CoreIOCs/README.md
@@ -120,11 +120,11 @@ There is no context output for this command.
 
 #### Command example
 
-```!core-iocs-enable indicator=11.11.11.11```
+```!core-iocs-enable indicator=1.1.1.1```
 
 #### Human Readable Output
 
->indicators 11.11.11.11 enabled.
+>indicators 1.1.1.1 enabled.
 
 ### core-iocs-disable
 

--- a/Packs/Core/Integrations/CoreIOCs/README.md
+++ b/Packs/Core/Integrations/CoreIOCs/README.md
@@ -112,7 +112,7 @@ Enables IOCs in the Cortex server.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| indicator | The indicator to enable. Only TIM-managed indicators (synced/pushed by this integration) can be enabled; indicators from other sources are not affected. | Required |
+| indicator | The indicator to enable. Only TIM-managed indicators can be enabled; indicators from other sources are not affected. | Required |
 
 #### Context Output
 
@@ -141,7 +141,7 @@ Disables IOCs in the Cortex server.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| indicator | The indicator to disable. Only TIM-managed indicators (synced/pushed by this integration) can be disabled; indicators from other sources are not affected. | Required |
+| indicator | The indicator to disable. Only TIM-managed indicators can be disabled; indicators from other sources are not affected. | Required |
 
 #### Context Output
 

--- a/Packs/Core/Integrations/CoreIOCs/README.md
+++ b/Packs/Core/Integrations/CoreIOCs/README.md
@@ -100,9 +100,9 @@ There is no context output for this command.
 ### core-iocs-enable
 
 ***
-Enables IOCs in the Cortex server.
+Enables IOCs in the Cortex tenant.
 
-> **Note:** This command applies only to TIM-managed indicators (indicators that were synced/pushed to the Cortex server by this integration). Enabling an indicator that is not managed by TIM has no effect.
+> **Note:** This command applies only to TIM-managed indicators (indicators that were synced/pushed to the Cortex tenant by this integration). Enabling an indicator not managed by TIM has no effect.
 
 #### Base Command
 
@@ -129,9 +129,9 @@ There is no context output for this command.
 ### core-iocs-disable
 
 ***
-Disables IOCs in the Cortex server.
+Disables IOCs in the Cortex tenant.
 
-> **Note:** This command applies only to TIM-managed indicators (indicators that were synced/pushed to the Cortex server by this integration). Disabling an indicator that is not managed by TIM has no effect.
+> **Note:** This command applies only to TIM-managed indicators (indicators that were synced/pushed to the Cortex tenant by this integration). Disabling an indicator not managed by TIM has no effect.
 
 #### Base Command
 

--- a/Packs/Core/ReleaseNotes/3_5_81.md
+++ b/Packs/Core/ReleaseNotes/3_5_81.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Indicators detection
+
+- Documentation and metadata improvements.

--- a/Packs/Core/ReleaseNotes/3_5_82.md
+++ b/Packs/Core/ReleaseNotes/3_5_82.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Indicators detection
+
+- Documentation and metadata improvements.

--- a/Packs/Core/pack_metadata.json
+++ b/Packs/Core/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Core",
     "description": "Automates incident response",
     "support": "xsoar",
-    "currentVersion": "3.5.81",
+    "currentVersion": "3.5.82",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/Core/pack_metadata.json
+++ b/Packs/Core/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Core",
     "description": "Automates incident response",
     "support": "xsoar",
-    "currentVersion": "3.5.80",
+    "currentVersion": "3.5.81",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
Cortex Core - IOC: document that enable/disable apply only to TIM-managed indicators

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
related: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-74420)

## Must have
- [ ] Tests
- [x] Documentation
