### PR TITLE
Reco: fix fetch-incidents skipping alerts during bursts

### DIFF
--- a/Packs/Reco/.pack-ignore
+++ b/Packs/Reco/.pack-ignore
@@ -1,3 +1,5 @@
 [known_words]
 SCIM
 backoff
+paginated
+resumable

--- a/Packs/Reco/Integrations/Reco/Reco.py
+++ b/Packs/Reco/Integrations/Reco/Reco.py
@@ -137,11 +137,17 @@ class RecoClient(BaseClient):
         filters: str = "",
         count: int = PAGE_SIZE,
         start_index: int = 0,
+        sort_by: str = "",
+        sort_order: str = "",
     ) -> dict[str, Any]:
-        """GET /external-api/{endpoint} with SCIM filter and pagination params."""
+        """GET /external-api/{endpoint} with SCIM filter, sort, and pagination params."""
         params: dict[str, Any] = {"count": count, "startIndex": start_index}
         if filters:
             params["filters"] = filters
+        if sort_by:
+            params["sortBy"] = sort_by
+        if sort_order:
+            params["sortOrder"] = sort_order
         return self._rate_limited_request(
             method="GET",
             url_suffix=f"{EXTERNAL_API_BASE}/{endpoint}",
@@ -213,11 +219,16 @@ class RecoClient(BaseClient):
         before: datetime | None = None,
         after: datetime | None = None,
         limit: int = PAGE_SIZE,
+        start_index: int = 0,
     ) -> list[dict[str, Any]]:
-        """List threat alerts via the external API.
+        """List threat alerts via the external API, oldest first.
 
         risk_levels: list of severity names, e.g. ["HIGH", "CRITICAL"].  Multiple
         values are combined with OR so a single call fetches all matching severities.
