### PR TITLE
Atlassian Confluence Cloud: return generic-file-get content as Markdown

### DIFF
--- a/Packs/AtlassianConfluenceCloud/Integrations/AtlassianConfluenceCloud/AtlassianConfluenceCloud.py
+++ b/Packs/AtlassianConfluenceCloud/Integrations/AtlassianConfluenceCloud/AtlassianConfluenceCloud.py
@@ -8,6 +8,7 @@ import demistomock as demisto  # noqa: F401
 import requests
 import urllib3
 from CommonServerPython import *  # noqa: F401
+from markdownify import markdownify
 
 MAX_FILE_SIZE = 5 * 1024 * 1024  # 5MB
 
@@ -2364,15 +2365,19 @@ def confluence_cloud_generic_file_get_command(client: Client, args: dict[str, st
 
     content_id = _extract_content_id_from_url(url)
 
+    # Request the body in storage format (XHTML/HTML), then convert it to Markdown for readability.
     params = {"expand": "body.storage"}
     request_url = urljoin(URL_SUFFIX.get("CONTENT"), content_id)
     response = client.http_request(method="GET", url_suffix=request_url, params=params)
     response_json = response.json()
 
     title = response_json.get("title", "")
-    body_content = response_json.get("body", {}).get("storage", {}).get("value", "")
+    html_content = response_json.get("body", {}).get("storage", {}).get("value", "")
 
-    # Check size of body_content (limit to 5MB = 5 * 1024 * 1024 bytes)
+    # Convert the Confluence storage-format HTML/XHTML into Markdown.
+    body_content = markdownify(html_content).strip() if html_content else ""
+
+    # Check size of the body content (limit to 5MB = 5 * 1024 * 1024 bytes).
     if body_content:
         size_bytes = len(body_content.encode("utf-8"))
         if size_bytes > MAX_FILE_SIZE:
@@ -2382,11 +2387,11 @@ def confluence_cloud_generic_file_get_command(client: Client, args: dict[str, st
                 f"The file '{title}' is {size_mb:.2f} MB, which exceeds the maximum allowed size of {limit_mb:.0f} MB."
             )
 
-    # Confluence returns the page body as HTML/XHTML (storage format), so the content MIME type is text/html.
+    # The body is converted from Confluence storage-format HTML to Markdown, so the MIME type is text/markdown.
     generic_output = remove_empty_elements(
         {
             "Title": title,
-            "Type": "text/html",
+            "Type": "text/markdown",
             "Name": title,
             "Content": body_content,
             "Url": url,

--- a/Packs/AtlassianConfluenceCloud/Integrations/AtlassianConfluenceCloud/AtlassianConfluenceCloud.yml
+++ b/Packs/AtlassianConfluenceCloud/Integrations/AtlassianConfluenceCloud/AtlassianConfluenceCloud.yml
@@ -2696,7 +2696,7 @@ script:
   - arguments: []
     name: confluence-cloud-oauth-test
     description: Tests the OAuth 2.0 authentication by verifying the current access token is valid.
-  dockerimage: demisto/python3:3.12.13.10116658
+  dockerimage: demisto/btfl-soup:1.0.1.10120494
   isfetchevents: true
   isfetchevents:xsoar: false
   runonce: false

--- a/Packs/AtlassianConfluenceCloud/Integrations/AtlassianConfluenceCloud/AtlassianConfluenceCloud_test.py
+++ b/Packs/AtlassianConfluenceCloud/Integrations/AtlassianConfluenceCloud/AtlassianConfluenceCloud_test.py
@@ -1986,8 +1986,16 @@ def test_generic_file_get_command_success(requests_mock):
     assert result.outputs_prefix == "FileContent"
     assert result.outputs["Id"] == "2097159"
     assert result.outputs["Title"] == "test_page"
-    assert result.outputs["Type"] == "text/html"
-    assert result.outputs["Content"] == "<p>This is the page content</p>"
+    assert result.outputs["Type"] == "text/markdown"
+    # Content is the storage-format HTML converted to Markdown.
+    assert isinstance(result.outputs["Content"], str)
+    content = result.outputs["Content"]
+    assert "Heading" in content
+    assert "This is the page content" in content
+    assert "Item one" in content
+    assert "Item two" in content
+    assert "<p>" not in content
+    assert "<h1>" not in content
     assert result.outputs["Url"] == args["url"]
 
 

--- a/Packs/AtlassianConfluenceCloud/Integrations/AtlassianConfluenceCloud/AtlassianConfluenceCloud_test.py
+++ b/Packs/AtlassianConfluenceCloud/Integrations/AtlassianConfluenceCloud/AtlassianConfluenceCloud_test.py
@@ -1990,12 +1990,18 @@ def test_generic_file_get_command_success(requests_mock):
     # Content is the storage-format HTML converted to Markdown.
     assert isinstance(result.outputs["Content"], str)
     content = result.outputs["Content"]
-    assert "Heading" in content
     assert "This is the page content" in content
-    assert "Item one" in content
-    assert "Item two" in content
+    # Assert specific Markdown syntax to ensure the HTML was actually converted to Markdown:
+    # - the <h1> is rendered as a setext heading (underlined with '=').
+    assert "Heading\n=======" in content
+    # - the <li> items are rendered as Markdown bullet-list markers.
+    assert "* Item one" in content
+    assert "* Item two" in content
+    # No raw HTML tags should remain after the conversion.
     assert "<p>" not in content
     assert "<h1>" not in content
+    assert "<ul>" not in content
+    assert "<li>" not in content
     assert result.outputs["Url"] == args["url"]
 
 

--- a/Packs/AtlassianConfluenceCloud/Integrations/AtlassianConfluenceCloud/test_data/content_get/generic_file_get_response.json
+++ b/Packs/AtlassianConfluenceCloud/Integrations/AtlassianConfluenceCloud/test_data/content_get/generic_file_get_response.json
@@ -5,7 +5,7 @@
     "title": "test_page",
     "body": {
         "storage": {
-            "value": "<p>This is the page content</p>",
+            "value": "<h1>Heading</h1><p>This is the page content</p><ul><li>Item one</li><li>Item two</li></ul>",
             "representation": "storage"
         }
     },

--- a/Packs/AtlassianConfluenceCloud/ReleaseNotes/1_2_1.md
+++ b/Packs/AtlassianConfluenceCloud/ReleaseNotes/1_2_1.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Atlassian Confluence Cloud
+
+- Updated the Docker image to *demisto/btfl-soup:1.0.1.10120494*.

--- a/Packs/AtlassianConfluenceCloud/ReleaseNotes/1_2_1.md
+++ b/Packs/AtlassianConfluenceCloud/ReleaseNotes/1_2_1.md
@@ -3,4 +3,4 @@
 
 ##### Atlassian Confluence Cloud
 
-- Updated the Docker image to *demisto/btfl-soup:1.0.1.10120494*.
+- Updated the Docker image to: *demisto/btfl-soup:1.0.1.10120494*.

--- a/Packs/AtlassianConfluenceCloud/pack_metadata.json
+++ b/Packs/AtlassianConfluenceCloud/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Atlassian Confluence Cloud",
     "description": "Atlassian Confluence Cloud allows users to interact with confluence entities like content, space, users and groups. Users can also manage the space permissions.",
     "support": "xsoar",
-    "currentVersion": "1.2.0",
+    "currentVersion": "1.2.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Summary
The `confluence-cloud-generic-file-get` command now returns the page content converted to **Markdown** instead of raw HTML.

## Changes
- `confluence-cloud-generic-file-get` fetches the page body in storage format (HTML/XHTML) and converts it to Markdown using `markdownify`. The output `Type` is set to `text/markdown`, and `Content` remains a string (required by the FileContent consumer).
- Added `from markdownify import markdownify`.
- Updated the Docker image to `demisto/btfl-soup:1.0.1.10120494` (lightweight image that bundles `markdownify`, ~102MB vs ~224MB for py3-tools).
- Updated unit test and fixture to cover the HTML-to-Markdown conversion.
- Bumped pack version to 1.2.1 and added ReleaseNotes.

## Testing
- `demisto-sdk pre-commit` (ruff, xsoar-lint, pylint, mypy, pytest in Docker) — all passed.
- `demisto-sdk validate` — all validations passed.