### PR TITLE
feat(CommonScripts): add containment evidence evaluator

### DIFF
--- a/Packs/CommonScripts/Scripts/EvaluateContainmentEvidence/EvaluateContainmentEvidence.py
+++ b/Packs/CommonScripts/Scripts/EvaluateContainmentEvidence/EvaluateContainmentEvidence.py
@@ -1,0 +1,122 @@
+from CommonServerPython import *
+
+
+ML_ONLY_MARKERS = ("ml-only", "snortml", "gid 411", "gid:411", "generatorid=411")
+ML_MARKERS = ML_ONLY_MARKERS + ("signature+ml", "signature and ml")
+CORROBORATION_MARKERS = ("signature+ml", "signature and ml")
+SIGNATURE_MARKERS = ("signature", "rule match", "rule-based", "rule based")
+
+
+def _text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, list):
+        return " ".join(_text(item) for item in value)
+    return str(value).strip().lower()
+
+
+def _is_true(value: Any) -> bool:
+    return _text(value) in {"true", "yes", "1"}
+
+
+def _has_true_flag(text: str, name: str) -> bool:
+    return any(token in text for token in (f"{name}=true", f"{name}:true", f"{name}: true"))
+
+
+def evaluate_containment_evidence(args: dict[str, Any]) -> dict[str, Any]:
+    basis = _text(args.get("detection_basis")).replace("-", "_")
+    analytic_type = _text(args.get("analytic_type"))
+    generator_id = _text(args.get("generator_id"))
+    signature_id = _text(args.get("signature_id"))
+    classification = _text(args.get("classification"))
+    context = _text(args.get("incident_context"))
+    combined = " ".join((analytic_type, classification, context))
+
+    explicit_ml = basis == "ml_only"
+    explicit_ml_only = (
+        explicit_ml
+        or generator_id == "411"
+        or _has_true_flag(combined, "is_ml_only")
+        or any(marker in combined for marker in ML_ONLY_MARKERS)
+    )
+    inferred_ml = (
+        generator_id == "411"
+        or _has_true_flag(combined, "is_ml_only")
+        or any(marker in combined for marker in ML_MARKERS)
+    )
+    ml_evidence = explicit_ml or inferred_ml or analytic_type in {"ml", "learning", "machine_learning"}
+
+    explicit_signature = basis == "signature"
+    inferred_signature = bool(signature_id) or any(marker in combined for marker in SIGNATURE_MARKERS)
+    signature_evidence = explicit_signature or inferred_signature
+
+    explicit_corroboration = basis == "corroborated" or _is_true(args.get("is_corroborated"))
+    corroboration_evidence = (
+        explicit_corroboration
+        or _has_true_flag(combined, "is_corroborated")
+        or any(marker in combined for marker in CORROBORATION_MARKERS)
+    )
+
+    reasons: list[str] = []
+    if basis and basis not in {"ml_only", "signature", "corroborated", "unknown"}:
+        reasons.append("invalid_detection_basis")
+        disposition = "unknown"
+    elif basis == "unknown":
+        reasons.append("explicit_unknown_evidence")
+        disposition = "unknown"
+    elif explicit_ml_only:
+        # Explicit ML-only evidence wins over classifications left on the same event.
+        reasons.append("explicit_ml_only_evidence")
+        disposition = "ml_only"
+    elif explicit_corroboration:
+        if ml_evidence and signature_evidence:
+            reasons.append("independent_ml_and_signature_evidence")
+            disposition = "corroborated"
+        else:
+            reasons.append("corroboration_missing_independent_signals")
+            disposition = "unknown"
+    elif explicit_signature:
+        reasons.append("explicit_signature_evidence")
+        disposition = "signature"
+    elif ml_evidence and signature_evidence and corroboration_evidence:
+        reasons.append("independent_ml_and_signature_evidence")
+        disposition = "corroborated"
+    elif signature_evidence and not ml_evidence:
+        reasons.append("inferred_signature_evidence")
+        disposition = "signature"
+    elif ml_evidence:
+        reasons.append("inferred_ml_only_evidence")
+        disposition = "ml_only"
+    else:
+        reasons.append("insufficient_evidence")
+        disposition = "unknown"
+
+    allow_auto_contain = disposition in {"signature", "corroborated"}
+    return {
+        "disposition": disposition,
+        "allow_auto_contain": allow_auto_contain,
+        "require_user_verification": not allow_auto_contain,
+        "reason_codes": reasons,
+        "evidence_summary": (
+            f"disposition={disposition}; auto_contain={'allowed' if allow_auto_contain else 'denied'}; "
+            f"reason={','.join(reasons)}"
+        ),
+    }
+
+
+def main() -> None:
+    try:
+        result = evaluate_containment_evidence(demisto.args())
+        return_results(CommandResults(
+            outputs_prefix="ContainmentEvidence",
+            outputs=result,
+            raw_response=result,
+            readable_output=tableToMarkdown("Containment evidence decision", result, removeNull=True),
+        ))
+    except Exception as ex:
+        demisto.error(traceback.format_exc())
+        return_error(f"Failed to evaluate containment evidence: {ex!s}")
+
+
+if __name__ in ("__main__", "__builtin__", "builtins"):
+    main()

