### PR TITLE
XSUP-58905 : update pan-os-platform-get-jobs  polling behavior in get_jobs_command

### DIFF
--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -12563,15 +12563,29 @@ def get_jobs_command(args: dict):
     job reaches a terminal status (FIN) or the timeout is reached. Without
     polling (or when no id is supplied), behaves like the original
     non-polling command.
+
+    Note: while polling a specific job by id, the status/job_type filters are
+    ignored. Otherwise a still-running job (e.g. status=ACT) would be filtered
+    out when a terminal status like FIN is requested, causing polling to stop
+    prematurely.
+
+    Polling requires a single job "id" (polling can only track one job), so an
+    error is raised when polling=true without an id.
     """
     topology = get_topology()
     job_id = args.get("id")
+    polling = argToBoolean(args.get("polling", "false"))
+
+    if polling and not job_id:
+        raise DemistoException("The 'id' argument is required when 'polling' is set to true.")
+
+    ignore_filters = polling and bool(job_id)
 
     result = get_jobs(
         topology,
         device_filter_string=args.get("device_filter_string"),
-        status=args.get("status"),
-        job_type=args.get("job_type"),
+        status=None if ignore_filters else args.get("status"),
+        job_type=None if ignore_filters else args.get("job_type"),
         id=job_id,
         target=args.get("target"),
     )

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.yml
@@ -8764,13 +8764,13 @@ script:
       name: status
     - description: The filter to return jobs by type.
       name: job_type
-    - description: The filter to return jobs by ID.
+    - description: The filter to return jobs by ID. Required when "polling" is set to true.
       name: id
     - description: The target number of the firewall. Used only on a Panorama instance.
       name: target
     - auto: PREDEFINED
       defaultValue: 'false'
-      description: Whether to poll the job status until it reaches a terminal state (FIN). Only takes effect when a single job "id" is provided.
+      description: Whether to poll the job status until it reaches a terminal state (FIN). Requires a single job "id" to be provided. When enabled, the "status" and "job_type" filters are ignored.
       name: polling
       predefined:
       - 'true'

--- a/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama_test.py
@@ -3744,36 +3744,91 @@ class TestUniversalCommand:
 
     @patch("Panorama.get_topology")
     @patch("Panorama.get_jobs")
-    def test_get_jobs_command_polling_no_id(self, patched_get_jobs, patched_get_topology, mock_topology):
+    def test_get_jobs_command_polling_no_id_raises(self, patched_get_jobs, patched_get_topology, mock_topology):
         """
-        Given: polling=true but no id argument (list mode).
+        Given: polling=true but no id argument.
         When: get_jobs_command is invoked.
-        Then: Polling is skipped because there is no deterministic terminal condition.
+        Then: A DemistoException is raised, since polling requires a single job id.
+        """
+        from Panorama import get_jobs_command
+
+        patched_get_topology.return_value = mock_topology
+
+        with pytest.raises(DemistoException, match="The 'id' argument is required when 'polling' is set to true."):
+            get_jobs_command({"polling": "true"})
+
+        # get_jobs must not be called when the validation fails.
+        patched_get_jobs.assert_not_called()
+
+    @patch("Panorama.get_topology")
+    @patch("Panorama.get_jobs")
+    def test_get_jobs_command_polling_ignores_status_and_job_type(self, patched_get_jobs, patched_get_topology, mock_topology):
+        """
+        Given: polling=true, a single job id, and status/job_type filters provided.
+        When: get_jobs_command is invoked.
+        Then: get_jobs is called with status=None and job_type=None (filters ignored),
+              so a still-running job is not filtered out and polling can continue.
         """
         from Panorama import ShowJobsAllResultData, get_jobs_command
 
         patched_get_topology.return_value = mock_topology
-        patched_get_jobs.return_value = [
-            ShowJobsAllResultData(
-                hostid="fw1",
-                id=1,
-                type="Commit",
-                tfin="",
-                status="ACT",
-                result="PEND",
-                user="admin",
-                tenq="2024/08/25 22:07:53",
-                stoppable="no",
-                positionInQ=0,
-                progress=50,
-                warnings=None,
-                description="",
-            )
-        ]
+        patched_get_jobs.return_value = ShowJobsAllResultData(
+            hostid="fw1",
+            id=7,
+            type="Downloadxxx",
+            tfin="",
+            status="ACT",
+            result="PEND",
+            user="admin",
+            tenq="2024/08/25 22:07:53",
+            stoppable="no",
+            positionInQ=0,
+            progress=50,
+            warnings=None,
+            description="",
+        )
 
-        result = get_jobs_command({"polling": "true"})
+        result = get_jobs_command({"polling": "true", "id": "7", "status": "FIN", "job_type": "Commit"})
 
-        assert result.scheduled_command is None
+        # Filters must be dropped while polling by id.
+        assert patched_get_jobs.call_args.kwargs["status"] is None
+        assert patched_get_jobs.call_args.kwargs["job_type"] is None
+        assert patched_get_jobs.call_args.kwargs["id"] == "7"
+        # Job is still running, so polling should continue.
+        assert result.scheduled_command is not None
+
+    @patch("Panorama.get_topology")
+    @patch("Panorama.get_jobs")
+    def test_get_jobs_command_no_polling_keeps_status_and_job_type(self, patched_get_jobs, patched_get_topology, mock_topology):
+        """
+        Given: no polling (defaults to false), a job id, and status/job_type filters.
+        When: get_jobs_command is invoked.
+        Then: get_jobs is called with the provided status/job_type (non-polling flow unchanged).
+        """
+        from Panorama import ShowJobsAllResultData, get_jobs_command
+
+        patched_get_topology.return_value = mock_topology
+        patched_get_jobs.return_value = ShowJobsAllResultData(
+            hostid="fw1",
+            id=7,
+            type="Commit",
+            tfin="2024/08/25 22:09:00",
+            status="FIN",
+            result="OK",
+            user="admin",
+            tenq="2024/08/25 22:07:53",
+            stoppable="no",
+            positionInQ=0,
+            progress=100,
+            warnings=None,
+            description="",
+        )
+
+        get_jobs_command({"id": "7", "status": "FIN", "job_type": "Commit"})
+
+        # Non-polling flow must keep applying the filters.
+        assert patched_get_jobs.call_args.kwargs["status"] == "FIN"
+        assert patched_get_jobs.call_args.kwargs["job_type"] == "Commit"
 
     def test_download_software(self, mock_topology):
         """

--- a/Packs/PAN-OS/ReleaseNotes/2_6_46.md
+++ b/Packs/PAN-OS/ReleaseNotes/2_6_46.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Palo Alto Networks PAN-OS
+
+- Fixed an issue where the ***pan-os-platform-get-jobs*** command stopped polling prematurely when the *status* or *job_type* arguments were provided together with the *id* argument and *polling=true*.

--- a/Packs/PAN-OS/pack_metadata.json
+++ b/Packs/PAN-OS/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "PAN-OS by Palo Alto Networks",
     "description": "Manage Palo Alto Networks Firewall and Panorama. Use this pack to manage Prisma Access through Panorama. For more information see Panorama documentation.",
     "support": "xsoar",
-    "currentVersion": "2.6.45",
+    "currentVersion": "2.6.46",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
related: https://jira-dc.paloaltonetworks.com/browse/XSUP-58905

## Description
fixing _pan-os-platform-get-jobs_ polling: when _polling=true_ with a job _id_, the _status_ and _job_type_ filters are now ignored so a still-running job (e.g. ACT) isn't filtered out and polling no longer terminates prematurely, while the non-polling flow stays unchanged. It also enforces that id is required when _polling=true_.