### PR TITLE
Fix SyntaxWarning in Google Sheets

### DIFF
--- a/Packs/GoogleSheets/Integrations/GoogleSheets/GoogleSheets.py
+++ b/Packs/GoogleSheets/Integrations/GoogleSheets/GoogleSheets.py
@@ -20,6 +20,9 @@ urllib3.disable_warnings()  # pylint: disable=no-member
 """ CONSTANTS """
 
 DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"  # ISO8601 format with UTC, default in XSOAR
+# Matches one or more bracket-enclosed groups, e.g. "[1,2,3]" or "[1,2,3],[4,5,6]".
+# Used to validate that the `values` argument is in the expected list-of-lists format.
+BRACKET_LIST_PATTERN = re.compile(r"\[(.*?)\]")
 
 
 # HELPER FUNCTIONS
@@ -105,7 +108,7 @@ def handle_values_input(values: str) -> list:
     """
 
     # Validate that the user has entered valid values
-    if not values or not re.findall("\[(.*?)\]", values):
+    if not values or not BRACKET_LIST_PATTERN.findall(values):
         raise ValueError("Wrong format of values entered, please check the documentation")
 
     # Converting the values the user entered into an array of arrays

--- a/Packs/GoogleSheets/Integrations/GoogleSheets/GoogleSheets.yml
+++ b/Packs/GoogleSheets/Integrations/GoogleSheets/GoogleSheets.yml
@@ -3,7 +3,7 @@ provider: Google
 commonfields:
   id: GoogleSheets
   version: -1
-sectionOrder:
+sectionorder:
 - Connect
 - Collect
 configuration:

--- a/Packs/GoogleSheets/Integrations/GoogleSheets/GoogleSheets.yml
+++ b/Packs/GoogleSheets/Integrations/GoogleSheets/GoogleSheets.yml
@@ -3,6 +3,9 @@ provider: Google
 commonfields:
   id: GoogleSheets
   version: -1
+sectionOrder:
+- Connect
+- Collect
 configuration:
 - name: service_account_credentials
   display:
@@ -12,16 +15,21 @@ configuration:
   additionalinfo: A service account key from Google.
   displaypassword: Service Account Key
   hiddenusername: true
+  section: Connect
 - name: insecure
   display: Trust any certificate (not secure)
   type: 8
   additionalinfo:
   required: false
+  section: Connect
+  advanced: true
 - name: proxy
   display: Use system proxy settings
   type: 8
   additionalinfo:
   required: false
+  section: Connect
+  advanced: true
 - name: user_id
   display: Email - Associate to Google Drive
   defaultvalue:
@@ -32,6 +40,7 @@ configuration:
     easily accessible from a UI. This parameter is used during the
     authentication process.
   required: false
+  section: Connect
 description: Google Sheets is a spreadsheet program that is part of the free web-based Google applications to create and format spreadsheets. Use this integration to create and modify spreadsheets.
 display: Google Sheets
 name: GoogleSheets

--- a/Packs/GoogleSheets/ReleaseNotes/1_0_54.md
+++ b/Packs/GoogleSheets/ReleaseNotes/1_0_54.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Google Sheets
+
+- Fixed an issue where all commands failed with `SyntaxWarning: invalid escape sequence '\['` on Python 3.12+ (introduced by the Docker image bump in v1.0.53). The regex pattern used to validate the *values* argument is now defined as a compiled constant using a raw string.

--- a/Packs/GoogleSheets/ReleaseNotes/1_0_54.md
+++ b/Packs/GoogleSheets/ReleaseNotes/1_0_54.md
@@ -3,4 +3,4 @@
 
 ##### Google Sheets
 
-- Fixed an issue where all commands failed with `SyntaxWarning: invalid escape sequence '\['` on Python 3.12+ (introduced by the Docker image bump in v1.0.53). The regex pattern used to validate the *values* argument is now defined as a compiled constant using a raw string.
+- Fixed an issue where all commands failed with `SyntaxWarning: invalid escape sequence '\['` on Python 3.12+ (introduced by the Docker image bump in content pack version 1.0.53). The regex pattern used to validate the *values* argument is now defined as a compiled constant using a raw string.

--- a/Packs/GoogleSheets/ReleaseNotes/1_0_54.md
+++ b/Packs/GoogleSheets/ReleaseNotes/1_0_54.md
@@ -3,4 +3,4 @@
 
 ##### Google Sheets
 
-- Fixed an issue where all commands failed with `SyntaxWarning: invalid escape sequence '\['` on Python 3.12+ (introduced by the Docker image bump in content pack version 1.0.53). The regex pattern used to validate the *values* argument is now defined as a compiled constant using a raw string.
+- Fixed an issue where all commands failed with `SyntaxWarning: invalid escape sequence '\['` on Python 3.12+ (introduced by the Docker image bump in content pack version *1.0.53*). The regex pattern used to validate the *values* argument is now defined as a compiled constant using a raw string.

--- a/Packs/GoogleSheets/pack_metadata.json
+++ b/Packs/GoogleSheets/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Google Sheets",
     "description": "The Google Sheets API is a RESTful interface that lets you read and modify a spreadsheet's data. The most common uses of this API include the following tasks- create spreadsheets, read and write spreadsheets cells, update spreadsheet formatting",
     "support": "xsoar",
-    "currentVersion": "1.0.53",
+    "currentVersion": "1.0.54",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixes: [XSUP-75129](https://jira-dc.paloaltonetworks.com/browse/XSUP-75129)

## Description
Fixed an issue where all commands failed with `SyntaxWarning: invalid escape sequence '\['` on Python 3.12+ (introduced by the Docker image bump in v1.0.53). The regex pattern used to validate the *values* argument is now defined as a compiled constant using a raw string.

