### PR TITLE
CIAC-17779: Align asset fetch parameters with supportedModules rules

### DIFF
--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.yml
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.yml
@@ -379,6 +379,7 @@ configuration:
   defaultvalue: 'false'
   hidden:
   - xsoar
+  - xpanse
   supportedModules:
   - "xsiam"
   - "exposure_management"

--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.yml
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.yml
@@ -379,7 +379,7 @@ configuration:
   defaultvalue: 'false'
   hidden:
   - xsoar
-  - xpanse
+    - xpanse
   supportedModules:
   - "xsiam"
   - "exposure_management"

--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.yml
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.yml
@@ -379,7 +379,7 @@ configuration:
   defaultvalue: 'false'
   hidden:
   - xsoar
-    - xpanse
+  - xpanse
   supportedModules:
   - "xsiam"
   - "exposure_management"

--- a/Packs/CrowdStrikeFalcon/ReleaseNotes/2_12_9.md
+++ b/Packs/CrowdStrikeFalcon/ReleaseNotes/2_12_9.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### CrowdStrike Falcon
+
+- Updated the asset fetch configuration parameters.

--- a/Packs/CrowdStrikeFalcon/pack_metadata.json
+++ b/Packs/CrowdStrikeFalcon/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CrowdStrike Falcon",
     "description": "The CrowdStrike Falcon OAuth 2 API (formerly the Falcon Firehose API), enables fetching and resolving detections, searching devices, getting behaviors by ID, containing hosts, and lifting host containment.",
     "support": "xsoar",
-    "currentVersion": "2.12.8",
+    "currentVersion": "2.12.9",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/Rapid7_Nexpose/Integrations/Rapid7_Nexpose/Rapid7_Nexpose.yml
+++ b/Packs/Rapid7_Nexpose/Integrations/Rapid7_Nexpose/Rapid7_Nexpose.yml
@@ -45,6 +45,8 @@ configuration:
   type: 8
   section: Collect
   required: false
+  hidden:
+  - xsoar
   supportedModules:
   - xsiam
   - exposure_management

--- a/Packs/Rapid7_Nexpose/ReleaseNotes/1_4_9.md
+++ b/Packs/Rapid7_Nexpose/ReleaseNotes/1_4_9.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Rapid7 InsightVM
+
+- Updated the asset fetch configuration parameters.

--- a/Packs/Rapid7_Nexpose/pack_metadata.json
+++ b/Packs/Rapid7_Nexpose/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Rapid7 InsightVM",
     "description": "Vulnerability management solution to help reduce threat exposure.",
     "support": "xsoar",