+
+        Sorted ascending by createdAt (rather than the API's default descending order) so
+        that fetch_incidents can page through a burst via `start_index` without ever
+        skipping alerts, regardless of how many share the same fetch window.
         """
         filter_parts: list[str] = []
 
@@ -240,7 +251,14 @@ class RecoClient(BaseClient):
         demisto.debug(f"get_alerts SCIM filter: {scim_filter!r}")
 
         try:
-            response = self._external_api_list("alerts/list", filters=scim_filter, count=limit)
+            response = self._external_api_list(
+                "alerts/list",
+                filters=scim_filter,
+                count=limit,
+                start_index=start_index,
+                sort_by="createdAt",
+                sort_order="ascending",
+            )
             alerts = response.get("alerts", [])
             demisto.info(f"get_alerts: fetched {len(alerts)} alerts (total={response.get('totalResults', '?')})")
             return alerts
@@ -893,12 +911,14 @@ def get_alerts(
     before: datetime | None = None,
     after: datetime | None = None,
     limit: int = PAGE_SIZE,
-) -> list[Any]:
+    start_index: int = 0,
+) -> tuple[list[Any], int]:
     """Fetch alert summaries then enrich each with full detail (policy violations).
 
-    Returns a list of ThreatAlertDetail dicts from the external API.
+    Returns the enriched ThreatAlertDetail dicts alongside the raw page size, so callers
+    can tell whether the page was truncated by `limit` (more alerts may remain).
     """
-    raw_alerts = reco_client.get_alerts(risk_levels, source, before, after, limit)
+    raw_alerts = reco_client.get_alerts(risk_levels, source, before, after, limit, start_index)
     alerts_data: list[Any] = []
 
     for raw in raw_alerts:
@@ -925,7 +945,7 @@ def get_alerts(
             demisto.error(f"Failed to enrich alert {alert_id}: {str(e)}")
 
     demisto.info(f"get_alerts: enriched {len(alerts_data)}/{len(raw_alerts)} alerts")
-    return alerts_data
+    return alerts_data, len(raw_alerts)
 
 
 # --- Score mapping ---
@@ -1017,8 +1037,9 @@ def fetch_incidents(
     last_run_time = last_run.get("lastRun", None)
     if last_run_time is not None:
         after = dateutil.parser.parse(last_run_time)
+    start_index = last_run.get("startIndex", 0)
 
-    alerts = get_alerts(reco_client, risk_levels, source, before, after, max_fetch)
+    alerts, raw_page_size = get_alerts(reco_client, risk_levels, source, before, after, max_fetch, start_index)
     incidents = parse_alerts_to_incidents(alerts)
 
     existing_incidents = last_run.get("incident_ids", [])
@@ -1029,12 +1050,22 @@ def fetch_incidents(
         and (incident.get("dbotMirrorId", None) not in existing_incidents)
     ]
 
-    incidents_sorted = sorted(incidents, key=lambda k: k["occurred"])
-    if incidents_sorted:
-        last_occurred_dt = dateutil.parser.parse(incidents_sorted[-1]["occurred"])
-        next_run["lastRun"] = (last_occurred_dt + timedelta(seconds=1)).strftime(DEMISTO_OCCURRED_FORMAT)
+    if raw_page_size < max_fetch:
+        # The window is fully drained - safe to advance the timestamp cursor.
+        incidents_sorted = sorted(incidents, key=lambda k: k["occurred"])
+        if incidents_sorted:
+            last_occurred_dt = dateutil.parser.parse(incidents_sorted[-1]["occurred"])
+            next_run["lastRun"] = (last_occurred_dt + timedelta(seconds=1)).strftime(DEMISTO_OCCURRED_FORMAT)
+        else:
+            next_run["lastRun"] = last_run_time
+        next_run["startIndex"] = 0
     else:
+        # The page was full - more alerts may remain in this window. Keep lastRun in place
+        # and resume from start_index next cycle, so a burst larger than max_fetch is
+        # drained over multiple cycles instead of the excess being permanently skipped.
         next_run["lastRun"] = last_run_time
+        next_run["startIndex"] = start_index + raw_page_size
+
     next_run["incident_ids"] = existing_incidents + [inc["dbotMirrorId"] for inc in incidents]
 
     return next_run, incidents

--- a/Packs/Reco/Integrations/Reco/Reco.py
+++ b/Packs/Reco/Integrations/Reco/Reco.py
@@ -229,8 +229,12 @@ class RecoClient(BaseClient):
         Sorted ascending by createdAt (rather than the API's default descending order) so
         that fetch_incidents can page through a burst via `start_index` without ever
         skipping alerts, regardless of how many share the same fetch window.
+
+        Preview-state alerts are always excluded: a Policy in Preview state is explicitly
+        meant to stay out of the customer's SOAR/ticketing systems while it's being
+        evaluated (the webhook and share-service paths already enforce this upstream).
         """
-        filter_parts: list[str] = []
+        filter_parts: list[str] = ['status ne "ALERT_STATUS_PREVIEW"']
 
         if risk_levels:
             if len(risk_levels) == 1:

--- a/Packs/Reco/Integrations/Reco/Reco_test.py
+++ b/Packs/Reco/Integrations/Reco/Reco_test.py
@@ -224,6 +224,54 @@ def test_fetch_same_incidents(requests_mock, reco_client: RecoClient) -> None:
     assert len(incidents) == 0
 
 
+def test_fetch_incidents_paginates_a_burst_without_skipping(requests_mock, reco_client: RecoClient) -> None:
+    """A page as large as max_fetch must not advance lastRun; the next cycle resumes via
+    startIndex instead, so a burst larger than max_fetch is drained over multiple cycles
+    rather than the excess being permanently skipped."""
+    created_at = datetime.datetime.now().strftime(TIME_FORMAT)
+    page_1_ids = [str(uuid.uuid4()), str(uuid.uuid4())]
+    page_2_ids = [str(uuid.uuid4())]
+
+    requests_mock.get(
+        f"{DUMMY_RECO_API_DNS_NAME}/external-api/alerts/list",
+        [
+            {"json": build_alerts_list_response(page_1_ids)},
+            {"json": build_alerts_list_response(page_2_ids)},
+        ],
+    )
+    for alert_id in page_1_ids + page_2_ids:
+        requests_mock.get(
+            f"{DUMMY_RECO_API_DNS_NAME}/external-api/alert-details/{alert_id}",
+            json=build_alert_detail(alert_id, INCIDENT_DESCRIPTION, 30, created_at),
+        )
+
+    last_run, incidents = fetch_incidents(reco_client=reco_client, last_run={}, max_fetch=2)
+
+    assert len(incidents) == 2
+    assert last_run["startIndex"] == 2
+    assert last_run["lastRun"] is None
+
+    last_run, incidents = fetch_incidents(reco_client=reco_client, last_run=last_run, max_fetch=2)
+
+    assert len(incidents) == 1
+    assert last_run["startIndex"] == 0
+    assert last_run["lastRun"] is not None
+
+
+def test_get_alerts_sorts_ascending_and_forwards_pagination(requests_mock, reco_client: RecoClient) -> None:
+    """get_alerts must request ascending createdAt order and forward start_index/count, so
+    resuming a burst mid-window never skips or re-jumps past unfetched alerts."""
+    requests_mock.get(f"{DUMMY_RECO_API_DNS_NAME}/external-api/alerts/list", json=build_alerts_list_response([]))
+
+    reco_client.get_alerts(limit=50, start_index=100)
+
+    sent_qs = requests_mock.last_request.qs
+    assert sent_qs["sortby"] == ["createdat"]
+    assert sent_qs["sortorder"] == ["ascending"]
+    assert sent_qs["startindex"] == ["100"]
+    assert sent_qs["count"] == ["50"]
+
+
 def test_fetch_incidents_without_assets_info(requests_mock, reco_client: RecoClient) -> None:
     created_at = datetime.datetime.now().strftime(TIME_FORMAT)
     requests_mock.get(f"{DUMMY_RECO_API_DNS_NAME}/external-api/alerts/list", json=build_alerts_list_response([ALERT_ID]))

--- a/Packs/Reco/Integrations/Reco/Reco_test.py
+++ b/Packs/Reco/Integrations/Reco/Reco_test.py
@@ -272,6 +272,19 @@ def test_get_alerts_sorts_ascending_and_forwards_pagination(requests_mock, reco_
     assert sent_qs["count"] == ["50"]
 
 
+def test_get_alerts_excludes_preview_status(requests_mock, reco_client: RecoClient) -> None:
+    """get_alerts must always filter out ALERT_STATUS_PREVIEW alerts - Preview-state
+    Policies are meant to stay out of the customer's SOAR, matching the guard already
+    enforced on the webhook and share-service paths."""
+    requests_mock.get(f"{DUMMY_RECO_API_DNS_NAME}/external-api/alerts/list", json=build_alerts_list_response([]))
+
+    reco_client.get_alerts(risk_levels=["HIGH"])
+
+    sent_filter = requests_mock.last_request.qs["filters"][0]
+    assert 'status ne "alert_status_preview"' in sent_filter
+    assert 'severity eq "high"' in sent_filter
+
+
 def test_fetch_incidents_without_assets_info(requests_mock, reco_client: RecoClient) -> None:
     created_at = datetime.datetime.now().strftime(TIME_FORMAT)
     requests_mock.get(f"{DUMMY_RECO_API_DNS_NAME}/external-api/alerts/list", json=build_alerts_list_response([ALERT_ID]))

--- a/Packs/Reco/ReleaseNotes/1_8_1.md
+++ b/Packs/Reco/ReleaseNotes/1_8_1.md
@@ -3,3 +3,4 @@
 ##### Reco
 
 - Fixed an issue where ***fetch-incidents*** could permanently skip alerts during a burst larger than *Max fetch* in a single time window. Alert fetching is now sorted ascending by *createdAt* and paginated across cycles via a resumable offset, so a burst is drained over multiple fetch cycles instead of the excess being silently dropped.
+- Fixed an issue where ***fetch-incidents*** ingested alerts from Policies in *Preview* state. Preview alerts are now excluded, matching the behavior of Reco's other alert delivery paths.

--- a/Packs/Reco/ReleaseNotes/1_8_1.md
+++ b/Packs/Reco/ReleaseNotes/1_8_1.md
@@ -1,0 +1,5 @@
+#### Integrations
+
+##### Reco
+
+- Fixed an issue where ***fetch-incidents*** could permanently skip alerts during a burst larger than *Max fetch* in a single time window. Alert fetching is now sorted ascending by *createdAt* and paginated across cycles via a resumable offset, so a burst is drained over multiple fetch cycles instead of the excess being silently dropped.

--- a/Packs/Reco/pack_metadata.json
+++ b/Packs/Reco/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Reco",
     "description": "Reco is the leader in Dynamic SaaS Security \u2014 the only approach that eliminates the SaaS Security Gap (the growing gap between what you can protect and what\u2019s outpacing your security).",
     "support": "partner",
-    "currentVersion": "1.8.0",
+    "currentVersion": "1.8.1",
     "author": "Reco",
     "url": "https://reco.ai",
     "email": "support@reco.ai",


### PR DESCRIPTION
## Summary

During an alert flood, `fetch-incidents` could permanently skip the majority of alerts in a single time window. Separately, `fetch-incidents` was also ingesting alerts belonging to Policies in *Preview* state, which should never leave Reco.

**Fix 1 - burst pagination:**

**Root cause:** `get_alerts` fetched one page per cycle using the External API's default sort (`createdAt` descending), then `fetch_incidents` advanced the `lastRun` cursor to the newest timestamp seen in that page. When a burst exceeded `Max fetch` in one window, the returned page was the *newest* slice of the burst, so the cursor jumped past all the older alerts that didn't make it into that page — silently dropping them forever (reported: 669/1069 alerts lost in a one-minute burst, Iron Mountain support ticket).

- `get_alerts` now requests ascending `createdAt` order and forwards `start_index`.
- `fetch_incidents` only advances `lastRun` once a page comes back smaller than `max_fetch` (i.e. the window is fully drained). A full page instead advances a `startIndex` offset persisted in `last_run`, so a burst larger than `max_fetch` is paginated across multiple fetch cycles instead of being truncated.

**Fix 2 - exclude Preview-state alerts:**

**Root cause:** a Policy in *Preview* state is meant to keep its alerts out of the customer's SOAR while it's being evaluated. Reco's webhook and share-service delivery paths already enforce this, but `fetch-incidents` (which polls the External API directly) had no equivalent guard, so Preview alerts leaked into XSOAR.

- `get_alerts` now always adds `status ne "ALERT_STATUS_PREVIEW"` to its SCIM filter.

Version bumped 1.8.0 → 1.8.1.

## Test plan

- [x] Local: `pytest Packs/Reco/Integrations/Reco/Reco_test.py` — 72/72 pass (Docker unavailable locally, so `demisto-sdk pre-commit`'s ruff/xsoar-lint/pylint/mypy steps will run via CI on this PR rather than locally)
- [x] New unit tests: burst spanning two fetch cycles resumes via `startIndex` without skipping; `get_alerts` sends ascending sort + pagination params; `get_alerts` excludes `ALERT_STATUS_PREVIEW` alongside other filters
- [x] `status ne "ALERT_STATUS_PREVIEW"` verified against the live External API (confirmed a known Preview alert is excluded by this exact filter)