--- a/Packs/CommonScripts/Scripts/EvaluateContainmentEvidence/EvaluateContainmentEvidence.yml
+++ b/Packs/CommonScripts/Scripts/EvaluateContainmentEvidence/EvaluateContainmentEvidence.yml
@@ -1,0 +1,60 @@
+args:
+- auto: PREDEFINED
+  description: An authoritative detection basis supplied by the calling analytic or playbook. Unknown and ML-only evidence require user verification.
+  name: detection_basis
+  predefined:
+  - ml_only
+  - signature
+  - corroborated
+  - unknown
+- description: The analytic type, such as Learning, ML, Rule, or Signature.
+  name: analytic_type
+- description: The generator ID associated with the detection. Generator ID 411 is treated as explicit ML-only evidence.
+  name: generator_id
+- description: The identifier of an independently matched signature or rule.
+  name: signature_id
+- description: The detection classification text.
+  name: classification
+- auto: PREDEFINED
+  defaultValue: 'False'
+  description: Whether independent ML and signature evidence was explicitly corroborated.
+  name: is_corroborated
+  predefined:
+  - 'True'
+  - 'False'
+- description: Additional incident text used for conservative evidence inference.
+  name: incident_context
+comment: Evaluates the evidence basis for a containment decision. ML-only, unknown, contradictory, and incomplete evidence require user verification. The script does not perform containment.
+commonfields:
+  id: EvaluateContainmentEvidence
+  version: -1
+enabled: true
+name: EvaluateContainmentEvidence
+outputs:
+- contextPath: ContainmentEvidence.disposition
+  description: The normalized evidence disposition. Possible values are ml_only, signature, corroborated, and unknown.
+  type: String
+- contextPath: ContainmentEvidence.allow_auto_contain
+  description: Whether the supplied evidence is sufficient for a caller to consider automatic containment.
+  type: Boolean
+- contextPath: ContainmentEvidence.require_user_verification
+  description: Whether the caller must require user verification before containment.
+  type: Boolean
+- contextPath: ContainmentEvidence.reason_codes
+  description: Deterministic reason codes supporting the decision.
+  type: String
+- contextPath: ContainmentEvidence.evidence_summary
+  description: A concise, deterministic decision summary suitable for an investigation record.
+  type: String
+script: '-'
+subtype: python3
+tags:
+- evaluation
+- containment
+timeout: '0'
+type: python
+dockerimage: demisto/python3:3.12.13.10404775
+runas: DBotWeakRole
+tests:
+- No tests (auto formatted)
+fromversion: 6.10.0

--- a/Packs/CommonScripts/Scripts/EvaluateContainmentEvidence/EvaluateContainmentEvidence_test.py
+++ b/Packs/CommonScripts/Scripts/EvaluateContainmentEvidence/EvaluateContainmentEvidence_test.py
@@ -1,0 +1,44 @@
+import pytest
+
+from EvaluateContainmentEvidence import evaluate_containment_evidence
+
+
+@pytest.mark.parametrize(
+    "args, disposition, allowed, reason",
+    [
+        ({"detection_basis": "ml_only"}, "ml_only", False, "explicit_ml_only_evidence"),
+        ({"detection_basis": "signature"}, "signature", True, "explicit_signature_evidence"),
+        ({"generator_id": "411", "classification": "attempted-admin"}, "ml_only", False,
+         "explicit_ml_only_evidence"),
+        ({"incident_context": "SnortML high confidence"}, "ml_only", False, "explicit_ml_only_evidence"),
+        ({"signature_id": "100042", "classification": "signature match"}, "signature", True,
+         "inferred_signature_evidence"),
+        ({}, "unknown", False, "insufficient_evidence"),
+        ({"detection_basis": "unknown", "signature_id": "42"}, "unknown", False,
+         "explicit_unknown_evidence"),
+        ({"detection_basis": "invalid"}, "unknown", False, "invalid_detection_basis"),
+        ({"detection_basis": "corroborated", "signature_id": "42"}, "unknown", False,
+         "corroboration_missing_independent_signals"),
+        ({"detection_basis": "corroborated", "signature_id": "42", "analytic_type": "ML"},
+         "corroborated", True, "independent_ml_and_signature_evidence"),
+        ({"incident_context": "signature+ml corroboration"}, "corroborated", True,
+         "independent_ml_and_signature_evidence"),
+        ({"generator_id": "411", "signature_id": "42", "is_corroborated": "True"}, "ml_only", False,
+         "explicit_ml_only_evidence"),
+        ({"incident_context": "is_ml_only=false", "signature_id": "42"}, "signature", True,
+         "inferred_signature_evidence"),
+    ],
+)
+def test_evaluate_containment_evidence(args, disposition, allowed, reason):
+    result = evaluate_containment_evidence(args)
+
+    assert result["disposition"] == disposition
+    assert result["allow_auto_contain"] is allowed
+    assert result["require_user_verification"] is not allowed
+    assert result["reason_codes"] == [reason]
+
+
+def test_output_is_deterministic():
+    args = {"generator_id": "411", "classification": "signature", "incident_context": ["A", "B"]}
+
+    assert evaluate_containment_evidence(args) == evaluate_containment_evidence(args)

