### PR TITLE
XSUP-74830 - AtlassianConfluenceCloud sanitize dots in parsing rule capture names

### DIFF
--- a/Packs/AtlassianConfluenceCloud/ParsingRules/AtlassianConfluenceCloud/AtlassianConfluenceCloud.xif
+++ b/Packs/AtlassianConfluenceCloud/ParsingRules/AtlassianConfluenceCloud/AtlassianConfluenceCloud.xif
@@ -1,7 +1,7 @@
 [INGEST:vendor="atlassian", product="confluence", target_dataset="atlassian_confluence_raw", no_hit = keep]
 filter to_string(changedvalues) ~= "^\[[\s\S]+\]$"
 | alter
-    tmp_changed_values_name = arraymap(to_string(changedvalues) -> [], replex("@element" -> name, "\s+|\/", "_")),
+    tmp_changed_values_name = arraymap(to_string(changedvalues) -> [], replex("@element" -> name, "\s+|\/|\.", "_")),
     tmp_values_old = arraystring(arraymap(to_string(changedvalues) -> [], "@element" -> oldValue), "|"),
     tmp_values_new = arraystring(arraymap(to_string(changedvalues) -> [], "@element" -> newValue), "|")
 | alter

--- a/Packs/AtlassianConfluenceCloud/ReleaseNotes/1_1_17.md
+++ b/Packs/AtlassianConfluenceCloud/ReleaseNotes/1_1_17.md
@@ -1,0 +1,6 @@
+
+#### Parsing Rules
+
+##### Atlassian Confluence Cloud
+
+- Fixed an issue where the parsing rule failed with a runtime error (*invalid named capture*) when a **changedValues** field name contained a dot (for example *audit.logging.change.space.content.mode*). Dot characters are now sanitized to underscores before being used as regex named-capture group names.

--- a/Packs/AtlassianConfluenceCloud/ReleaseNotes/1_1_17.md
+++ b/Packs/AtlassianConfluenceCloud/ReleaseNotes/1_1_17.md
@@ -1,6 +1,5 @@
-
 #### Parsing Rules
 
-##### Atlassian Confluence Cloud
+##### Atlassian Confluence Parsing Rule
 
 - Fixed an issue where the parsing rule failed with a runtime error (*invalid named capture*) when a **changedValues** field name contained a dot (for example *audit.logging.change.space.content.mode*). Dot characters are now sanitized to underscores before being used as regex named-capture group names.

--- a/Packs/AtlassianConfluenceCloud/pack_metadata.json
+++ b/Packs/AtlassianConfluenceCloud/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Atlassian Confluence Cloud",
     "description": "Atlassian Confluence Cloud allows users to interact with confluence entities like content, space, users and groups. Users can also manage the space permissions.",
     "support": "xsoar",
-    "currentVersion": "1.1.16",
+    "currentVersion": "1.1.17",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Description
The Atlassian Confluence Cloud parsing rule (AtlassianConfluenceCloud.xif) builds RE2 named-capture groups dynamically from each changedValues[].name. Confluence audit-log field names contain dots (e.g. audit.logging.change.space.content.mode). Go's RE2 only permits [A-Za-z0-9_] in capture-group names, so a dotted name throws a runtime error:

```
unable to compile regex `(?i)(?P<audit.logging.change.space.content.mode>[^\|]+)` - invalid named capture
```

The sanitize step `replex("@element" -> name, "\s+|\/", "_")` replaced whitespace and `/` but not dots. This adds `\.` to the alternation so dots become underscores.

## Root cause verified on the reporting tenant
Tenant xdr-eu-2006800998707 (read-only investigation), last ~19 days of atlassian_confluence_raw:

| Category | Rows |
|---|---|
| Total | 10,237 |
| Parse OK | 5,748 |
| Parse-NULL, empty changedValues (no-op) | 4,488 |
| Parse-NULL, real data (the failure) | 1 - name audit.logging.change.space.content.mode |

The single genuine failure carries the exact dotted field from the ticket. Fix validated offline: pre-fix pattern fails to compile, post-fix (audit_logging_change_space_content_mode) compiles cleanly.

## Related
- Jira: XSUP-74830