-    "currentVersion": "1.4.8",
+    "currentVersion": "1.4.9",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/Rapid7_Nexpose/pack_metadata.json
+++ b/Packs/Rapid7_Nexpose/pack_metadata.json
@@ -13,7 +13,8 @@
     "tags": [],
     "useCases": [],
     "keywords": [
-        "nexpose"
+        "nexpose",
+        "Rapid7"
     ],
     "dependencies": {
         "CVESearch": {

--- a/Packs/Tenable_sc/Integrations/Tenable_sc/Tenable_sc.yml
+++ b/Packs/Tenable_sc/Integrations/Tenable_sc/Tenable_sc.yml
@@ -63,6 +63,16 @@ configuration:
   required: false
   type: 19
   section: Collect
+- display: Fetch assets and vulnerabilities
+  name: isFetchAssets
+  type: 8
+  required: false
+  section: Collect
+  hidden:
+  - xsoar
+  supportedModules:
+  - xsiam
+  - exposure_management
 - additionalinfo: The fetch interval for assets and vulnerabilities. It is recommended to set it to 12 hours. Interval lower then 1 hour is not supported.
   defaultvalue: '720'
   display: Assets fetch interval in minutes.
@@ -73,6 +83,9 @@ configuration:
   section: Collect
   hidden:
   - xsoar
+  supportedModules:
+  - xsiam
+  - exposure_management
 description: With Tenable.sc (formerly SecurityCenter) you get a real-time, continuous assessment of your security posture so you can find and fix vulnerabilities faster.
 display: Tenable.sc
 name: Tenable.sc

--- a/Packs/Tenable_sc/Integrations/Tenable_sc/Tenable_sc.yml
+++ b/Packs/Tenable_sc/Integrations/Tenable_sc/Tenable_sc.yml
@@ -45,11 +45,17 @@ configuration:
   type: 8
   section: Collect
   required: false
+  supportedModules:
+  - agentix
+  - xsiam
 - display: Incident type
   name: incidentType
   type: 13
   section: Connect
   required: false
+  supportedModules:
+  - agentix
+  - xsiam
 - defaultvalue: 3 days
   display: First fetch timestamp (<number> <time unit>, e.g., 12 hours, 7 days)
   name: fetch_time
@@ -63,6 +69,9 @@ configuration:
   required: false
   type: 19
   section: Collect
+  supportedModules:
+  - agentix
+  - xsiam
 - display: Fetch assets and vulnerabilities
   name: isFetchAssets
   type: 8

--- a/Packs/Tenable_sc/ReleaseNotes/1_2_3.md
+++ b/Packs/Tenable_sc/ReleaseNotes/1_2_3.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Tenable.sc
+
+- Updated the asset fetch configuration parameters.

--- a/Packs/Tenable_sc/pack_metadata.json
+++ b/Packs/Tenable_sc/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Tenable.sc",
     "description": "With Tenable.sc (formerly SecurityCenter) you get a real-time, continuous assessment of your security posture so you can find and fix vulnerabilities faster.",
     "support": "xsoar",
-    "currentVersion": "1.2.2",
+    "currentVersion": "1.2.3",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/qualys/Integrations/Qualysv2/Qualysv2.yml
+++ b/Packs/qualys/Integrations/Qualysv2/Qualysv2.yml
@@ -84,6 +84,17 @@ configuration:
   - xpanse
   supportedModules:
   - xsiam
+- display: Fetch assets and vulnerabilities
+  name: isFetchAssets
+  type: 8
+  section: Collect
+  required: false
+  hidden:
+  - xsoar
+  - xpanse
+  supportedModules:
+  - xsiam
+  - exposure_management
 - additionalinfo: The fetch interval for assets and vulnerabilities. It is recommended to set it to 24 hours. Interval lower then 1 hour is not supported.
   defaultvalue: 1440
   display: Assets and Vulnerabilities Fetch Interval
@@ -97,6 +108,7 @@ configuration:
   - xpanse
   supportedModules:
   - xsiam
+  - exposure_management
 description: Qualys Vulnerability Management lets you create, run, manage reports and to fetch Activity Logs, Assets and Vulnerabilities, launch and manage vulnerability and compliance scans, and manage the host assets you want to scan for vulnerabilities and compliance.
 display: Qualys VMDR
 name: QualysV2

--- a/Packs/qualys/Integrations/Qualysv2/Qualysv2.yml
+++ b/Packs/qualys/Integrations/Qualysv2/Qualysv2.yml
@@ -46,6 +46,16 @@ configuration:
   - xpanse
   supportedModules:
   - xsiam
+- display: Fetch events
+  name: isFetchEvents
+  type: 8
+  section: Collect
+  required: false
+  hidden:
+  - xsoar
+  - xpanse
+  supportedModules:
+  - xsiam
 - defaultvalue: 3 days
   section: Collect
   display: Event first fetch time

--- a/Packs/qualys/ReleaseNotes/3_4_5.md
+++ b/Packs/qualys/ReleaseNotes/3_4_5.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Qualys VMDR
+
+- Updated the asset fetch configuration parameters.

--- a/Packs/qualys/pack_metadata.json
+++ b/Packs/qualys/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Qualys",
     "description": "Qualys Vulnerability Management let's you create, run, fetch and manage reports, launch and manage vulnerability and compliance scans, and manage the host assets you want to scan for vulnerabilities and compliance",
     "support": "xsoar",
-    "currentVersion": "3.4.4",
+    "currentVersion": "3.4.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [ ] In Progress
- [X] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CIAC-17779

## Description
Aligns the Fetch Assets configuration parameters (`isFetchAssets`, `assetsFetchInterval`) of the asset integrations with the required `supportedModules` / `hidden` rules. For each of these params, `supportedModules` must be a subset of `[xsiam, exposure_management]` and the params should be hidden on `xsoar`.

## Must have
- [X] Tests
- [X] Documentation
