### PR TITLE
Fix broken Cortex docs links for Amazon S3 log ingestion

### DIFF
--- a/Packs/AWS_ELB/README.md
+++ b/Packs/AWS_ELB/README.md
@@ -25,7 +25,7 @@ In order to use the collector, use the [XDRC (XDR Collector)](#xdrc-xdr-collecto
 
 ### XDRC (XDR Collector)
 
-To create or configure the Amazon S3 collector, use the information described [here](https://docs-cortex.paloaltonetworks.com/r/Cortex-XDR/Cortex-XDR-Documentation/Ingest-network-flow-logs-from-Amazon-S3).
+To create or configure the Amazon S3 collector, use the information described [here](https://cortex-docs.paloaltonetworks.com/cortex-xdr-5.x/configure-cortex-xdr/cortex-xdr-data-sources/vendor-specific-data-sources/amazon/amazon-s3/ingest-network-flow-logs-from-amazon-s3).
 
 You can configure the specific vendor and product for this instance.
 
@@ -45,6 +45,6 @@ You can configure the specific vendor and product for this instance.
    | `Log Format`  | Enter **Raw**.
    | `Compression` | Enter **uncompressed**.
 
-For additional information, see [here](https://docs-cortex.paloaltonetworks.com/r/Cortex-XSIAM/Cortex-XSIAM-Documentation/Ingest-generic-logs-from-Amazon-S3).
+For additional information, see [here](https://cortex-docs.paloaltonetworks.com/cortex-xsiam/configure-cortex-xsiam/cortex-xsiam-data-sources/vendor-specific-data-sources-and-connectors/amazon/amazon-s3/ingest-generic-logs-from-amazon-s3).
 
 </~XSIAM>

--- a/Packs/AWS_WAF/README.md
+++ b/Packs/AWS_WAF/README.md
@@ -15,7 +15,7 @@ In order to use the collector, use the [Amazon S3](#amazon-s3) collector.
 
 ### Amazon S3
 
-To create or configure the Amazon S3 collector, use the information described [here](https://docs-cortex.paloaltonetworks.com/r/Cortex-XSIAM/Cortex-XSIAM-Documentation/Ingest-generic-logs-from-Amazon-S3).
+To create or configure the Amazon S3 collector, use the information described [here](https://cortex-docs.paloaltonetworks.com/cortex-xsiam/configure-cortex-xsiam/cortex-xsiam-data-sources/vendor-specific-data-sources-and-connectors/amazon/amazon-s3/ingest-generic-logs-from-amazon-s3).
 
 1. Navigate to **Settings** > **Configuration** > **Data Sources** > **Amazon S3**.
 2. Press **Add New Istance**.

--- a/Packs/BeyondTrustEPM/README.md
+++ b/Packs/BeyondTrustEPM/README.md
@@ -19,7 +19,7 @@ Data normalization capabilities:
 
 Sign in to your AWS account and create a dedicated Amazon S3 bucket, which collects the generic logs that you want to capture.
 
-For more information on creating an S3 bucket,  [see Ingest Generic Logs from Amazon S3.](https://docs-cortex.paloaltonetworks.com/r/Cortex-XSIAM/Cortex-XSIAM-Documentation/Ingest-generic-logs-from-Amazon-S3) for further instructions on how to create a S3 bucket.
+For more information on creating an S3 bucket,  [see Ingest Generic Logs from Amazon S3.](https://cortex-docs.paloaltonetworks.com/cortex-xsiam/configure-cortex-xsiam/cortex-xsiam-data-sources/vendor-specific-data-sources-and-connectors/amazon/amazon-s3/ingest-generic-logs-from-amazon-s3) for further instructions on how to create a S3 bucket.
 
 ### BeyondTrust EPM side
 
@@ -50,7 +50,7 @@ To connect Cortex XSIAM to the AWS S3 bucket, follow the below steps.
 
     | Parameter    | Value                                                                                                                                           |
     |:-------------|:------------------------------------------------------------------------------------------------------------------------------------------------|
-    | `SQS URL`    | For more information, see  [Configure an Amazon Simple Queue Service (SQS).](https://docs-cortex.paloaltonetworks.com/r/Cortex-XSIAM/Cortex-XSIAM-Documentation/Ingest-generic-logs-from-Amazon-S3). |
+    | `SQS URL`    | For more information, see  [Configure an Amazon Simple Queue Service (SQS).](https://cortex-docs.paloaltonetworks.com/cortex-xsiam/configure-cortex-xsiam/cortex-xsiam-data-sources/vendor-specific-data-sources-and-connectors/amazon/amazon-s3/ingest-generic-logs-from-amazon-s3). |
     | `Name`       | BeyondTrust EPM Logs.                 |
     | `AWS Client ID`     |                                                                                                                                   |
     | `AWS Client Secret`    |                                                                                                                                  |
@@ -60,6 +60,6 @@ To connect Cortex XSIAM to the AWS S3 bucket, follow the below steps.
     | `Product`    | Enter EPM.                                                                                                                                 |
     | `Compression`    | Select the desired compression.                                                                                                                                 |
 
-For more information, see this [Ingest Generic Logs from Amazon S3.](https://docs-cortex.paloaltonetworks.com/r/Cortex-XSIAM/Cortex-XSIAM-Documentation/Ingest-generic-logs-from-Amazon-S3).
+For more information, see this [Ingest Generic Logs from Amazon S3.](https://cortex-docs.paloaltonetworks.com/cortex-xsiam/configure-cortex-xsiam/cortex-xsiam-data-sources/vendor-specific-data-sources-and-connectors/amazon/amazon-s3/ingest-generic-logs-from-amazon-s3).
 
 </~XSIAM>

--- a/Packs/Cisco-umbrella-cloud-security/README.md
+++ b/Packs/Cisco-umbrella-cloud-security/README.md
@@ -42,7 +42,7 @@ More information can be found [here](https://docs.umbrella.com/deployment-umbrel
 2. Click **Amazon S3**.
 3. Click **Connect** or **Connect Another Instance**.
 4. Set the following values:
-   - SQS URL - Refer to Configure an Amazon Simple Queue Service (SQS) [here](https://docs-cortex.paloaltonetworks.com/r/Cortex-XSIAM/Cortex-XSIAM-Documentation/Ingest-generic-logs-from-Amazon-S3).
+   - SQS URL - Refer to Configure an Amazon Simple Queue Service (SQS) [here](https://cortex-docs.paloaltonetworks.com/cortex-xsiam/configure-cortex-xsiam/cortex-xsiam-data-sources/vendor-specific-data-sources-and-connectors/amazon/amazon-s3/ingest-generic-logs-from-amazon-s3).
    - Name as `Cisco Umbrella`
    - AWS Client ID
    - AWS Client Secret
@@ -53,6 +53,6 @@ More information can be found [here](https://docs.umbrella.com/deployment-umbrel
    - Compression as `gzip`
    - Multiline Parsing Regex as `^\"\d{4,}`
 
-For more information, see this [doc](https://docs-cortex.paloaltonetworks.com/r/Cortex-XSIAM/Cortex-XSIAM-Documentation/Ingest-generic-logs-from-Amazon-S3).
+For more information, see this [doc](https://cortex-docs.paloaltonetworks.com/cortex-xsiam/configure-cortex-xsiam/cortex-xsiam-data-sources/vendor-specific-data-sources-and-connectors/amazon/amazon-s3/ingest-generic-logs-from-amazon-s3).
 
 </~XSIAM>

--- a/Packs/FortinetFortiwebVM/README.md
+++ b/Packs/FortinetFortiwebVM/README.md
@@ -29,7 +29,7 @@ This pack contains an integration, whose main purpose is to perform controlled c
 ## Collect Events from Vendor
 
 In order to receive logs, use the [Broker VM](#broker-vm) option. <br>
-For Traffic logs via Fortiweb Cloud, you are required to send the logs with [Amazon S3](https://docs-cortex.paloaltonetworks.com/r/Cortex-XSIAM/Cortex-XSIAM-Documentation/Ingest-generic-logs-from-Amazon-S3) services.
+For Traffic logs via Fortiweb Cloud, you are required to send the logs with [Amazon S3](https://cortex-docs.paloaltonetworks.com/cortex-xsiam/configure-cortex-xsiam/cortex-xsiam-data-sources/vendor-specific-data-sources-and-connectors/amazon/amazon-s3/ingest-generic-logs-from-amazon-s3) services.
 <br>
 
 ### Fortiweb Cloud

--- a/Packs/Incapsula/README.md
+++ b/Packs/Incapsula/README.md
@@ -10,7 +10,7 @@ To setup a real-time SIEM log integration via AWS S3 push, follow the **Set up l
 
 ### Collection via AWS S3
 
-To create or configure Incapsula log collection via S3, use the information described [here](https://docs-cortex.paloaltonetworks.com/r/Cortex-XSIAM/Cortex-XSIAM-Documentation/Ingest-network-flow-logs-from-Amazon-S3).
+To create or configure Incapsula log collection via S3, use the information described [here](https://cortex-docs.paloaltonetworks.com/cortex-xsiam/configure-cortex-xsiam/cortex-xsiam-data-sources/vendor-specific-data-sources-and-connectors/amazon/amazon-s3/ingest-network-flow-logs-from-amazon-s3).
 
 You can configure the AWS S3 collector:
 

--- a/Packs/RadwareCloudServices/README.md
+++ b/Packs/RadwareCloudServices/README.md
@@ -22,7 +22,7 @@ See the documentation below for the configuration required for each event type t
 
 Sign in to your AWS account and create a dedicated Amazon S3 bucket, which collects the generic logs that you want to capture.
 
-See this [doc](https://docs-cortex.paloaltonetworks.com/r/Cortex-XSIAM/Cortex-XSIAM-Documentation/Ingest-generic-logs-from-Amazon-S3) for further instructions on how to create a S3 bucket.
+See this [doc](https://cortex-docs.paloaltonetworks.com/cortex-xsiam/configure-cortex-xsiam/cortex-xsiam-data-sources/vendor-specific-data-sources-and-connectors/amazon/amazon-s3/ingest-generic-logs-from-amazon-s3) for further instructions on how to create a S3 bucket.
 
 **On Radware Cloud Services**
 
@@ -44,7 +44,7 @@ For additional information, refer to the official Radware [documentation](https:
 2. Click **Amazon S3**.
 3. Click **Connect** or **Connect Another Instance**.
 4. Set the following values:
-   - SQS URL - Refer to Configure an Amazon Simple Queue Service (SQS) [here](https://docs-cortex.paloaltonetworks.com/r/Cortex-XSIAM/Cortex-XSIAM-Documentation/Ingest-generic-logs-from-Amazon-S3).
+   - SQS URL - Refer to Configure an Amazon Simple Queue Service (SQS) [here](https://cortex-docs.paloaltonetworks.com/cortex-xsiam/configure-cortex-xsiam/cortex-xsiam-data-sources/vendor-specific-data-sources-and-connectors/amazon/amazon-s3/ingest-generic-logs-from-amazon-s3).
    - Name as `Radware Access Log`
    - AWS Client ID
    - AWS Client Secret
@@ -54,7 +54,7 @@ For additional information, refer to the official Radware [documentation](https:
    - Product as `access_logs`
    - Compression as `gzip`
 
-For additional information, see this [doc](https://docs-cortex.paloaltonetworks.com/r/Cortex-XSIAM/Cortex-XSIAM-Documentation/Ingest-generic-logs-from-Amazon-S3).
+For additional information, see this [doc](https://cortex-docs.paloaltonetworks.com/cortex-xsiam/configure-cortex-xsiam/cortex-xsiam-data-sources/vendor-specific-data-sources-and-connectors/amazon/amazon-s3/ingest-generic-logs-from-amazon-s3).
 
 ## Collect Radware AppWall Cloud WAF Security Events
 


### PR DESCRIPTION


## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
<!-- To link a Jira ticket use fixes/related: link to the issue, for example fixes: CIAC-XXXX -->

## Description
The docs-cortex.paloaltonetworks.com documentation portal migrated to the GitBook-based cortex-docs.paloaltonetworks.com and dropped the old /r/Product/Guide/Page-Name URL scheme in favour of a deep hierarchical path scheme.

These links are especially deceptive: the old domain returns HTTP 200 for every path while silently redirecting to the portal home page, so naive status-code link checkers do not flag them. Verified that even docs-cortex.paloaltonetworks.com/thispagedoesnotexist-zzz returns 200 and lands on the home page. Readers following these links get the portal landing page instead of the intended instructions.

A domain-only swap does not work - the old paths 404 on the new domain. Replacement targets were resolved from the portal's own llms.txt index and each was verified to return HTTP 200, resolve with no redirect, and render the expected page title.
## Must have
- [ ] Tests
- [ ] Documentation
