### PR TITLE
fix(CybleThreatIntel): improve fetch reliability and indicator ingestion

### DIFF
--- a/Packs/CybleThreatIntel/.secrets-ignore
+++ b/Packs/CybleThreatIntel/.secrets-ignore
@@ -1,0 +1,3 @@
+https://example.com
+example.com
+user@example.com

--- a/Packs/CybleThreatIntel/Integrations/CybleThreatIntel/CybleThreatIntel.py
+++ b/Packs/CybleThreatIntel/Integrations/CybleThreatIntel/CybleThreatIntel.py
@@ -1,12 +1,12 @@
 from typing import *
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
+import traceback
 import time
 import demistomock as demisto
 from CommonServerPython import *
 from CommonServerUserPython import *
 from enum import Enum
 
-import requests
 import urllib3
 
 urllib3.disable_warnings()
@@ -16,7 +16,7 @@ urllib3.disable_warnings()
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S+00:00"  # Your API format
 MAX_API_PAGE_LIMIT = 100
 CHUNK_MINUTES = 15
-# Non-TIM XSOAR licenses hard-cap ingestion at 100 indicators per fetch-indicators run.
+# Non-TIM Cortex licenses hard-cap ingestion at 100 indicators per fetch-indicators run.
 # Calling createIndicators again after that logs success in our code but the platform ingests 0
 # and advancing the page checkpoint would permanently skip those IOCs.
 DEFAULT_MAX_INDICATORS_PER_FETCH = 100
@@ -25,34 +25,41 @@ DEFAULT_MAX_INDICATORS_PER_FETCH = 100
 TIME_TO_RUN_BUFFER_SECONDS = 60
 DEFAULT_EXECUTION_TIMEOUT_SECONDS = 3 * 60
 FETCH_RETRY_ATTEMPTS = 5
-FETCH_RETRY_SLEEP_SECONDS = 1
+HTTP_STATUS_LIST_TO_RETRY = [429, 500, 502, 503, 504]
 
 
-class Client:
+def get_current_utc_time() -> datetime:
+    """Return a timezone-aware UTC datetime."""
+    return datetime.now(tz=UTC)
+
+
+class Client(BaseClient):
+    """HTTP client for Cyble Vision using BaseClient._http_request retries (no time.sleep)."""
+
     def __init__(self, params: dict):
-        self.base_url = params.get("base_url", "").rstrip("/")
-        self.access_token = params.get("credentials", {}).get("password", "").strip()
-
+        self.base_url = (params.get("base_url") or "").rstrip("/")
+        self.access_token = str((params.get("credentials") or {}).get("password", "") or "").strip()
+        verify = not argToBoolean(params.get("insecure", False))
+        proxy = argToBoolean(params.get("proxy", False))
         self.headers = {
             "Authorization": f"Bearer {self.access_token}",
             "Accept": "application/json",
             "Content-Type": "application/json",
         }
+        super().__init__(base_url=self.base_url, verify=verify, proxy=proxy, headers=self.headers)
         demisto.debug(f"Client initialized with base_url: {self.base_url}")
 
     def http_post(self, endpoint: str, json_body: dict):
-        url = f"{self.base_url}/{endpoint.lstrip('/')}"
-        demisto.debug(f"POST Request URL: {url}")
-        demisto.debug(f"POST Request Body: {json_body}")
-        resp = requests.post(url, headers=self.headers, json=json_body, verify=False)
-        demisto.debug(f"Response Status Code: {resp.status_code}")
-        try:
-            resp.raise_for_status()
-            resp_json = resp.json()
-            return resp_json
-        except Exception as e:
-            demisto.debug(f"HTTP request failed: {e}, Response Text: {resp.text}")
-            raise
+        """POST JSON to the Cyble Vision API with built-in retries (no time.sleep)."""
+        demisto.debug(f"POST Request endpoint: {endpoint}, body: {json_body}")
+        return self._http_request(
+            method="POST",
+            url_suffix=endpoint,
+            json_data=json_body,
+            retries=FETCH_RETRY_ATTEMPTS,
+            status_list_to_retry=HTTP_STATUS_LIST_TO_RETRY,
+            backoff_factor=1.0,
+        )
 
     # ------------------------------
     # IOC LOOKUP
@@ -77,19 +84,21 @@ def get_time_range(hours_back: int, last_run: dict) -> Tuple[str, str]:
     Determine the gte/lte timestamps for fetch.
     Uses hours only (days no longer supported).
     """
-    now = datetime.utcnow()
+    now = get_current_utc_time()
 
     # If we have last_fetch → resume from there
     last_fetch = last_run.get("last_fetch")
     if last_fetch:
         gte_dt = datetime.fromisoformat(last_fetch)
+        if gte_dt.tzinfo is None:
+            gte_dt = gte_dt.replace(tzinfo=UTC)
     else:
         # First run → go back N hours
         gte_dt = now - timedelta(hours=hours_back)
 
     lte_dt = now
 
-    demisto.debug(f"Calculated fetch time range: gte={gte_dt.isoformat()}Z, lte={lte_dt.isoformat()}Z")
+    demisto.debug(f"Calculated fetch time range: gte={gte_dt.isoformat()}, lte={lte_dt.isoformat()}")
 
     return gte_dt.isoformat(), lte_dt.isoformat()
 
@@ -102,9 +111,7 @@ def get_execution_timeout_seconds() -> float:
     return float(DEFAULT_EXECUTION_TIMEOUT_SECONDS)
 
 
-def should_stop_before_next_page(
-    pages_completed: int, last_page_duration_seconds: float, execution_start: datetime
-) -> bool:
+def should_stop_before_next_page(pages_completed: int, last_page_duration_seconds: float, execution_start: datetime) -> bool:
     """
     Akamai-style guard: always allow the first page, then stop if there is not enough
     budget left to safely complete another page plus TIME_TO_RUN_BUFFER_SECONDS.
