### PR TITLE
Fix update_incident_status command failing on empty API response

### DIFF
--- a/Packs/ThreatMon/Integrations/ThreatMon/ThreatMon.py
+++ b/Packs/ThreatMon/Integrations/ThreatMon/ThreatMon.py
@@ -28,7 +28,7 @@ class Client(BaseClient):
     def set_status(self, data):
         """Updates incidents on Threatmon API using PATCH request."""
 
-        return self._http_request(method="PATCH", url_suffix="/incident/status", json_data=data)
+        return self._http_request(method="PATCH", url_suffix="/incident/status", json_data=data, resp_type="response")
 
     def request_takedown(self, finding_id: int, finding: str):
         """Submits a takedown request for a specific finding (alarm row)."""
@@ -194,11 +194,11 @@ def change_incident_status(client: Client, args: dict[str, Any]) -> CommandResul
     code = args.get("alarmId")
     status = args.get("status")
     data = {"status": status, "alarmIds": [code]}
-    changingStatus = client.set_status(data=data)
-    if changingStatus:
-        return CommandResults(readable_output=f"Incident {code} status changed to {changingStatus}")
+    response = client.set_status(data=data)
+    if response.ok:
+        return CommandResults(readable_output=f"Incident {code} status changed to {status}.")
     else:
-        return CommandResults(readable_output=f"Failed to change status for incident {code}.")
+        raise DemistoException(f"Failed to change status for incident {code}. API returned {response.status_code}: {response.text}")
 
 
 def request_takedown_command(client: Client, args: dict[str, Any]) -> CommandResults:

--- a/Packs/ThreatMon/ReleaseNotes/1_0_5.md
+++ b/Packs/ThreatMon/ReleaseNotes/1_0_5.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Threatmon
+
+- Fixed the **threatmon_update_incident_status** command failing with "Failed to parse json object from response" when the API returns an empty response body on successful status updates.

--- a/Packs/ThreatMon/pack_metadata.json
+++ b/Packs/ThreatMon/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ThreatMon",
     "description": "This integration pulls data from the ThreatMon API and updates XSOAR incidents. You can also update the status of your Incedents in the ThreatMon dashboard from the XSOAR interface with this integration.",
     "support": "community",
-    "currentVersion": "1.0.4",
+    "currentVersion": "1.0.5",
     "author": "ThreatMon",
     "url": "https://www.threatmon.io",
     "email": "integration@threatmonit.io",


### PR DESCRIPTION
## Summary
- Fixed the `threatmon_update_incident_status` command that was failing with `Failed to parse json object from response: b''` error.
- The `/incident/status` API endpoint returns `200 OK` with an empty body on success. The `set_status` client method was using the default `resp_type="json"`, causing `_http_request` to fail when parsing the empty response as JSON.
- Changed `set_status` to use `resp_type="response"` and updated `change_incident_status` to check `response.ok` instead of truthy JSON content.

## Changes
- `ThreatMon.py`: Added `resp_type="response"` to `set_status()` method, refactored `change_incident_status()` to handle raw response
- `pack_metadata.json`: Version bump `1.0.4` → `1.0.5`
- `ReleaseNotes/1_0_5.md`: Added release note for the fix

## Test plan
- [ ] Run `!threatmon_update_incident_status alarmId="18618355" status="Resolved"` in XSOAR and verify it succeeds without JSON parse errors
- [ ] Verify error handling works correctly when API returns non-200 status codes (403, 500)
relates: link to the issue