### PR TITLE
Qualys: default LAST_VM_AUTH_SCAN_DATETIME when missing

### DIFF
--- a/Packs/qualys/Integrations/Qualysv2/Qualysv2.py
+++ b/Packs/qualys/Integrations/Qualysv2/Qualysv2.py
@@ -34,6 +34,12 @@ ASSET_SIZE_LIMIT = 10**6  # 1MB
 TEST_FROM_DATE = "one day"
 FETCH_ASSETS_COMMAND_TIME_OUT = 180
 QIDS_BATCH_SIZE = 500
+# Fields that should always be present on a fetched detection asset, along with their default
+# value to use when missing from the raw Qualys response. Add new entries here in the future
+# instead of scattering ad-hoc `setdefault` calls across the code.
+DEFAULT_DETECTION_ASSET_FIELDS: dict[str, Any] = {
+    "LAST_VM_AUTH_SCAN_DATETIME": None,
+}
 # Retry configuration for Qualys rate-limit (HTTP 409, Error Code 1965) responses.
 RATE_LIMIT_STATUS_CODE = 409
 RATE_LIMIT_TO_WAIT_HEADER = "X-RateLimit-ToWait-Sec"
@@ -2930,6 +2936,19 @@ def add_fields_to_events(events, time_field_path, event_type_field):
             event["event_type"] = event_type_field
 
 
+def apply_default_detection_asset_fields(asset: dict) -> None:
+    """
+    Ensures that fields listed in DEFAULT_DETECTION_ASSET_FIELDS are always present on the asset,
+    filling in the configured default value when a field is missing.
+
+    To add a new default field in the future, simply add an entry to DEFAULT_DETECTION_ASSET_FIELDS.
+
+    :param asset: the detection asset dict to mutate in-place.
+    """
+    for field, default_value in DEFAULT_DETECTION_ASSET_FIELDS.items():
+        asset.setdefault(field, default_value)
+
+
 def truncate_asset_size(asset):
     if results := asset.get("DETECTION", {}).get("RESULTS"):
         results_size = get_size_of_object(results)
@@ -2991,6 +3010,7 @@ def get_detections_from_hosts(hosts):
             new_detection = copy.deepcopy(host)
             del new_detection["DETECTION_LIST"]
             new_detection["DETECTION"] = detection
+            apply_default_detection_asset_fields(new_detection)
             fetched_assets.append(new_detection)
             truncate_asset_size(new_detection)
 

--- a/Packs/qualys/Integrations/Qualysv2/Qualysv2.py
+++ b/Packs/qualys/Integrations/Qualysv2/Qualysv2.py
@@ -2936,7 +2936,7 @@ def add_fields_to_events(events, time_field_path, event_type_field):
             event["event_type"] = event_type_field
 
 
-def apply_default_detection_asset_fields(asset: dict) -> None:
+def apply_default_detection_asset_fields(asset: dict[str, Any]) -> None:
     """
     Ensures that fields listed in DEFAULT_DETECTION_ASSET_FIELDS are always present on the asset,
     filling in the configured default value when a field is missing.

--- a/Packs/qualys/Integrations/Qualysv2/Qualysv2_test.py
+++ b/Packs/qualys/Integrations/Qualysv2/Qualysv2_test.py
@@ -32,6 +32,7 @@ from Qualysv2 import (
     fetch_events,
     get_activity_logs_events,
     fetch_assets,
+    get_detections_from_hosts,
     fetch_vulnerabilities,
     fetch_assets_and_vulnerabilities_by_date,
     fetch_assets_and_vulnerabilities_by_qids,
@@ -203,6 +204,56 @@ def test_fetch_assets_command_time_out(requests_mock: RequestsMocker, mocker, cl
     assets, new_last_run, amount_to_report, snapshot_id, set_new_limit = fetch_assets(client=client, assets_last_run={})
     assert not assets
     assert set_new_limit
+
+
+def test_get_detections_from_hosts_sets_last_vm_auth_scan_datetime_null_when_missing():
+    """
+    Given:
+    - A host that does not contain the LAST_VM_AUTH_SCAN_DATETIME field.
+    When:
+    - Parsing detections from hosts via get_detections_from_hosts.
+    Then:
+    - Ensure the resulting asset has LAST_VM_AUTH_SCAN_DATETIME set to None.
+    """
+    hosts = [
+        {
+            "ID": "1",
+            "IP": "1.1.1.1",
+            "LAST_VM_SCANNED_DATE": "01-01-2020",
+            "DETECTION_LIST": {"DETECTION": [{"QID": "123"}]},
+        }
+    ]
+
+    assets, _ = get_detections_from_hosts(hosts)
+
+    assert len(assets) == 1
+    assert "LAST_VM_AUTH_SCAN_DATETIME" in assets[0]
+    assert assets[0]["LAST_VM_AUTH_SCAN_DATETIME"] is None
+
+
+def test_get_detections_from_hosts_preserves_existing_last_vm_auth_scan_datetime():
+    """
+    Given:
+    - A host that already contains the LAST_VM_AUTH_SCAN_DATETIME field.
+    When:
+    - Parsing detections from hosts via get_detections_from_hosts.
+    Then:
+    - Ensure the existing LAST_VM_AUTH_SCAN_DATETIME value is preserved.
+    """
+    hosts = [
+        {
+            "ID": "1",
+            "IP": "1.1.1.1",
+            "LAST_VM_SCANNED_DATE": "01-01-2020",
+            "LAST_VM_AUTH_SCAN_DATETIME": "2020-01-01T00:00:00Z",
+            "DETECTION_LIST": {"DETECTION": [{"QID": "123"}]},
+        }
+    ]
+
+    assets, _ = get_detections_from_hosts(hosts)
+
+    assert len(assets) == 1
+    assert assets[0]["LAST_VM_AUTH_SCAN_DATETIME"] == "2020-01-01T00:00:00Z"
 
 
 def test_fetch_vulnerabilities_command_by_date(requests_mock: RequestsMocker, client: Client):

--- a/Packs/qualys/ReleaseNotes/3_4_6.md
+++ b/Packs/qualys/ReleaseNotes/3_4_6.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Qualys VMDR
+
+- Fixed an issue where the **fetch-assets** command did not set the *LAST_VM_AUTH_SCAN_DATETIME* field to null when it was missing from an asset.

--- a/Packs/qualys/ReleaseNotes/3_4_6.md
+++ b/Packs/qualys/ReleaseNotes/3_4_6.md
@@ -3,4 +3,4 @@
 
 ##### Qualys VMDR
 
-- Fixed an issue where the **fetch-assets** command did not set the *LAST_VM_AUTH_SCAN_DATETIME* field to null when it was missing from an asset.
+- Fixed an issue where the ***fetch-assets*** command did not set the *LAST_VM_AUTH_SCAN_DATETIME* field to null when it was missing from an asset.

--- a/Packs/qualys/pack_metadata.json
+++ b/Packs/qualys/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Qualys",
     "description": "Qualys Vulnerability Management let's you create, run, fetch and manage reports, launch and manage vulnerability and compliance scans, and manage the host assets you want to scan for vulnerabilities and compliance",
     "support": "xsoar",
-    "currentVersion": "3.4.5",
+    "currentVersion": "3.4.6",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/CRTX-276900
## Description
Added default null values for required fields in the assets schema.

## Must have
- [x] Tests