@@ -112,8 +119,13 @@ def should_stop_before_next_page(
     if pages_completed <= 0:
         return False
 
-    elapsed_seconds = (datetime.utcnow() - execution_start).total_seconds()
-    remaining_seconds = get_execution_timeout_seconds() - elapsed_seconds - TIME_TO_RUN_BUFFER_SECONDS
+    start = execution_start if execution_start.tzinfo else execution_start.replace(tzinfo=UTC)
+    elapsed_seconds = (get_current_utc_time() - start).total_seconds()
+    try:
+        timeout_seconds = float(get_execution_timeout_seconds())
+    except (TypeError, ValueError):
+        timeout_seconds = float(DEFAULT_EXECUTION_TIMEOUT_SECONDS)
+    remaining_seconds = timeout_seconds - elapsed_seconds - TIME_TO_RUN_BUFFER_SECONDS
     estimated_next_page_seconds = last_page_duration_seconds if last_page_duration_seconds > 0 else elapsed_seconds
 
     demisto.debug(
@@ -163,19 +175,19 @@ def fmt_date(ts):
         return "None"
     # Convert timestamp (seconds since epoch) to readable UTC
     try:
-        return datetime.utcfromtimestamp(int(ts)).strftime("%Y-%m-%d %H:%M:%S UTC")
+        return datetime.fromtimestamp(int(ts), tz=UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
     except Exception:
         return str(ts)
 
 
 def epoch_to_iso(ts):
     try:
-        return datetime.utcfromtimestamp(int(ts)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        return datetime.fromtimestamp(int(ts), tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
     except Exception:
         return None
 
 
-# Cyble Vision returns types like IPv4 / FileHash-MD5; XSOAR TIM expects FeedIndicatorType values (IP / File).
+# Cyble Vision returns types like IPv4 / FileHash-MD5; Cortex TIM expects FeedIndicatorType values (IP / File).
 CYBLE_IOC_TYPE_MAP = {
     "ip": FeedIndicatorType.IP,
     "ipv4": FeedIndicatorType.IP,
@@ -210,7 +222,7 @@ CYBLE_IOC_TYPE_MAP = {
 
 def map_cyble_ioc_type(raw_type: Any, value: Any = None) -> str | None:
     """
-    Map a Cyble ioc_type to an XSOAR FeedIndicatorType string.
+    Map a Cyble ioc_type to a Cortex FeedIndicatorType string.
     Returns None when the type cannot be mapped (caller should skip the IOC).
     """
     if raw_type is not None:
@@ -218,7 +230,7 @@ def map_cyble_ioc_type(raw_type: Any, value: Any = None) -> str | None:
         mapped = CYBLE_IOC_TYPE_MAP.get(normalized)
         if mapped:
             return mapped
-        # Already a valid XSOAR type (e.g. "IP", "Domain")
+        # Already a valid Cortex type (e.g. "IP", "Domain")
         if FeedIndicatorType.is_valid_type(str(raw_type).strip()):
             return str(raw_type).strip()
 
@@ -231,7 +243,7 @@ def map_cyble_ioc_type(raw_type: Any, value: Any = None) -> str | None:
 
 
 def build_indicator_from_ioc(ioc: dict) -> dict | None:
-    """Build an XSOAR indicator dict from a Cyble IOC row, or None if it must be skipped."""
+    """Build a Cortex indicator dict from a Cyble IOC row, or None if it must be skipped."""
     value = ioc.get("ioc")
     if value is None or str(value).strip() == "":
         return None
@@ -341,24 +353,31 @@ def fetch_indicators_command(client: Client, params: dict) -> int:
     Inserts each page immediately, saves last_run after each successful page, and exits
     gracefully before the Docker execution timeout when the remaining budget is low.
 
-    Also respects the per-fetch indicator cap (default 100). Non-TIM XSOAR licenses reject
+    Also respects the per-fetch indicator cap (default 100). Non-TIM Cortex licenses reject
     any createIndicators calls after the first 100 of a run; we must stop and checkpoint
     instead of advancing pages that were not actually ingested.
     """
-    first_fetch_hours = int(params.get("initial_interval", 2))
+    # Match YAML defaultvalue for initial_interval (1 hour).
+    first_fetch_hours = arg_to_number(params.get("initial_interval")) or 1
 
     if first_fetch_hours < 1:
         first_fetch_hours = 1
     if first_fetch_hours > 3:
         first_fetch_hours = 3
 
-    limit = min(int(params.get("limit", MAX_API_PAGE_LIMIT)), MAX_API_PAGE_LIMIT)
     try:
-        max_per_fetch = int(params.get("max_indicators_per_fetch") or DEFAULT_MAX_INDICATORS_PER_FETCH)
+        max_per_fetch = arg_to_number(params.get("max_indicators_per_fetch")) or DEFAULT_MAX_INDICATORS_PER_FETCH
     except (TypeError, ValueError):
         max_per_fetch = DEFAULT_MAX_INDICATORS_PER_FETCH
     if max_per_fetch < 1:
         max_per_fetch = DEFAULT_MAX_INDICATORS_PER_FETCH
+
+    # Bound page size by API cap and per-fetch cap to prevent unbounded pagination loops.
+    limit = min(
+        arg_to_number(params.get("limit")) or MAX_API_PAGE_LIMIT,
+        MAX_API_PAGE_LIMIT,
+        max_per_fetch,
+    )
 
     should_reset = demisto.args().get("recreate")
     if should_reset:
@@ -370,17 +389,21 @@ def fetch_indicators_command(client: Client, params: dict) -> int:
     gte_str, final_lte_str = get_time_range(first_fetch_hours, last_run)
     gte = datetime.fromisoformat(gte_str)
     final_lte = datetime.fromisoformat(final_lte_str)
+    if gte.tzinfo is None:
+        gte = gte.replace(tzinfo=UTC)
+    if final_lte.tzinfo is None:
+        final_lte = final_lte.replace(tzinfo=UTC)
 
     resume_page, resume_chunk_lte = parse_resume_state(last_run)
-    execution_start = datetime.utcnow()
+    execution_start = get_current_utc_time()
     last_page_duration_seconds = 0.0
     pages_completed = 0
     total_inserted = 0
 
     demisto.debug(
-        f"[fetch] initial gte={gte.isoformat()}Z final_lte={final_lte.isoformat()}Z "
+        f"[fetch] initial gte={gte.isoformat()} final_lte={final_lte.isoformat()} "
         f"resume_page={resume_page} timeout_budget={get_execution_timeout_seconds()}s "
-        f"max_per_fetch={max_per_fetch}"
+        f"max_per_fetch={max_per_fetch} limit={limit}"
     )
 
     while gte < final_lte:
@@ -388,6 +411,8 @@ def fetch_indicators_command(client: Client, params: dict) -> int:
         if resume_chunk_lte:
             try:
                 parsed_chunk_lte = datetime.fromisoformat(resume_chunk_lte)
+                if parsed_chunk_lte.tzinfo is None:
+                    parsed_chunk_lte = parsed_chunk_lte.replace(tzinfo=UTC)
                 if gte <= parsed_chunk_lte <= final_lte:
                     chunk_lte_dt = parsed_chunk_lte
             except ValueError:
@@ -406,7 +431,7 @@ def fetch_indicators_command(client: Client, params: dict) -> int:
                 demisto.debug(
                     f"[fetch] Reached per-fetch indicator cap ({max_per_fetch}). "
                     f"Exiting cleanly; next run resumes at page {page}. "
-                    f"(Non-TIM XSOAR licenses ingest at most 100 indicators per fetch.)"
+                    f"(Non-TIM Cortex licenses ingest at most 100 indicators per fetch.)"
                 )
                 return total_inserted
 
@@ -416,23 +441,17 @@ def fetch_indicators_command(client: Client, params: dict) -> int:
 
             demisto.debug(f"[fetch] Requesting page {page} for chunk {chunk_gte_iso} → {chunk_lte_iso}")
             page_start = time.time()
-            response = None
 
-            for attempt in range(FETCH_RETRY_ATTEMPTS):
-                try:
-                    resp = client.fetch_iocs(start_dt=chunk_gte_iso, end_dt=chunk_lte_iso, page=page, limit=limit)
-                    if isinstance(resp, dict) and resp.get("success", True):
-                        response = resp
-                        break
+            try:
+                resp = client.fetch_iocs(start_dt=chunk_gte_iso, end_dt=chunk_lte_iso, page=page, limit=limit)
+                if not (isinstance(resp, dict) and resp.get("success", True)):
                     raise ValueError(f"Non-success API response: {resp}")
-                except Exception as e:
-                    demisto.debug(f"[fetch] Attempt {attempt + 1}/{FETCH_RETRY_ATTEMPTS} failed: {e}")
-                    if attempt + 1 == FETCH_RETRY_ATTEMPTS:
-                        demisto.debug("[fetch] Max retries reached; preserving checkpoint and exiting.")
-                        if pages_completed > 0:
-                            save_fetch_checkpoint(chunk_gte_iso, page, chunk_lte_iso)
-                        return total_inserted
-                    time.sleep(FETCH_RETRY_SLEEP_SECONDS)
+                response = resp
+            except Exception as e:
+                demisto.error(f"[fetch] Request failed for page {page} after retries: {e}\n{traceback.format_exc()}")
+                if pages_completed > 0:
+                    save_fetch_checkpoint(chunk_gte_iso, page, chunk_lte_iso)
+                return total_inserted
 
             data = response.get("data", {}) if isinstance(response, dict) else {}
             ioc_list = data.get("iocs", []) if isinstance(data, dict) else []
@@ -441,7 +460,7 @@ def fetch_indicators_command(client: Client, params: dict) -> int:
                 demisto.debug(f"[fetch] No IOCs returned for page {page}; chunk finished.")
                 break
 
-            page_indicators = []
+            page_indicators: list[dict] = []
             skipped = 0
             for i in ioc_list:
                 indicator = build_indicator_from_ioc(i)
@@ -451,10 +470,7 @@ def fetch_indicators_command(client: Client, params: dict) -> int:
                     skipped += 1
 
             if skipped:
-                demisto.debug(
-                    f"[fetch] Page {page}: skipped {skipped}/{len(ioc_list)} IOCs "
-                    f"(empty value or unmapped ioc_type)"
-                )
+                demisto.debug(f"[fetch] Page {page}: skipped {skipped}/{len(ioc_list)} IOCs (empty value or unmapped ioc_type)")
 
             remaining_quota = max_per_fetch - total_inserted
             if remaining_quota <= 0:
@@ -491,7 +507,7 @@ def fetch_indicators_command(client: Client, params: dict) -> int:
                     + (f", skipped {skipped}." if skipped else ".")
                 )
             except Exception as e:
-                demisto.error(f"[fetch] Failed to createIndicators for page {page}: {e}")
+                demisto.error(f"[fetch] Failed to createIndicators for page {page}: {e}\n{traceback.format_exc()}")
                 save_fetch_checkpoint(chunk_gte_iso, page, chunk_lte_iso)
                 return total_inserted
 
@@ -500,18 +516,6 @@ def fetch_indicators_command(client: Client, params: dict) -> int:
             last_page_duration_seconds = max(last_page_duration_seconds, time.time() - page_start)
             page += 1
             save_fetch_checkpoint(chunk_gte_iso, page, chunk_lte_iso)
-
-            if total_inserted >= max_per_fetch:
-                demisto.debug(
-                    f"[fetch] Reached per-fetch indicator cap ({max_per_fetch}). "
-                    f"Exiting cleanly; next run resumes at page {page}. "
-                    f"(Non-TIM XSOAR licenses ingest at most 100 indicators per fetch.)"
-                )
-                return total_inserted
-
-            if should_stop_before_next_page(pages_completed, last_page_duration_seconds, execution_start):
-                demisto.debug("[fetch] Page budget exhausted; exiting cleanly to commit checkpoint.")
-                return total_inserted
 
         save_chunk_completed_checkpoint(chunk_lte_iso)
         gte = chunk_lte_dt
@@ -526,7 +530,7 @@ def fetch_indicators_command(client: Client, params: dict) -> int:
 def cyble_ioc_lookup_command(client: Client, args: dict):
     ioc = args.get("ioc")
     if not ioc:
-        return_error("Missing required argument: ioc")
+        raise ValueError("Missing required argument: ioc")
     ioc_value: str = str(ioc)
     demisto.debug(f"Running IOC lookup command for IOC: {ioc}")
     response = client.ioc_lookup(ioc_value)
@@ -579,15 +583,12 @@ def main():  # pragma: no cover
         client = Client(params)
 
         if command == "test-module":
-            try:
-                now = datetime.utcnow()
-                start_dt = (now - timedelta(days=1)).strftime(DATETIME_FORMAT)
-                end_dt = now.strftime(DATETIME_FORMAT)
+            now = get_current_utc_time()
+            start_dt = (now - timedelta(days=1)).strftime(DATETIME_FORMAT)
+            end_dt = now.strftime(DATETIME_FORMAT)
 
-                client.fetch_iocs(start_dt=start_dt, end_dt=end_dt, limit=1, page=1)
-                return_results("ok")
-            except Exception as e:
-                return_error(f"Test failed: {e}")
+            client.fetch_iocs(start_dt=start_dt, end_dt=end_dt, limit=1, page=1)
+            return_results("ok")
 
         elif command == "cyble-vision-ioc-lookup":
             return_results(cyble_ioc_lookup_command(client, args))
@@ -600,7 +601,7 @@ def main():  # pragma: no cover
             return_results(f"The command '{command}' is deprecated and no longer supported.")
 
     except Exception as e:
-        return_error(f"Failed to execute {demisto.command()} command. Error: {str(e)}")
+        return_error(f"Failed to execute {demisto.command()} command. Error: {str(e)}\n{traceback.format_exc()}")
 
 
 if __name__ in ("__main__", "__builtin__", "builtins"):

--- a/Packs/CybleThreatIntel/Integrations/CybleThreatIntel/CybleThreatIntel.py
+++ b/Packs/CybleThreatIntel/Integrations/CybleThreatIntel/CybleThreatIntel.py
@@ -14,6 +14,18 @@ urllib3.disable_warnings()
 
 """ CONSTANTS """
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S+00:00"  # Your API format
+MAX_API_PAGE_LIMIT = 100
+CHUNK_MINUTES = 15
+# Non-TIM XSOAR licenses hard-cap ingestion at 100 indicators per fetch-indicators run.
+# Calling createIndicators again after that logs success in our code but the platform ingests 0
+# and advancing the page checkpoint would permanently skip those IOCs.
+DEFAULT_MAX_INDICATORS_PER_FETCH = 100
+# Stop before the Docker execution limit so setLastRun commits on a normal return.
+# 60s covers a slow API round-trip, createIndicators, setLastRun, and script teardown.
+TIME_TO_RUN_BUFFER_SECONDS = 60
+DEFAULT_EXECUTION_TIMEOUT_SECONDS = 3 * 60
+FETCH_RETRY_ATTEMPTS = 5
+FETCH_RETRY_SLEEP_SECONDS = 1
 
 
 class Client:
@@ -82,6 +94,70 @@ def get_time_range(hours_back: int, last_run: dict) -> Tuple[str, str]:
     return gte_dt.isoformat(), lte_dt.isoformat()
 
 
+def get_execution_timeout_seconds() -> float:
+    """Return the Docker execution budget in seconds from the platform, or the default."""
+    timeout_nanoseconds = demisto.callingContext.get("context", {}).get("TimeoutDuration")
+    if timeout_nanoseconds:
+        return timeout_nanoseconds / 1_000_000_000
+    return float(DEFAULT_EXECUTION_TIMEOUT_SECONDS)
+
+
+def should_stop_before_next_page(
+    pages_completed: int, last_page_duration_seconds: float, execution_start: datetime
+) -> bool:
+    """
+    Akamai-style guard: always allow the first page, then stop if there is not enough
+    budget left to safely complete another page plus TIME_TO_RUN_BUFFER_SECONDS.
+    """
+    if pages_completed <= 0:
+        return False
+
+    elapsed_seconds = (datetime.utcnow() - execution_start).total_seconds()
+    remaining_seconds = get_execution_timeout_seconds() - elapsed_seconds - TIME_TO_RUN_BUFFER_SECONDS
+    estimated_next_page_seconds = last_page_duration_seconds if last_page_duration_seconds > 0 else elapsed_seconds
+
+    demisto.debug(
+        f"[fetch] timeout check: elapsed={elapsed_seconds:.1f}s, remaining={remaining_seconds:.1f}s, "
+        f"estimated_next_page={estimated_next_page_seconds:.1f}s"
+    )
+    return remaining_seconds <= estimated_next_page_seconds
+
+
+def save_fetch_checkpoint(chunk_gte_iso: str, next_page: int, chunk_lte_iso: str) -> None:
+    """Persist in-progress chunk pagination. All values must be strings for setLastRun."""
+    demisto.setLastRun(
+        {
+            "last_fetch": chunk_gte_iso,
+            "page": str(next_page),
+            "chunk_lte": chunk_lte_iso,
+        }
+    )
+    demisto.debug(f"[fetch] Checkpoint saved: last_fetch={chunk_gte_iso}, page={next_page}, chunk_lte={chunk_lte_iso}")
+
+
+def save_chunk_completed_checkpoint(chunk_lte_iso: str) -> None:
+    """Chunk finished; advance the time cursor and clear pagination state."""
+    demisto.setLastRun({"last_fetch": chunk_lte_iso})
+    demisto.debug(f"[fetch] Chunk completed, last_fetch advanced to {chunk_lte_iso}")
+
+
+def parse_resume_state(last_run: dict) -> tuple[int, str | None]:
+    """Return the page and chunk end to resume from, if present."""
+    raw_page = last_run.get("page")
+    if raw_page is None:
+        return 1, None
+
+    try:
+        resume_page = int(raw_page)
+    except (TypeError, ValueError):
+        return 1, None
+
+    if resume_page <= 1:
+        return 1, None
+
+    return resume_page, last_run.get("chunk_lte")
+
+
 def fmt_date(ts):
     if not ts:
         return "None"
@@ -97,6 +173,93 @@ def epoch_to_iso(ts):
         return datetime.utcfromtimestamp(int(ts)).strftime("%Y-%m-%dT%H:%M:%SZ")
     except Exception:
         return None
+
+
+# Cyble Vision returns types like IPv4 / FileHash-MD5; XSOAR TIM expects FeedIndicatorType values (IP / File).
+CYBLE_IOC_TYPE_MAP = {
+    "ip": FeedIndicatorType.IP,
+    "ipv4": FeedIndicatorType.IP,
+    "ipv6": FeedIndicatorType.IPv6,
+    "cidr": FeedIndicatorType.CIDR,
+    "ipv6cidr": FeedIndicatorType.IPv6CIDR,
+    "domain": FeedIndicatorType.Domain,
+    "hostname": FeedIndicatorType.Domain,
+    "fqdn": FeedIndicatorType.Domain,
+    "url": FeedIndicatorType.URL,
+    "uri": FeedIndicatorType.URL,
+    "email": FeedIndicatorType.Email,
+    "cve": FeedIndicatorType.CVE,
+    "md5": FeedIndicatorType.File,
+    "sha1": FeedIndicatorType.File,
+    "sha256": FeedIndicatorType.File,
+    "sha512": FeedIndicatorType.File,
+    "hash": FeedIndicatorType.File,
+    "file": FeedIndicatorType.File,
+    "filehash-md5": FeedIndicatorType.File,
+    "filehash-sha1": FeedIndicatorType.File,
+    "filehash-sha256": FeedIndicatorType.File,
+    "filehash-sha512": FeedIndicatorType.File,
+    "filehash-imphash": FeedIndicatorType.File,
+    "filehash-pehash": FeedIndicatorType.File,
+    "ssdeep": FeedIndicatorType.SSDeep,
+    "mutex": FeedIndicatorType.MUTEX,
+    "asn": FeedIndicatorType.AS,
+    "as": FeedIndicatorType.AS,
+}
+
+
+def map_cyble_ioc_type(raw_type: Any, value: Any = None) -> str | None:
+    """
+    Map a Cyble ioc_type to an XSOAR FeedIndicatorType string.
+    Returns None when the type cannot be mapped (caller should skip the IOC).
+    """
+    if raw_type is not None:
+        normalized = str(raw_type).strip().lower().replace("_", "-").replace(" ", "")
+        mapped = CYBLE_IOC_TYPE_MAP.get(normalized)
+        if mapped:
+            return mapped
+        # Already a valid XSOAR type (e.g. "IP", "Domain")
+        if FeedIndicatorType.is_valid_type(str(raw_type).strip()):
+            return str(raw_type).strip()
+
+    if value:
+        detected = FeedIndicatorType.ip_to_indicator_type(str(value).strip())
+        if detected:
+            return detected
+
+    return None
+
+
+def build_indicator_from_ioc(ioc: dict) -> dict | None:
+    """Build an XSOAR indicator dict from a Cyble IOC row, or None if it must be skipped."""
+    value = ioc.get("ioc")
+    if value is None or str(value).strip() == "":
+        return None
+
+    indicator_type = map_cyble_ioc_type(ioc.get("ioc_type"), value)
+    if not indicator_type:
+        return None
+
+    verdict = calculate_verdict(ioc.get("risk_score"), ioc.get("confidence_rating"))
+    return {
+        "value": str(value).strip(),
+        "type": indicator_type,
+        "rawJSON": ioc,
+        "fields": {
+            "confidence": ioc.get("confidence_rating"),
+            "cybleverdict": verdict,
+            "cybleriskscore": ioc.get("risk_score"),
+            "cyblefirstseen": epoch_to_iso(ioc.get("first_seen")),
+            "cyblelastseen": epoch_to_iso(ioc.get("last_seen")),
+            "cyblebehaviourtags": ioc.get("behaviour_tags") or [],
+            "cyblesources": ioc.get("sources") or [],
+            "cybletargetcountries": ioc.get("target_countries") or [],
+            "cybletargetregions": ioc.get("target_regions") or [],
+            "cybletargetindustries": ioc.get("target_industries") or [],
+            "cyblerelatedmalware": ioc.get("related_malware") or [],
+            "cyblerelatedthreatactors": ioc.get("related_threat_actors") or [],
+        },
+    }
 
 
 class VerdictEnum(str, Enum):
@@ -174,20 +337,29 @@ def calculate_verdict(risk_score: float | None, confidence_rating: str | None):
 # =====================================================
 def fetch_indicators_command(client: Client, params: dict) -> int:
     """
-    Fetch indicators in 1-hour chunks, insert per page immediately,
-    use retry for HTTP errors, enforce max 24-hour first_fetch.
+    Fetch indicators in bounded 15-minute chunks with page-level checkpointing.
+    Inserts each page immediately, saves last_run after each successful page, and exits
+    gracefully before the Docker execution timeout when the remaining budget is low.
+
+    Also respects the per-fetch indicator cap (default 100). Non-TIM XSOAR licenses reject
+    any createIndicators calls after the first 100 of a run; we must stop and checkpoint
+    instead of advancing pages that were not actually ingested.
     """
-    # --- first_fetch (hours) validation ---
-    first_fetch_hours = int(params.get("initial_interval", 2))  # default 6 hrs
+    first_fetch_hours = int(params.get("initial_interval", 2))
 
     if first_fetch_hours < 1:
         first_fetch_hours = 1
     if first_fetch_hours > 3:
         first_fetch_hours = 3
 
-    limit = int(params.get("limit", 100))
+    limit = min(int(params.get("limit", MAX_API_PAGE_LIMIT)), MAX_API_PAGE_LIMIT)
+    try:
+        max_per_fetch = int(params.get("max_indicators_per_fetch") or DEFAULT_MAX_INDICATORS_PER_FETCH)
+    except (TypeError, ValueError):
+        max_per_fetch = DEFAULT_MAX_INDICATORS_PER_FETCH
+    if max_per_fetch < 1:
+        max_per_fetch = DEFAULT_MAX_INDICATORS_PER_FETCH
 
-    # honor "recreate"
     should_reset = demisto.args().get("recreate")
     if should_reset:
         demisto.debug("Re-fetch triggered → resetting last_run")
@@ -195,116 +367,153 @@ def fetch_indicators_command(client: Client, params: dict) -> int:
     else:
         last_run = demisto.getLastRun() or {}
 
-    # --- compute initial range ---
     gte_str, final_lte_str = get_time_range(first_fetch_hours, last_run)
     gte = datetime.fromisoformat(gte_str)
     final_lte = datetime.fromisoformat(final_lte_str)
 
-    demisto.debug(f"[fetch] initial gte={gte.isoformat()}Z final_lte={final_lte.isoformat()}Z")
-
-    chunk_hours = 1
+    resume_page, resume_chunk_lte = parse_resume_state(last_run)
+    execution_start = datetime.utcnow()
+    last_page_duration_seconds = 0.0
+    pages_completed = 0
     total_inserted = 0
 
-    # -------------------------
-    # Fetch loop per chunk
-    # -------------------------
+    demisto.debug(
+        f"[fetch] initial gte={gte.isoformat()}Z final_lte={final_lte.isoformat()}Z "
+        f"resume_page={resume_page} timeout_budget={get_execution_timeout_seconds()}s "
+        f"max_per_fetch={max_per_fetch}"
+    )
+
     while gte < final_lte:
-        chunk_lte_dt = min(gte + timedelta(hours=chunk_hours), final_lte)
+        chunk_lte_dt = min(gte + timedelta(minutes=CHUNK_MINUTES), final_lte)
+        if resume_chunk_lte:
+            try:
+                parsed_chunk_lte = datetime.fromisoformat(resume_chunk_lte)
+                if gte <= parsed_chunk_lte <= final_lte:
+                    chunk_lte_dt = parsed_chunk_lte
+            except ValueError:
+                demisto.debug(f"[fetch] Ignoring invalid resume chunk_lte: {resume_chunk_lte}")
+            resume_chunk_lte = None
+
         chunk_gte_iso = gte.isoformat()
         chunk_lte_iso = chunk_lte_dt.isoformat()
+        page = resume_page
+        resume_page = 1
 
-        demisto.debug(f"[fetch] Processing chunk: {chunk_gte_iso} → {chunk_lte_iso}")
-
-        page = 1
+        demisto.debug(f"[fetch] Processing chunk: {chunk_gte_iso} → {chunk_lte_iso}, starting at page {page}")
 
         while True:
-            demisto.debug(f"[fetch] Requesting page {page} for chunk {chunk_gte_iso} → {chunk_lte_iso}")
+            if total_inserted >= max_per_fetch:
+                demisto.debug(
+                    f"[fetch] Reached per-fetch indicator cap ({max_per_fetch}). "
+                    f"Exiting cleanly; next run resumes at page {page}. "
+                    f"(Non-TIM XSOAR licenses ingest at most 100 indicators per fetch.)"
+                )
+                return total_inserted
 
-            # -------------------------
-            # Retry mechanism (max 5 tries)
-            # -------------------------
-            retry_count = 0
+            if should_stop_before_next_page(pages_completed, last_page_duration_seconds, execution_start):
+                demisto.debug("[fetch] Approaching Docker timeout; exiting after last successful page.")
+                return total_inserted
+
+            demisto.debug(f"[fetch] Requesting page {page} for chunk {chunk_gte_iso} → {chunk_lte_iso}")
+            page_start = time.time()
             response = None
 
-            while retry_count < 5:
+            for attempt in range(FETCH_RETRY_ATTEMPTS):
                 try:
                     resp = client.fetch_iocs(start_dt=chunk_gte_iso, end_dt=chunk_lte_iso, page=page, limit=limit)
-
-                    # enforce dict & 200
                     if isinstance(resp, dict) and resp.get("success", True):
                         response = resp
                         break
-
                     raise ValueError(f"Non-success API response: {resp}")
-
                 except Exception as e:
-                    retry_count += 1
-                    demisto.debug(f"[fetch] Attempt {retry_count}/5 failed: {e}")
+                    demisto.debug(f"[fetch] Attempt {attempt + 1}/{FETCH_RETRY_ATTEMPTS} failed: {e}")
+                    if attempt + 1 == FETCH_RETRY_ATTEMPTS:
+                        demisto.debug("[fetch] Max retries reached; preserving checkpoint and exiting.")
+                        if pages_completed > 0:
+                            save_fetch_checkpoint(chunk_gte_iso, page, chunk_lte_iso)
+                        return total_inserted
+                    time.sleep(FETCH_RETRY_SLEEP_SECONDS)
 
-                    if retry_count == 5:
-                        demisto.debug("[fetch] Max retries reached → skipping this page.")
-                        response = None
-                    else:
-                        time.sleep(1)
-
-            if not response:
-                break
-
-            # Parse IOCs safely
             data = response.get("data", {}) if isinstance(response, dict) else {}
             ioc_list = data.get("iocs", []) if isinstance(data, dict) else []
 
             if not ioc_list:
-                demisto.debug(f"[fetch] No IOCs returned for page {page} (chunk finished).")
+                demisto.debug(f"[fetch] No IOCs returned for page {page}; chunk finished.")
                 break
 
-            # -------------------------
-            # Build indicators
-            # -------------------------
             page_indicators = []
+            skipped = 0
             for i in ioc_list:
-                verdict = calculate_verdict(i.get("risk_score"), i.get("confidence_rating"))
+                indicator = build_indicator_from_ioc(i)
+                if indicator:
+                    page_indicators.append(indicator)
+                else:
+                    skipped += 1
 
-                page_indicators.append(
-                    {
-                        "value": i.get("ioc"),
-                        "type": i.get("ioc_type") or "Unknown",
-                        "rawJSON": i,
-                        "fields": {
-                            # confidence auto-managed by XSOAR
-                            "confidence": i.get("confidence_rating"),
-                            "cybleverdict": verdict,
-                            "cybleriskscore": i.get("risk_score"),
-                            "cyblefirstseen": epoch_to_iso(i.get("first_seen")),
-                            "cyblelastseen": epoch_to_iso(i.get("last_seen")),
-                            "cyblebehaviourtags": i.get("behaviour_tags") or [],
-                            "cyblesources": i.get("sources") or [],
-                            "cybletargetcountries": i.get("target_countries") or [],
-                            "cybletargetregions": i.get("target_regions") or [],
-                            "cybletargetindustries": i.get("target_industries") or [],
-                            "cyblerelatedmalware": i.get("related_malware") or [],
-                            "cyblerelatedthreatactors": i.get("related_threat_actors") or [],
-                        },
-                    }
+            if skipped:
+                demisto.debug(
+                    f"[fetch] Page {page}: skipped {skipped}/{len(ioc_list)} IOCs "
+                    f"(empty value or unmapped ioc_type)"
                 )
 
-            # Insert indicators
+            remaining_quota = max_per_fetch - total_inserted
+            if remaining_quota <= 0:
+                demisto.debug(
+                    f"[fetch] Per-fetch cap already reached before submitting page {page}; "
+                    f"not calling createIndicators. Resume page stays {page}."
+                )
+                return total_inserted
+
+            if len(page_indicators) > remaining_quota:
+                # Avoid partial-page checkpointing: submit only what fits, then resume same page
+                # would re-send duplicates. Prefer stopping before this page if it cannot fit fully.
+                demisto.debug(
+                    f"[fetch] Page {page} has {len(page_indicators)} indicators but only "
+                    f"{remaining_quota} remain in this fetch's quota. Exiting without advancing "
+                    f"so the full page can be ingested on the next run."
+                )
+                save_fetch_checkpoint(chunk_gte_iso, page, chunk_lte_iso)
+                return total_inserted
+
+            if not page_indicators:
+                # API returned rows we cannot store; advance so we do not loop forever on this page.
+                demisto.debug(f"[fetch] Page {page}: no mappable indicators; advancing pagination.")
+                pages_completed += 1
+                last_page_duration_seconds = max(last_page_duration_seconds, time.time() - page_start)
+                page += 1
+                save_fetch_checkpoint(chunk_gte_iso, page, chunk_lte_iso)
+                continue
+
             try:
                 demisto.createIndicators(page_indicators)
-                demisto.debug(f"[fetch] Inserted {len(page_indicators)} indicators (page {page}).")
+                demisto.debug(
+                    f"[fetch] Inserted {len(page_indicators)} indicators (page {page})"
+                    + (f", skipped {skipped}." if skipped else ".")
+                )
             except Exception as e:
-                demisto.debug(f"[fetch] Failed to createIndicators for page {page}: {e}")
-                # decide: continue to next page or break. We'll continue.
+                demisto.error(f"[fetch] Failed to createIndicators for page {page}: {e}")
+                save_fetch_checkpoint(chunk_gte_iso, page, chunk_lte_iso)
+                return total_inserted
+
             total_inserted += len(page_indicators)
+            pages_completed += 1
+            last_page_duration_seconds = max(last_page_duration_seconds, time.time() - page_start)
             page += 1
+            save_fetch_checkpoint(chunk_gte_iso, page, chunk_lte_iso)
 
-        # save last_run per chunk
-        try:
-            demisto.setLastRun({"last_fetch": chunk_lte_iso})
-            demisto.debug(f"[fetch] Updated last_run → {chunk_lte_iso}")
-        except Exception as e:
-            demisto.debug(f"[fetch] Failed to setLastRun: {e}")
+            if total_inserted >= max_per_fetch:
+                demisto.debug(
+                    f"[fetch] Reached per-fetch indicator cap ({max_per_fetch}). "
+                    f"Exiting cleanly; next run resumes at page {page}. "
+                    f"(Non-TIM XSOAR licenses ingest at most 100 indicators per fetch.)"
+                )
+                return total_inserted
 
+            if should_stop_before_next_page(pages_completed, last_page_duration_seconds, execution_start):
+                demisto.debug("[fetch] Page budget exhausted; exiting cleanly to commit checkpoint.")
+                return total_inserted
+
+        save_chunk_completed_checkpoint(chunk_lte_iso)
         gte = chunk_lte_dt
 
     demisto.debug(f"[fetch] Completed. total_inserted={total_inserted}")

--- a/Packs/CybleThreatIntel/Integrations/CybleThreatIntel/CybleThreatIntel.yml
+++ b/Packs/CybleThreatIntel/Integrations/CybleThreatIntel/CybleThreatIntel.yml
@@ -135,7 +135,14 @@ configuration:
     type: 0
     defaultvalue: '100'
     section: Collect
-    additionalinfo: Maximum number of indicators to fetch per execution.
+    additionalinfo: Maximum indicators per API page (API cap is 100).
+    hidden: true
+  - display: Max indicators per fetch run
+    name: max_indicators_per_fetch
+    type: 0
+    defaultvalue: '100'
+    section: Collect
+    additionalinfo: Hard cap of indicators submitted per fetch-indicators run. Non-TIM XSOAR licenses ingest at most 100 per fetch; leave at 100 unless you have a TIM license that allows more. Raising this on a non-TIM tenant causes skipped IOCs.
     hidden: true
 script:
   type: python

--- a/Packs/CybleThreatIntel/Integrations/CybleThreatIntel/CybleThreatIntel.yml
+++ b/Packs/CybleThreatIntel/Integrations/CybleThreatIntel/CybleThreatIntel.yml
@@ -127,7 +127,7 @@ configuration:
     type: 0
     defaultvalue: 1
     required: true
-    additionalinfo: How many hours back to fetch IOCs on first run. Max 3 hours.
+    additionalinfo: The number of hours back to fetch IOCs on first run. Maximum is 3 hours.
     section: Collect
     hidden: true
   - display: Indicator Fetch Limit
@@ -135,15 +135,17 @@ configuration:
     type: 0
     defaultvalue: '100'
     section: Collect
-    additionalinfo: Maximum indicators per API page (API cap is 100).
+    required: false
+    additionalinfo: The maximum number of indicators per API page (API cap is 100).
     hidden: true
   - display: Max indicators per fetch run
     name: max_indicators_per_fetch
     type: 0
     defaultvalue: '100'
     section: Collect
-    additionalinfo: Hard cap of indicators submitted per fetch-indicators run. Non-TIM XSOAR licenses ingest at most 100 per fetch; leave at 100 unless you have a TIM license that allows more. Raising this on a non-TIM tenant causes skipped IOCs.
-    hidden: true
+    required: false
+    additionalinfo: The hard cap of indicators submitted per fetch-indicators run. Non-TIM Cortex licenses ingest at most 100 per fetch; leave at 100 unless you have a TIM license that allows more. Raising this on a non-TIM tenant causes skipped IOCs.
+    hidden: false
 script:
   type: python
   subtype: python3
@@ -182,7 +184,7 @@ script:
         - contextPath: CybleIntel.collection.names
           description: Backward compatibility placeholder.
           type: String
-fromversion: 6.2.0
+fromversion: 6.8.0
 tests:
 - No tests (auto formatted)
 sectionorder:

--- a/Packs/CybleThreatIntel/Integrations/CybleThreatIntel/CybleThreatIntel_test.py
+++ b/Packs/CybleThreatIntel/Integrations/CybleThreatIntel/CybleThreatIntel_test.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, Mock
 from datetime import datetime, timedelta
 
 from CybleThreatIntel import (
@@ -18,40 +18,39 @@ from CybleThreatIntel import (
     save_chunk_completed_checkpoint,
     map_cyble_ioc_type,
     build_indicator_from_ioc,
-    TIME_TO_RUN_BUFFER_SECONDS,
+    get_current_utc_time,
     DEFAULT_EXECUTION_TIMEOUT_SECONDS,
 )
+
+
+def _make_client(params=None):
+    """Build a Client without performing real HTTP setup side effects beyond BaseClient init."""
+    return Client(params or {"base_url": "https://example.com", "credentials": {"password": "token"}})
 
 
 # -------------------------------------------------------------------
 #   HTTP POST – SUCCESS
 # -------------------------------------------------------------------
-@patch("CybleThreatIntel.requests.post")
-def test_http_post_success(mock_post):
-    resp = MagicMock()
-    resp.status_code = 200
-    resp.json.return_value = {"ok": True}
-    mock_post.return_value = resp
+def test_http_post_success():
+    client = _make_client()
+    client._http_request = MagicMock(return_value={"ok": True})
 
-    client = Client({"base_url": "https://example.com", "access_token": {"password": "a"}})
     r = client.http_post("/y/iocs", {"x": 1})
 
     assert r == {"ok": True}
-    mock_post.assert_called_once()
+    client._http_request.assert_called_once()
+    kwargs = client._http_request.call_args.kwargs
+    assert kwargs["method"] == "POST"
+    assert kwargs["url_suffix"] == "/y/iocs"
+    assert kwargs["retries"] == 5
 
 
 # -------------------------------------------------------------------
 #   HTTP POST – FAILURE
 # -------------------------------------------------------------------
-@patch("CybleThreatIntel.requests.post")
-def test_http_post_failure(mock_post):
-    resp = MagicMock()
-    resp.status_code = 500
-    resp.raise_for_status.side_effect = Exception("Server Error")
-    resp.text = "error"
-    mock_post.return_value = resp
-
-    client = Client({"base_url": "https://example.com", "access_token": {"password": "a"}})
+def test_http_post_failure():
+    client = _make_client()
+    client._http_request = MagicMock(side_effect=Exception("Server Error"))
 
     with pytest.raises(Exception):
         client.http_post("/y/iocs", {})
@@ -61,15 +60,15 @@ def test_http_post_failure(mock_post):
 #   DATE RANGE LOGIC
 # -------------------------------------------------------------------
 def test_get_time_range_without_last_run():
-    now = datetime.utcnow()
+    now = get_current_utc_time()
     gte, lte = get_time_range(5, {})
 
     g = datetime.fromisoformat(gte)
-    assert (now - g).seconds <= 5 * 3600 + 5  # small tolerance
+    assert (now - g).total_seconds() <= 5 * 3600 + 5  # small tolerance
 
 
 def test_get_time_range_with_last_run():
-    now = datetime.utcnow().isoformat()
+    now = get_current_utc_time().isoformat()
     gte, lte = get_time_range(6, {"last_fetch": now})
 
     assert gte == now
@@ -107,12 +106,11 @@ def test_calculate_verdict_values(risk, conf, expected):
 # -------------------------------------------------------------------
 #   IOC LOOKUP COMMAND – NO RESULTS
 # -------------------------------------------------------------------
-@patch("CybleThreatIntel.return_error")
 @patch("CybleThreatIntel.Client.ioc_lookup")
-def test_ioc_lookup_no_results(mock_lookup, mock_return):
+def test_ioc_lookup_no_results(mock_lookup):
     mock_lookup.return_value = {"data": {"iocs": []}}
 
-    c = Client({"base_url": "x", "access_token": {"password": "a"}})
+    c = _make_client({"base_url": "https://example.com", "credentials": {"password": "a"}})
     result = cyble_ioc_lookup_command(c, {"ioc": "1.1.1.1"})
 
     assert "No results found" in result.readable_output
@@ -121,21 +119,14 @@ def test_ioc_lookup_no_results(mock_lookup, mock_return):
 # -------------------------------------------------------------------
 #   IOC LOOKUP – WITH RESULTS
 # -------------------------------------------------------------------
-
-
 @patch("CybleThreatIntel.Client.ioc_lookup")
 def test_ioc_lookup_success(mock_lookup):
     mock_lookup.return_value = {"data": {"iocs": [{"ioc": "SAMPLE_IOC", "ioc_type": "custom", "first_seen": 1700000000}]}}
 
-    c = Client({"base_url": "x", "access_token": {"password": "a"}})
+    c = _make_client({"base_url": "https://example.com", "credentials": {"password": "a"}})
     result = cyble_ioc_lookup_command(c, {"ioc": "SAMPLE_IOC"})
 
     assert result.outputs["IOC"] == "SAMPLE_IOC"
-
-
-# -------------------------------------------------------------------
-#   FETCH INDICATORS – MAIN LOGIC
-# -------------------------------------------------------------------
 
 
 # -------------------------------------------------------------------
@@ -146,18 +137,14 @@ def test_fetch_indicators_retry_fail(mock_demisto):
     mock_demisto.args.return_value = {}
     mock_demisto.getLastRun.return_value = {}
 
-    client = Client({"base_url": "x", "access_token": {"password": "a"}})
-
+    client = _make_client({"base_url": "https://example.com", "credentials": {"password": "a"}})
     client.fetch_iocs = MagicMock(side_effect=Exception("fail"))
 
-    params = {"first_fetch": 1, "max_fetch": 50}
+    params = {"initial_interval": 1, "limit": 50}
 
     count = fetch_indicators_command(client, params)
 
     assert count == 0
-
-
-from unittest.mock import Mock
 
 
 def test_calculate_verdict_invalid_inputs():
@@ -166,16 +153,15 @@ def test_calculate_verdict_invalid_inputs():
     assert calculate_verdict(200, "high") == "Malicious"
 
 
-def test_ioc_lookup_missing_argument(mocker):
+def test_ioc_lookup_missing_argument():
     client = Mock()
-    mocker.patch("CybleThreatIntel.return_error", side_effect=Exception("Missing required argument: ioc"))
 
-    with pytest.raises(Exception) as e:
+    with pytest.raises(ValueError) as e:
         cyble_ioc_lookup_command(client, {})
     assert "Missing required argument: ioc" in str(e.value)
 
 
-def test_client_init_empty(mocker):
+def test_client_init_empty():
     params = {}
     client = Client(params)
     assert client.base_url == ""
@@ -183,18 +169,13 @@ def test_client_init_empty(mocker):
     assert client.headers["Authorization"] == "Bearer "
 
 
-def test_client_http_post_failure(mocker):
-    client = Client({"base_url": "http://test.com", "access_token": {"password": "token"}})
-    mock_resp = mocker.Mock()
-    mock_resp.status_code = 400
-    mock_resp.text = "Bad request"
-    mock_resp.raise_for_status.side_effect = Exception("HTTP error")
-    mocker.patch("requests.post", return_value=mock_resp)
+def test_client_http_post_failure():
+    client = _make_client({"base_url": "https://example.com", "credentials": {"password": "token"}})
+    client._http_request = MagicMock(side_effect=Exception("HTTP error"))
 
-    try:
+    with pytest.raises(Exception) as e:
         client.http_post("/endpoint", {"key": "value"})
-    except Exception as e:
-        assert "HTTP error" in str(e)
+    assert "HTTP error" in str(e.value)
 
 
 def test_epoch_to_iso_invalid():
@@ -206,10 +187,10 @@ def test_fmt_date_none_and_invalid():
     assert "invalid" in fmt_date("invalid")
 
 
-def test_client_init_edge_case(mocker):
-    # edge case: empty access_token dict and trailing slash in URL
-    client = Client({"base_url": "https://api.test.com/", "access_token": {"password": ""}})
-    assert client.base_url == "https://api.test.com"
+def test_client_init_edge_case():
+    # edge case: empty credentials password and trailing slash in URL
+    client = Client({"base_url": "https://api.example.com/", "credentials": {"password": ""}})
+    assert client.base_url == "https://api.example.com"
     assert client.access_token == ""
 
 
@@ -229,37 +210,36 @@ def test_calculate_verdict_edge_cases():
 def test_get_time_range_first_run_with_last_fetch():
     last_run = {"last_fetch": "2025-12-01T00:00:00"}
     gte, lte = get_time_range(5, last_run)
-    assert gte == "2025-12-01T00:00:00"
+    assert gte.startswith("2025-12-01T00:00:00")
 
 
-def test_get_execution_timeout_seconds_from_calling_context(mocker):
-    mocker.patch(
-        "CybleThreatIntel.demisto.callingContext",
-        {"context": {"TimeoutDuration": 900_000_000_000}},
-    )
-    assert get_execution_timeout_seconds() == 900.0
+def test_get_execution_timeout_seconds_from_calling_context():
+    with patch("CybleThreatIntel.demisto") as mock_demisto:
+        mock_demisto.callingContext = {"context": {"TimeoutDuration": 900_000_000_000}}
+        assert get_execution_timeout_seconds() == 900.0
 
 
-def test_get_execution_timeout_seconds_default(mocker):
-    mocker.patch("CybleThreatIntel.demisto.callingContext", {"context": {}})
-    assert get_execution_timeout_seconds() == float(DEFAULT_EXECUTION_TIMEOUT_SECONDS)
+def test_get_execution_timeout_seconds_default():
+    with patch("CybleThreatIntel.demisto") as mock_demisto:
+        mock_demisto.callingContext = {"context": {}}
+        assert get_execution_timeout_seconds() == float(DEFAULT_EXECUTION_TIMEOUT_SECONDS)
 
 
 def test_should_stop_before_next_page_first_page():
-    execution_start = datetime.utcnow()
+    execution_start = get_current_utc_time()
     assert should_stop_before_next_page(0, 0, execution_start) is False
 
 
-def test_should_stop_before_next_page_low_remaining_budget(mocker):
-    execution_start = datetime.utcnow() - timedelta(seconds=170)
-    mocker.patch("CybleThreatIntel.get_execution_timeout_seconds", return_value=180.0)
-    assert should_stop_before_next_page(1, 20.0, execution_start) is True
+def test_should_stop_before_next_page_low_remaining_budget():
+    execution_start = get_current_utc_time() - timedelta(seconds=170)
+    with patch("CybleThreatIntel.get_execution_timeout_seconds", return_value=180.0), patch("CybleThreatIntel.demisto"):
+        assert should_stop_before_next_page(1, 20.0, execution_start) is True
 
 
-def test_should_stop_before_next_page_enough_budget(mocker):
-    execution_start = datetime.utcnow() - timedelta(seconds=30)
-    mocker.patch("CybleThreatIntel.get_execution_timeout_seconds", return_value=900.0)
-    assert should_stop_before_next_page(1, 20.0, execution_start) is False
+def test_should_stop_before_next_page_enough_budget():
+    execution_start = get_current_utc_time() - timedelta(seconds=30)
+    with patch("CybleThreatIntel.get_execution_timeout_seconds", return_value=900.0), patch("CybleThreatIntel.demisto"):
+        assert should_stop_before_next_page(1, 20.0, execution_start) is False
 
 
 def test_parse_resume_state():
@@ -289,31 +269,27 @@ def test_save_chunk_completed_checkpoint(mock_set_last_run):
 @patch("CybleThreatIntel.demisto.createIndicators")
 @patch("CybleThreatIntel.demisto.setLastRun")
 @patch("CybleThreatIntel.demisto")
-def test_fetch_indicators_saves_checkpoint_per_page(mock_demisto, mock_set_last_run, mock_create_indicators, mocker):
+def test_fetch_indicators_saves_checkpoint_per_page(mock_demisto, mock_set_last_run, mock_create_indicators):
     mock_demisto.args.return_value = {}
     mock_demisto.getLastRun.return_value = {}
-    mocker.patch("CybleThreatIntel.get_execution_timeout_seconds", return_value=900.0)
 
-    client = Client({"base_url": "x", "credentials": {"password": "a"}})
-    client.fetch_iocs = MagicMock(
-        side_effect=[
-            {"success": True, "data": {"iocs": [{"ioc": "1.1.1.1", "ioc_type": "IPv4"}]}},
-            {"success": True, "data": {"iocs": []}},
-        ]
-    )
+    with patch("CybleThreatIntel.get_execution_timeout_seconds", return_value=900.0):
+        client = _make_client({"base_url": "https://example.com", "credentials": {"password": "a"}})
+        client.fetch_iocs = MagicMock(
+            side_effect=[
+                {"success": True, "data": {"iocs": [{"ioc": "1.1.1.1", "ioc_type": "IPv4"}]}},
+                {"success": True, "data": {"iocs": []}},
+            ]
+        )
 
-    count = fetch_indicators_command(client, {"initial_interval": 1, "limit": 100})
+        count = fetch_indicators_command(client, {"initial_interval": 1, "limit": 100})
 
     assert count == 1
     assert mock_create_indicators.call_count == 1
     submitted = mock_create_indicators.call_args[0][0]
     assert submitted[0]["type"] == "IP"
     assert submitted[0]["value"] == "1.1.1.1"
-    checkpoint_calls = [
-        call
-        for call in mock_set_last_run.call_args_list
-        if call.args[0].get("page") == "2"
-    ]
+    checkpoint_calls = [call for call in mock_set_last_run.call_args_list if call.args[0].get("page") == "2"]
     assert checkpoint_calls
     completed_calls = [call for call in mock_set_last_run.call_args_list if "page" not in call.args[0]]
     assert completed_calls
@@ -325,11 +301,11 @@ def test_fetch_indicators_saves_checkpoint_per_page(mock_demisto, mock_set_last_
         ("IPv4", "1.1.1.1", "IP"),
         ("ip", "1.1.1.1", "IP"),
         ("IPv6", "2001:db8::1", "IPv6"),
-        ("Domain", "evil.com", "Domain"),
-        ("URL", "https://evil.com", "URL"),
+        ("Domain", "example.com", "Domain"),
+        ("URL", "https://example.com", "URL"),
         ("FileHash-MD5", "d41d8cd98f00b204e9800998ecf8427e", "File"),
         ("FileHash-SHA256", "a" * 64, "File"),
-        ("Email", "a@b.com", "Email"),
+        ("Email", "user@example.com", "Email"),
         ("Wallet-Address", "0xabc", None),
         ("", "8.8.8.8", "IP"),  # fall back to value detection
     ],
@@ -341,27 +317,27 @@ def test_map_cyble_ioc_type(raw_type, value, expected):
 def test_build_indicator_from_ioc_skips_empty_and_unknown():
     assert build_indicator_from_ioc({"ioc": "", "ioc_type": "IPv4"}) is None
     assert build_indicator_from_ioc({"ioc": "x", "ioc_type": "Wallet-Address"}) is None
-    indicator = build_indicator_from_ioc({"ioc": "evil.com", "ioc_type": "Domain", "risk_score": 80})
+    indicator = build_indicator_from_ioc({"ioc": "example.com", "ioc_type": "Domain", "risk_score": 80})
     assert indicator is not None
     assert indicator["type"] == "Domain"
-    assert indicator["value"] == "evil.com"
+    assert indicator["value"] == "example.com"
 
 
 @patch("CybleThreatIntel.demisto.createIndicators")
 @patch("CybleThreatIntel.demisto.setLastRun")
 @patch("CybleThreatIntel.demisto")
-def test_fetch_indicators_exits_before_timeout(mock_demisto, mock_set_last_run, mock_create_indicators, mocker):
+def test_fetch_indicators_exits_before_timeout(mock_demisto, mock_set_last_run, mock_create_indicators):
     mock_demisto.args.return_value = {}
     mock_demisto.getLastRun.return_value = {}
-    mocker.patch("CybleThreatIntel.get_execution_timeout_seconds", return_value=180.0)
-    mocker.patch("CybleThreatIntel.should_stop_before_next_page", side_effect=[False, True])
 
-    client = Client({"base_url": "x", "credentials": {"password": "a"}})
-    client.fetch_iocs = MagicMock(
-        return_value={"success": True, "data": {"iocs": [{"ioc": "1.1.1.1", "ioc_type": "ip"}]}}
-    )
+    with (
+        patch("CybleThreatIntel.get_execution_timeout_seconds", return_value=180.0),
+        patch("CybleThreatIntel.should_stop_before_next_page", side_effect=[False, True]),
+    ):
+        client = _make_client({"base_url": "https://example.com", "credentials": {"password": "a"}})
+        client.fetch_iocs = MagicMock(return_value={"success": True, "data": {"iocs": [{"ioc": "1.1.1.1", "ioc_type": "ip"}]}})
 
-    count = fetch_indicators_command(client, {"initial_interval": 1, "limit": 100})
+        count = fetch_indicators_command(client, {"initial_interval": 1, "limit": 100})
 
     assert count == 1
     assert client.fetch_iocs.call_count == 1
@@ -371,23 +347,23 @@ def test_fetch_indicators_exits_before_timeout(mock_demisto, mock_set_last_run, 
 @patch("CybleThreatIntel.demisto.createIndicators")
 @patch("CybleThreatIntel.demisto.setLastRun")
 @patch("CybleThreatIntel.demisto")
-def test_fetch_stops_at_per_fetch_cap(mock_demisto, mock_set_last_run, mock_create_indicators, mocker):
+def test_fetch_stops_at_per_fetch_cap(mock_demisto, mock_set_last_run, mock_create_indicators):
     """Non-TIM: only one page of 100 should be submitted; page must not keep advancing."""
     mock_demisto.args.return_value = {}
     mock_demisto.getLastRun.return_value = {}
-    mocker.patch("CybleThreatIntel.get_execution_timeout_seconds", return_value=900.0)
-    mocker.patch("CybleThreatIntel.should_stop_before_next_page", return_value=False)
 
     page_payload = {
         "success": True,
         "data": {"iocs": [{"ioc": f"1.1.1.{i}", "ioc_type": "IPv4"} for i in range(100)]},
     }
-    client = Client({"base_url": "x", "credentials": {"password": "a"}})
-    client.fetch_iocs = MagicMock(return_value=page_payload)
+    with (
+        patch("CybleThreatIntel.get_execution_timeout_seconds", return_value=900.0),
+        patch("CybleThreatIntel.should_stop_before_next_page", return_value=False),
+    ):
+        client = _make_client({"base_url": "https://example.com", "credentials": {"password": "a"}})
+        client.fetch_iocs = MagicMock(return_value=page_payload)
 
-    count = fetch_indicators_command(
-        client, {"initial_interval": 1, "limit": 100, "max_indicators_per_fetch": 100}
-    )
+        count = fetch_indicators_command(client, {"initial_interval": 1, "limit": 100, "max_indicators_per_fetch": 100})
 
     assert count == 100
     assert mock_create_indicators.call_count == 1

--- a/Packs/CybleThreatIntel/Integrations/CybleThreatIntel/CybleThreatIntel_test.py
+++ b/Packs/CybleThreatIntel/Integrations/CybleThreatIntel/CybleThreatIntel_test.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import patch, MagicMock
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from CybleThreatIntel import (
     Client,
@@ -11,6 +11,15 @@ from CybleThreatIntel import (
     cyble_ioc_lookup_command,
     fetch_indicators_command,
     VerdictEnum,
+    get_execution_timeout_seconds,
+    should_stop_before_next_page,
+    parse_resume_state,
+    save_fetch_checkpoint,
+    save_chunk_completed_checkpoint,
+    map_cyble_ioc_type,
+    build_indicator_from_ioc,
+    TIME_TO_RUN_BUFFER_SECONDS,
+    DEFAULT_EXECUTION_TIMEOUT_SECONDS,
 )
 
 
@@ -221,3 +230,167 @@ def test_get_time_range_first_run_with_last_fetch():
     last_run = {"last_fetch": "2025-12-01T00:00:00"}
     gte, lte = get_time_range(5, last_run)
     assert gte == "2025-12-01T00:00:00"
+
+
+def test_get_execution_timeout_seconds_from_calling_context(mocker):
+    mocker.patch(
+        "CybleThreatIntel.demisto.callingContext",
+        {"context": {"TimeoutDuration": 900_000_000_000}},
+    )
+    assert get_execution_timeout_seconds() == 900.0
+
+
+def test_get_execution_timeout_seconds_default(mocker):
+    mocker.patch("CybleThreatIntel.demisto.callingContext", {"context": {}})
+    assert get_execution_timeout_seconds() == float(DEFAULT_EXECUTION_TIMEOUT_SECONDS)
+
+
+def test_should_stop_before_next_page_first_page():
+    execution_start = datetime.utcnow()
+    assert should_stop_before_next_page(0, 0, execution_start) is False
+
+
+def test_should_stop_before_next_page_low_remaining_budget(mocker):
+    execution_start = datetime.utcnow() - timedelta(seconds=170)
+    mocker.patch("CybleThreatIntel.get_execution_timeout_seconds", return_value=180.0)
+    assert should_stop_before_next_page(1, 20.0, execution_start) is True
+
+
+def test_should_stop_before_next_page_enough_budget(mocker):
+    execution_start = datetime.utcnow() - timedelta(seconds=30)
+    mocker.patch("CybleThreatIntel.get_execution_timeout_seconds", return_value=900.0)
+    assert should_stop_before_next_page(1, 20.0, execution_start) is False
+
+
+def test_parse_resume_state():
+    assert parse_resume_state({}) == (1, None)
+    assert parse_resume_state({"page": "1"}) == (1, None)
+    assert parse_resume_state({"page": "3", "chunk_lte": "2025-12-01T01:00:00"}) == (3, "2025-12-01T01:00:00")
+
+
+@patch("CybleThreatIntel.demisto.setLastRun")
+def test_save_fetch_checkpoint(mock_set_last_run):
+    save_fetch_checkpoint("2025-12-01T00:00:00", 4, "2025-12-01T01:00:00")
+    mock_set_last_run.assert_called_once_with(
+        {
+            "last_fetch": "2025-12-01T00:00:00",
+            "page": "4",
+            "chunk_lte": "2025-12-01T01:00:00",
+        }
+    )
+
+
+@patch("CybleThreatIntel.demisto.setLastRun")
+def test_save_chunk_completed_checkpoint(mock_set_last_run):
+    save_chunk_completed_checkpoint("2025-12-01T01:00:00")
+    mock_set_last_run.assert_called_once_with({"last_fetch": "2025-12-01T01:00:00"})
+
+
+@patch("CybleThreatIntel.demisto.createIndicators")
+@patch("CybleThreatIntel.demisto.setLastRun")
+@patch("CybleThreatIntel.demisto")
+def test_fetch_indicators_saves_checkpoint_per_page(mock_demisto, mock_set_last_run, mock_create_indicators, mocker):
+    mock_demisto.args.return_value = {}
+    mock_demisto.getLastRun.return_value = {}
+    mocker.patch("CybleThreatIntel.get_execution_timeout_seconds", return_value=900.0)
+
+    client = Client({"base_url": "x", "credentials": {"password": "a"}})
+    client.fetch_iocs = MagicMock(
+        side_effect=[
+            {"success": True, "data": {"iocs": [{"ioc": "1.1.1.1", "ioc_type": "IPv4"}]}},
+            {"success": True, "data": {"iocs": []}},
+        ]
+    )
+
+    count = fetch_indicators_command(client, {"initial_interval": 1, "limit": 100})
+
+    assert count == 1
+    assert mock_create_indicators.call_count == 1
+    submitted = mock_create_indicators.call_args[0][0]
+    assert submitted[0]["type"] == "IP"
+    assert submitted[0]["value"] == "1.1.1.1"
+    checkpoint_calls = [
+        call
+        for call in mock_set_last_run.call_args_list
+        if call.args[0].get("page") == "2"
+    ]
+    assert checkpoint_calls
+    completed_calls = [call for call in mock_set_last_run.call_args_list if "page" not in call.args[0]]
+    assert completed_calls
+
+
+@pytest.mark.parametrize(
+    "raw_type,value,expected",
+    [
+        ("IPv4", "1.1.1.1", "IP"),
+        ("ip", "1.1.1.1", "IP"),
+        ("IPv6", "2001:db8::1", "IPv6"),
+        ("Domain", "evil.com", "Domain"),
+        ("URL", "https://evil.com", "URL"),
+        ("FileHash-MD5", "d41d8cd98f00b204e9800998ecf8427e", "File"),
+        ("FileHash-SHA256", "a" * 64, "File"),
+        ("Email", "a@b.com", "Email"),
+        ("Wallet-Address", "0xabc", None),
+        ("", "8.8.8.8", "IP"),  # fall back to value detection
+    ],
+)
+def test_map_cyble_ioc_type(raw_type, value, expected):
+    assert map_cyble_ioc_type(raw_type, value) == expected
+
+
+def test_build_indicator_from_ioc_skips_empty_and_unknown():
+    assert build_indicator_from_ioc({"ioc": "", "ioc_type": "IPv4"}) is None
+    assert build_indicator_from_ioc({"ioc": "x", "ioc_type": "Wallet-Address"}) is None
+    indicator = build_indicator_from_ioc({"ioc": "evil.com", "ioc_type": "Domain", "risk_score": 80})
+    assert indicator is not None
+    assert indicator["type"] == "Domain"
+    assert indicator["value"] == "evil.com"
+
+
+@patch("CybleThreatIntel.demisto.createIndicators")
+@patch("CybleThreatIntel.demisto.setLastRun")
+@patch("CybleThreatIntel.demisto")
+def test_fetch_indicators_exits_before_timeout(mock_demisto, mock_set_last_run, mock_create_indicators, mocker):
+    mock_demisto.args.return_value = {}
+    mock_demisto.getLastRun.return_value = {}
+    mocker.patch("CybleThreatIntel.get_execution_timeout_seconds", return_value=180.0)
+    mocker.patch("CybleThreatIntel.should_stop_before_next_page", side_effect=[False, True])
+
+    client = Client({"base_url": "x", "credentials": {"password": "a"}})
+    client.fetch_iocs = MagicMock(
+        return_value={"success": True, "data": {"iocs": [{"ioc": "1.1.1.1", "ioc_type": "ip"}]}}
+    )
+
+    count = fetch_indicators_command(client, {"initial_interval": 1, "limit": 100})
+
+    assert count == 1
+    assert client.fetch_iocs.call_count == 1
+    assert mock_create_indicators.call_count == 1
+
+
+@patch("CybleThreatIntel.demisto.createIndicators")
+@patch("CybleThreatIntel.demisto.setLastRun")
+@patch("CybleThreatIntel.demisto")
+def test_fetch_stops_at_per_fetch_cap(mock_demisto, mock_set_last_run, mock_create_indicators, mocker):
+    """Non-TIM: only one page of 100 should be submitted; page must not keep advancing."""
+    mock_demisto.args.return_value = {}
+    mock_demisto.getLastRun.return_value = {}
+    mocker.patch("CybleThreatIntel.get_execution_timeout_seconds", return_value=900.0)
+    mocker.patch("CybleThreatIntel.should_stop_before_next_page", return_value=False)
+
+    page_payload = {
+        "success": True,
+        "data": {"iocs": [{"ioc": f"1.1.1.{i}", "ioc_type": "IPv4"} for i in range(100)]},
+    }
+    client = Client({"base_url": "x", "credentials": {"password": "a"}})
+    client.fetch_iocs = MagicMock(return_value=page_payload)
+
+    count = fetch_indicators_command(
+        client, {"initial_interval": 1, "limit": 100, "max_indicators_per_fetch": 100}
+    )
+
+    assert count == 100
+    assert mock_create_indicators.call_count == 1
+    assert client.fetch_iocs.call_count == 1
+    # Next page checkpointed for resume
+    assert any(call.args[0].get("page") == "2" for call in mock_set_last_run.call_args_list)

--- a/Packs/CybleThreatIntel/Integrations/CybleThreatIntel/README.md
+++ b/Packs/CybleThreatIntel/Integrations/CybleThreatIntel/README.md
@@ -37,7 +37,7 @@ This integration allows XSOAR to:
 
 ### Fetch Behavior
 
-* Fetch is performed **in 1-hour chunks** until the full range is covered.
+* Fetch is performed **in 15-minute chunks** until the full range is covered.
 * Each page of IOCs is inserted immediately using
   `demisto.createIndicators`.
 * Fetch uses a retry mechanism (up to 5 attempts per page).

--- a/Packs/CybleThreatIntel/Integrations/CybleThreatIntel/README.md
+++ b/Packs/CybleThreatIntel/Integrations/CybleThreatIntel/README.md
@@ -1,6 +1,6 @@
-# Cyble Threat Intelligence – Cortex XSOAR Integration
+# Cyble Threat Intelligence – Cortex Integration
 
-This integration enables Cortex XSOAR to ingest and query Indicators of
+This integration enables Cortex to ingest and query Indicators of
 Compromise (IOCs) from the **Cyble Vision API**.
 It supports two capabilities:
 
@@ -9,15 +9,15 @@ It supports two capabilities:
 
 ---
 
-## Overview
+## What does this pack do?
 
 The Cyble Vision platform provides enriched, high-fidelity threat
 intelligence including malware associations, threat actor links,
 behaviour tags, risk scoring, and more.
-This integration allows XSOAR to:
+This integration allows Cortex to:
 
 * Pull fresh IOCs at scheduled intervals
-* Tag, score, and store indicators in the Cortex XSOAR indicator store
+* Tag, score, and store indicators in the Cortex indicator store
 * Support analyst lookups for a single IOC via the command line or
   playbooks
 
@@ -30,17 +30,17 @@ This integration allows XSOAR to:
 | Parameter                    | Description                                                        | Example                              |
 |------------------------------| ------------------------------------------------------------------ | ------------------------------------ |
 | **Base URL**                 | Cyble Vision API endpoint                                          | `https://api.cyble.ai/engine/api/v4` |
-| **API Key (Access Token)**   | Cyble Vision API Bearer token                                      | *(stored securely in XSOAR)*         |
-| **First fetch time (hours)** | Number of hours to fetch backward on first run                     | `2`                                  |
+| **API Key (Access Token)**   | Cyble Vision API Bearer token                                      | *(stored securely in Cortex)*         |
+| **First fetch time (hours)** | Number of hours to fetch backward on first run                     | `1`                                  |
 |                              | (1–3 hours allowed)                                                |                                      |
 | **Indicator Fetch Limit**    | Maximum indicators per API page                                    | `100`                                |
 
 ### Fetch Behavior
 
-* Fetch is performed **in 15-minute chunks** until the full range is covered.
+* The integration fetches indicators **in 15-minute chunks** until the full range is covered.
 * Each page of IOCs is inserted immediately using
   `demisto.createIndicators`.
-* Fetch uses a retry mechanism (up to 5 attempts per page).
+* Fetch uses the built-in HTTP client retry mechanism for transient API errors.
 * `last_run` is updated after every chunk.
 * Supported fetch window: **1–3 hours** (anything outside is
   automatically corrected).
@@ -96,12 +96,12 @@ Prefix: `CybleIntel.IOCLookup`
 
 ## 📌 2. fetch-indicators
 
-Fetch IOCs from Cyble Vision and insert them into XSOAR's indicator store.
+Fetch IOCs from Cyble Vision and insert them into the Cortex indicator store.
 
 ### **Execution**
 
 This command is **not run manually**.
-It is used by the XSOAR engine when *Fetches Indicators* is enabled.
+It is used by the Cortex engine when *Fetches Indicators* is enabled.
 
 ### Behavior
 
@@ -119,7 +119,7 @@ It is used by the XSOAR engine when *Fetches Indicators* is enabled.
   * `cyblerelatedmalware`
   * `cyblerelatedthreatactors`
 
-* Automatically maps each IOC into XSOAR Indicator fields.
+* Automatically maps each IOC into Cortex Indicator fields.
 * Updates `last_run` after each successful chunk.
 
 ## Known Limitations

--- a/Packs/CybleThreatIntel/README.md
+++ b/Packs/CybleThreatIntel/README.md
@@ -37,7 +37,7 @@ This integration allows XSOAR to:
 
 ### Fetch Behavior
 
-* Fetch is performed **in 1-hour chunks** until the full range is covered.
+* Fetch is performed **in 15-minute chunks** until the full range is covered.
 * Each page of IOCs is inserted immediately using
   `demisto.createIndicators`.
 * Fetch uses a retry mechanism (up to 5 attempts per page).

--- a/Packs/CybleThreatIntel/README.md
+++ b/Packs/CybleThreatIntel/README.md
@@ -1,6 +1,6 @@
-# Cyble Threat Intelligence – Cortex XSOAR Integration
+# Cyble Threat Intelligence – Cortex Integration
 
-This integration enables Cortex XSOAR to ingest and query Indicators of
+This integration enables Cortex to ingest and query Indicators of
 Compromise (IOCs) from the **Cyble Vision API**.
 It supports two capabilities:
 
@@ -9,15 +9,15 @@ It supports two capabilities:
 
 ---
 
-## Overview
+## What does this pack do?
 
 The Cyble Vision platform provides enriched, high-fidelity threat
 intelligence including malware associations, threat actor links,
 behaviour tags, risk scoring, and more.
-This integration allows XSOAR to:
+This integration allows Cortex to:
 
 * Pull fresh IOCs at scheduled intervals
-* Tag, score, and store indicators in the Cortex XSOAR indicator store
+* Tag, score, and store indicators in the Cortex indicator store
 * Support analyst lookups for a single IOC via the command line or
   playbooks
 
@@ -30,17 +30,17 @@ This integration allows XSOAR to:
 | Parameter                    | Description                                                        | Example                              |
 |------------------------------| ------------------------------------------------------------------ | ------------------------------------ |
 | **Base URL**                 | Cyble Vision API endpoint                                          | `https://api.cyble.ai/engine/api/v4` |
-| **API Key (Access Token)**   | Cyble Vision API Bearer token                                      | *(stored securely in XSOAR)*         |
-| **First fetch time (hours)** | Number of hours to fetch backward on first run                     | `2`                                  |
+| **API Key (Access Token)**   | Cyble Vision API Bearer token                                      | *(stored securely in Cortex)*         |
+| **First fetch time (hours)** | Number of hours to fetch backward on first run                     | `1`                                  |
 |                              | (1–3 hours allowed)                                                |                                      |
 | **Indicator Fetch Limit**    | Maximum indicators per API page                                    | `100`                                |
 
 ### Fetch Behavior
 
-* Fetch is performed **in 15-minute chunks** until the full range is covered.
+* The integration fetches indicators **in 15-minute chunks** until the full range is covered.
 * Each page of IOCs is inserted immediately using
   `demisto.createIndicators`.
-* Fetch uses a retry mechanism (up to 5 attempts per page).
+* Fetch uses the built-in HTTP client retry mechanism for transient API errors.
 * `last_run` is updated after every chunk.
 * Supported fetch window: **1–3 hours** (anything outside is
   automatically corrected).
@@ -96,12 +96,12 @@ Prefix: `CybleIntel.IOCLookup`
 
 ## 📌 2. fetch-indicators
 
-Fetch IOCs from Cyble Vision and insert them into XSOAR's indicator store.
+Fetch IOCs from Cyble Vision and insert them into the Cortex indicator store.
 
 ### **Execution**
 
 This command is **not run manually**.
-It is used by the XSOAR engine when *Fetches Indicators* is enabled.
+It is used by the Cortex engine when *Fetches Indicators* is enabled.
 
 ### Behavior
 
@@ -119,7 +119,7 @@ It is used by the XSOAR engine when *Fetches Indicators* is enabled.
   * `cyblerelatedmalware`
   * `cyblerelatedthreatactors`
 
-* Automatically maps each IOC into XSOAR Indicator fields.
+* Automatically maps each IOC into Cortex Indicator fields.
 * Updates `last_run` after each successful chunk.
 
 ## Known Limitations

--- a/Packs/CybleThreatIntel/ReleaseNotes/3_0_3.md
+++ b/Packs/CybleThreatIntel/ReleaseNotes/3_0_3.md
@@ -1,0 +1,8 @@
+#### Integrations
+
+##### Cyble Threat Intel
+
+- Improved `fetch-indicators` to checkpoint pagination after each successful page, exit gracefully before the Docker execution timeout, and resume from `{last_fetch, page, chunk_lte}` on the next run.
+- Reduced fetch time chunks to 15 minutes for steadier catch-up across scheduled runs.
+- Fixed indicators being dropped after fetch by mapping Cyble `ioc_type` values (e.g. `IPv4`, `FileHash-MD5`) to XSOAR `FeedIndicatorType` values (`IP`, `File`).
+- Stop at the per-fetch indicator cap (default 100) so non-TIM tenants do not advance the page cursor after the platform rejects further `createIndicators` calls. Optional `max_indicators_per_fetch` can be raised only with a TIM license.

--- a/Packs/CybleThreatIntel/ReleaseNotes/3_0_3.md
+++ b/Packs/CybleThreatIntel/ReleaseNotes/3_0_3.md
@@ -1,8 +1,0 @@
-#### Integrations
-
-##### Cyble Threat Intel
-
-- Improved `fetch-indicators` to checkpoint pagination after each successful page, exit gracefully before the Docker execution timeout, and resume from `{last_fetch, page, chunk_lte}` on the next run.
-- Reduced fetch time chunks to 15 minutes for steadier catch-up across scheduled runs.
-- Fixed indicators being dropped after fetch by mapping Cyble `ioc_type` values (e.g. `IPv4`, `FileHash-MD5`) to XSOAR `FeedIndicatorType` values (`IP`, `File`).
-- Stop at the per-fetch indicator cap (default 100) so non-TIM tenants do not advance the page cursor after the platform rejects further `createIndicators` calls. Optional `max_indicators_per_fetch` can be raised only with a TIM license.

--- a/Packs/CybleThreatIntel/ReleaseNotes/3_1_0.md
+++ b/Packs/CybleThreatIntel/ReleaseNotes/3_1_0.md
@@ -1,0 +1,8 @@
+#### Integrations
+
+##### Cyble Threat Intel
+
+- Improved implementation of ***fetch-indicators*** to checkpoint pagination after each successful page, exit gracefully before the Docker execution timeout, and resume from *last_fetch*, *page*, and *chunk_lte* on the next run.
+- Improved implementation by reducing fetch time chunks to 15 minutes for steadier catch-up across scheduled runs.
+- Fixed an issue where indicators were being dropped after fetch by mapping Cyble *ioc_type* values (e.g., *IPv4*, *FileHash-MD5*) to Cortex *FeedIndicatorType* values (*IP*, *File*).
+- Improved implementation to stop at the per-fetch indicator cap (default 100) so non-TIM tenants do not advance the page cursor after the platform rejects further *createIndicators* calls. Optional *max_indicators_per_fetch* can be raised only with a TIM license.

--- a/Packs/CybleThreatIntel/pack_metadata.json
+++ b/Packs/CybleThreatIntel/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cyble Threat Intel",
     "description": "Cyble Threat Intelligence for Vision Users. Must have access to Vision Taxii feed to access the threat intelligence.",
     "support": "partner",
-    "currentVersion": "3.0.3",
+    "currentVersion": "3.1.0",
     "author": "Cyble Infosec",
     "url": "https://cyble.com",
     "email": "",
@@ -13,7 +13,9 @@
     ],
     "tags": [],
     "useCases": [],
-    "keywords": [],
+    "keywords": [
+        "Cyble"
+    ],
     "dependencies": {
         "CommonScripts": {
             "mandatory": false,
@@ -28,5 +30,8 @@
     "supportedModules": [
         "agentix",
         "xsiam"
+    ],
+    "githubUser": [
+        "tushar-parwani"
     ]
 }

--- a/Packs/CybleThreatIntel/pack_metadata.json
+++ b/Packs/CybleThreatIntel/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Cyble Threat Intel",
     "description": "Cyble Threat Intelligence for Vision Users. Must have access to Vision Taxii feed to access the threat intelligence.",
     "support": "partner",
-    "currentVersion": "3.0.2",
+    "currentVersion": "3.0.3",
     "author": "Cyble Infosec",
     "url": "https://cyble.com",
     "email": "",


### PR DESCRIPTION
Add page checkpointing, map Cyble IOC types to FeedIndicatorType, and respect the non-TIM 100 indicators-per-fetch cap for partner pack 3.0.3.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
<!-- To link a Jira ticket use fixes/related: link to the issue, for example relates: link to the issue

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

## Must have
- [ ] Tests
- [ ] Documentation


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-17758