### PR TITLE
fix(Slack): resolve GR105 duplicate ID on modeling rule version overlap

### DIFF
--- a/Packs/Slack/ModelingRules/SlackModelingRules_1_3/SlackModelingRules_1_3.yml
+++ b/Packs/Slack/ModelingRules/SlackModelingRules_1_3/SlackModelingRules_1_3.yml
@@ -1,5 +1,5 @@
 fromversion: 6.10.0
-toversion: 8.13.0
+toversion: 8.12.0
 id: Slack_ModelingRule
 name: Slack Modeling Rule
 rules: ''

--- a/Packs/Slack/ReleaseNotes/3_8_17.md
+++ b/Packs/Slack/ReleaseNotes/3_8_17.md
@@ -1,0 +1,6 @@
+
+#### Modeling Rules
+
+##### Slack Modeling Rule
+
+- Documentation and metadata improvements.

--- a/Packs/Slack/pack_metadata.json
+++ b/Packs/Slack/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Slack",
     "description": "Interact with Slack API - collect logs, send messages and notifications to your Slack team.",
     "support": "xsoar",
-    "currentVersion": "3.8.16",
+    "currentVersion": "3.8.17",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
The Slack_ModelingRule ID was shared by SlackModelingRules_1_3 and SlackModelingRules_2_10 with overlapping version ranges. Both fromversion and toversion are inclusive, so version 8.13.0 was covered by both files, triggering GR105.

Set SlackModelingRules_1_3 toversion to 8.12.0 so the ranges are disjoint, matching the convention used in Packs/VMwareESXi/ModelingRules.

Bump pack version to 3.8.17 and add release notes.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
<!-- To link a Jira ticket use fixes/related: link to the issue, for example fixes: CIAC-XXXX -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

## Must have
- [ ] Tests
- [ ] Documentation
