### PR TITLE
HY/XSUP-75552/SlackCollectionErrorNotHandlingEmptyString

### DIFF
--- a/Packs/Slack/Integrations/SlackV3/SlackV3.py
+++ b/Packs/Slack/Integrations/SlackV3/SlackV3.py
@@ -2083,7 +2083,11 @@ async def handle_entitlement_interactions(
             entitlement_json = actions[0].get("value")
             if not entitlement_json:
                 return True
-            entitlement_string = json.loads(entitlement_json)
+            try:
+                entitlement_string = json.loads(entitlement_json)
+            except json.JSONDecodeError:
+                demisto.debug(f"SlackV3 - Action value is not valid JSON, skipping entitlement handling: {entitlement_json}")
+                return True
             if actions[0].get("action_id") == "xsoar-button-submit":
                 demisto.debug("Handling a SlackBlockBuilder response.")
                 state = data.get("state", {})
@@ -2240,6 +2244,7 @@ async def listen(client: SocketModeClient, req: SocketModeRequest):
         message_ts = message.get("ts", "")
         actions = data.get("actions", [])
         quick_check_payload = json.dumps(data)
+        demisto.debug(f"SlackV3 - Processing payload: {quick_check_payload}")
 
         # Check if the message is from a bot so we can quit processing ASAP
         if is_bot_message(data):

--- a/Packs/Slack/Integrations/SlackV3/SlackV3.py
+++ b/Packs/Slack/Integrations/SlackV3/SlackV3.py
@@ -2081,7 +2081,7 @@ async def handle_entitlement_interactions(
         user = await get_user_details(user_id=user_id)
         if len(actions) > 0:
             entitlement_json = actions[0].get("value")
-            if entitlement_json is None:
+            if not entitlement_json:
                 return True
             entitlement_string = json.loads(entitlement_json)
             if actions[0].get("action_id") == "xsoar-button-submit":

--- a/Packs/Slack/Integrations/SlackV3/SlackV3_test.py
+++ b/Packs/Slack/Integrations/SlackV3/SlackV3_test.py
@@ -6016,3 +6016,36 @@ def test_create_script_notice_ui():
     assert quote_block["type"] == "rich_text_quote"
     text_element = quote_block["elements"][1]
     assert AssistantMessages.SCRIPT_AVAILABLE_NOTICE in text_element["text"]
+
+
+@pytest.mark.asyncio
+async def test_handle_entitlement_interactions_empty_action_value(mocker):
+    """
+    Given:
+        A Slack interactive payload where actions[0]["value"] is an empty string "".
+    When:
+        handle_entitlement_interactions is called.
+    Then:
+        The function returns True without raising a JSONDecodeError.
+        (Regression test for XSUP-75552)
+    """
+    import SlackV3
+
+    ENTITLEMENT_REGEX = r"4404dae8-2d45-46bd-85fa-64779c12abe8@22"
+    quick_check_payload = f'{{"actions": [{{"value": "", "action_id": "some-action"}}], "entitlement": "{ENTITLEMENT_REGEX}"}}'
+
+    mocker.patch.object(SlackV3, "get_user_details", return_value={"profile": {"email": "test@example.com"}})
+
+    result = await SlackV3.handle_entitlement_interactions(
+        data={},
+        event={},
+        user_id="U123",
+        actions=[{"value": "", "action_id": "some-action"}],
+        channel="C123",
+        thread=None,
+        message_ts="123456.789",
+        quick_check_payload=quick_check_payload,
+        user_profile={},
+    )
+
+    assert result is True

--- a/Packs/Slack/ReleaseNotes/3_8_18.md
+++ b/Packs/Slack/ReleaseNotes/3_8_18.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### SlackV3
+
+- Fixed an issue where clicking a button with a non-entitlement value caused the integration to report a collection error in XSIAM, even though the integration continued working normally.

--- a/Packs/Slack/pack_metadata.json
+++ b/Packs/Slack/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Slack",
     "description": "Interact with Slack API - collect logs, send messages and notifications to your Slack team.",
     "support": "xsoar",
-    "currentVersion": "3.8.17",
+    "currentVersion": "3.8.18",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
[XSUP-75552](https://jira-dc.paloaltonetworks.com/browse/XSUP-75552)

## Description
Fixes a bug where the SlackV3 long-running listener crashed with a JSONDecodeError when receiving a Slack interactive payload containing a button with an empty value field ("").


## Must have
- [ ] Tests
- [ ] Documentation