--- a/Packs/CommonScripts/Scripts/EvaluateContainmentEvidence/README.md
+++ b/Packs/CommonScripts/Scripts/EvaluateContainmentEvidence/README.md
@@ -1,0 +1,27 @@
+# EvaluateContainmentEvidence
+
+Evaluates whether detection evidence is sufficient for a calling playbook to consider automatic containment. The script does not perform containment or override the caller's policy.
+
+ML-only and unknown evidence require user verification. A corroborated disposition requires independent ML and signature evidence. Explicit ML-only evidence, including generator ID 411, takes precedence over classification text that may remain on the same event.
+
+## Inputs
+
+| Name | Description |
+|---|---|
+| detection_basis | Optional authoritative basis: `ml_only`, `signature`, `corroborated`, or `unknown`. |
+| analytic_type | Analytic type such as Learning, ML, Rule, or Signature. |
+| generator_id | Detection generator ID. Generator ID 411 is ML-only evidence. |
+| signature_id | Identifier of an independently matched signature or rule. |
+| classification | Detection classification text. |
+| is_corroborated | Whether independent ML and signature evidence was explicitly corroborated. |
+| incident_context | Additional incident text for conservative inference. |
+
+## Outputs
+
+| Context path | Description |
+|---|---|
+| ContainmentEvidence.disposition | `ml_only`, `signature`, `corroborated`, or `unknown`. |
+| ContainmentEvidence.allow_auto_contain | Whether the evidence is sufficient for a caller to consider automatic containment. |
+| ContainmentEvidence.require_user_verification | Whether verification is required before containment. |
+| ContainmentEvidence.reason_codes | Deterministic reason codes for the decision. |
+| ContainmentEvidence.evidence_summary | Concise decision summary for the investigation record. |


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content

I will complete the contribution registration form linked by the repository before requesting review.

## Status

- [x] In Progress
- [ ] Ready
- [ ] In Hold

## Related Issues

N/A - new common automation.

## Description

Adds `EvaluateContainmentEvidence`, a deterministic common automation that normalizes the evidence basis for a containment decision without performing containment itself.

The script returns:

- `ml_only`, `signature`, `corroborated`, or `unknown` disposition;
- whether evidence is sufficient for a caller to consider automatic containment;
- whether user verification is required;
- stable reason codes and a concise evidence summary for the investigation record.

Safety behavior:

- ML-only and unknown evidence require user verification.
- Explicit ML-only evidence takes precedence over classification text left on the same event.
- Generator ID 411 is treated as explicit ML-only evidence.
- A corroborated disposition requires independent ML and signature evidence.
- Invalid, contradictory, or incomplete inputs fail closed.
- `is_ml_only=false` is not interpreted as affirmative ML-only evidence.

The script is vendor-neutral and has no external API or model dependency. It is intended as a reusable primitive for containment playbooks; wiring it into a generic blocking playbook can be reviewed separately after the evidence contract is accepted.

## Verification

- [x] Python syntax compilation
- [x] YAML parsing
- [x] 13 focused decision cases passed locally
- [x] `git diff --check`
- [ ] Repository-native pytest/CI

Local focused cases cover explicit and inferred ML-only evidence, signature evidence, independent corroboration, missing evidence, invalid basis, explicit unknown precedence, conflicting generator/signature fields, false boolean flags, and deterministic output.

## Must have

- [x] Tests
- [x] Documentation


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-17717