### PR TITLE
sklearn: fail build when NLTK data download fails

### DIFF
--- a/Packs/Base/ReleaseNotes/1_42_24.md
+++ b/Packs/Base/ReleaseNotes/1_42_24.md
@@ -1,0 +1,19 @@
+
+#### Scripts
+
+##### DrawRelatedIncidentsCanvas
+
+- Updated the Docker image to: *demisto/sklearn:1.0.0.12545527*.
+
+##### DBotFindSimilarIncidentsByIndicators
+
+- Updated the Docker image to: *demisto/sklearn:1.0.0.12545527*.
+
+##### DBotFindSimilarIncidents
+
+- Updated the Docker image to: *demisto/sklearn:1.0.0.12545527*.
+
+##### FindSimilarIncidentsByText
+
+- Updated the Docker image to: *demisto/sklearn:1.0.0.12545527*.
+

--- a/Packs/Base/Scripts/DBotFindSimilarIncidents/DBotFindSimilarIncidents.yml
+++ b/Packs/Base/Scripts/DBotFindSimilarIncidents/DBotFindSimilarIncidents.yml
@@ -86,7 +86,7 @@ script: '-'
 subtype: python3
 timeout: '0'
 type: python
-dockerimage: demisto/sklearn:1.0.0.10866354
+dockerimage: demisto/sklearn:1.0.0.12545527
 runas: DBotWeakRole
 tests:
 - DBotFindSimilarIncidents-test

--- a/Packs/Base/Scripts/DBotFindSimilarIncidentsByIndicators/DBotFindSimilarIncidentsByIndicators.yml
+++ b/Packs/Base/Scripts/DBotFindSimilarIncidentsByIndicators/DBotFindSimilarIncidentsByIndicators.yml
@@ -42,7 +42,7 @@ script: '-'
 subtype: python3
 timeout: '0'
 type: python
-dockerimage: demisto/sklearn:1.0.0.10866354
+dockerimage: demisto/sklearn:1.0.0.12545527
 runas: DBotWeakRole
 tests:
 - DBotFindSimilarIncidentsByIndicators - Test

--- a/Packs/Base/Scripts/DrawRelatedIncidentsCanvas/DrawRelatedIncidentsCanvas.yml
+++ b/Packs/Base/Scripts/DrawRelatedIncidentsCanvas/DrawRelatedIncidentsCanvas.yml
@@ -34,7 +34,7 @@ script: '-'
 subtype: python3
 timeout: '0'
 type: python
-dockerimage: demisto/sklearn:1.0.0.10866354
+dockerimage: demisto/sklearn:1.0.0.12545527
 runas: DBotWeakRole
 tests:
 - No tests (auto formatted)

--- a/Packs/Base/Scripts/FindSimilarIncidentsByText/FindSimilarIncidentsByText.yml
+++ b/Packs/Base/Scripts/FindSimilarIncidentsByText/FindSimilarIncidentsByText.yml
@@ -78,7 +78,7 @@ tags:
 - incidents
 timeout: '0'
 type: python
-dockerimage: demisto/sklearn:1.0.0.10866354
+dockerimage: demisto/sklearn:1.0.0.12545527
 runonce: true
 tests:
 - No test

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.42.23",
+    "currentVersion": "1.42.24",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",

--- a/Packs/Campaign/ReleaseNotes/3_4_31.md
+++ b/Packs/Campaign/ReleaseNotes/3_4_31.md
@@ -1,0 +1,7 @@
+
+#### Scripts
+
+##### FindEmailCampaign
+
+- Updated the Docker image to: *demisto/sklearn:1.0.0.12545527*.
+

--- a/Packs/Campaign/Scripts/FindEmailCampaign/FindEmailCampaign.yml
+++ b/Packs/Campaign/Scripts/FindEmailCampaign/FindEmailCampaign.yml
@@ -126,7 +126,7 @@ tags:
 - phishing
 timeout: '0'
 type: python
-dockerimage: demisto/sklearn:1.0.0.10866354
+dockerimage: demisto/sklearn:1.0.0.12545527
 tests:
 - Detect & Manage Phishing Campaigns - Test
 fromversion: 5.0.0

--- a/Packs/Campaign/pack_metadata.json
+++ b/Packs/Campaign/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Phishing Campaign",
     "description": "This pack can help you find related phishing, spam or other types of email incidents and characterize campaigns.",
     "support": "xsoar",
-    "currentVersion": "3.4.30",
+    "currentVersion": "3.4.31",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",

--- a/Packs/Phishing/ReleaseNotes/3_8_6.md
+++ b/Packs/Phishing/ReleaseNotes/3_8_6.md
@@ -1,0 +1,11 @@
+
+#### Scripts
+
+##### FindDuplicateEmailIncidents
+
+- Updated the Docker image to: *demisto/sklearn:1.0.0.12545527*.
+
+##### PhishingDedupPreprocessingRule
+
+- Updated the Docker image to: *demisto/sklearn:1.0.0.12545527*.
+

--- a/Packs/Phishing/Scripts/FindDuplicateEmailIncidents/FindDuplicateEmailIncidents.yml
+++ b/Packs/Phishing/Scripts/FindDuplicateEmailIncidents/FindDuplicateEmailIncidents.yml
@@ -109,7 +109,7 @@ tags:
 - phishing
 timeout: 600ns
 type: python
-dockerimage: demisto/sklearn:1.0.0.10866354
+dockerimage: demisto/sklearn:1.0.0.12545527
 tests:
 - Detect & Manage Phishing Campaigns - Test
 fromversion: 5.0.0

--- a/Packs/Phishing/Scripts/PhishingDedupPreprocessingRule/PhishingDedupPreprocessingRule.yml
+++ b/Packs/Phishing/Scripts/PhishingDedupPreprocessingRule/PhishingDedupPreprocessingRule.yml
@@ -87,5 +87,5 @@ tags:
 - phishing
 timeout: '0'
 type: python
-dockerimage: demisto/sklearn:1.0.0.10866354
+dockerimage: demisto/sklearn:1.0.0.12545527
 fromversion: 5.0.0

--- a/Packs/Phishing/pack_metadata.json
+++ b/Packs/Phishing/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Phishing",
     "description": "Phishing emails still hooking your end users? This Content Pack can drastically reduce the time your security team spends on phishing alerts.",
     "support": "xsoar",
-    "currentVersion": "3.8.5",
+    "currentVersion": "3.8.6",
     "serverMinVersion": "6.0.0",
     "videos": [
         "https://www.youtube.com/watch?v=SY-3L348PoY"


### PR DESCRIPTION
## Related Issues
<!-- To link a Jira ticket use fixes/related: link to the issue, for example fixes: CIAC-XXXX -->
fixes: XSUP-75716
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
https://github.com/demisto/dockerfiles/pull/46298

Error:
```
LookupError:
**********************************************************************
Resource 'punkt_tab' not found.
Please use the NLTK Downloader to obtain the resource:

>>> import nltk
>>> nltk.download('punkt_tab')

Attempted to load 'tokenizers/punkt_tab/english/'

Searched in:
- '/root/nltk_data'
- '/usr/local/nltk_data'
********************************************************************** 
```