### PR TITLE
Enterprise DLP: migrate incident fetch to v4 incident-inventory API

### DIFF
--- a/Packs/Palo_Alto_Networks_Enterprise_DLP/Integrations/Palo_Alto_Networks_Enterprise_DLP/Palo_Alto_Networks_Enterprise_DLP.py
+++ b/Packs/Palo_Alto_Networks_Enterprise_DLP/Integrations/Palo_Alto_Networks_Enterprise_DLP/Palo_Alto_Networks_Enterprise_DLP.py
@@ -26,8 +26,6 @@ UPDATE_INCIDENT_URL = "public/incident-feedback"
 SLEEP_TIME_URL = "public/seconds-between-incident-notifications-pull"
 V4_INCIDENTS_PATH = "/v4/api/incidents"
 V4_PAGE_SIZE = 1000
-V4_PENDING_ATTEMPTS = 3  # times to re-poll the query token while the backend reports PENDING
-V4_PENDING_SLEEP = 2  # seconds between PENDING polls
 FETCH_SLEEP = 5  # sleep between fetches (in seconds)
 LAST_FETCH_TIME = "last_fetch_time"
 DEFAULT_FIRST_FETCH = "60 minutes"
@@ -817,21 +815,32 @@ def fetch_notifications(
 
     # A single query covers every configured region, so the watermark below is derived
     # from all of them rather than from whichever region happened to be queried last.
-    resp, _ = client.get_incidents_first_page(start_time_ms=start_time_ms, end_time_ms=end_time_ms, regions=regions)
+    resp, status_code = client.get_incidents_first_page(start_time_ms=start_time_ms, end_time_ms=end_time_ms, regions=regions)
+    rows: list[dict] = resp.get("rows") or []
+    demisto.debug(f"First page: {len(rows)} rows, total_rows={resp.get('total_rows')}, status={resp.get('status')}.")
+
+    # Persist a token that may have been refreshed during the call above before returning early.
+    demisto.debug("Updating integration context with access token.")
+    demisto.setIntegrationContext({ACCESS_TOKEN: client.access_token})
+
+    # An unread window must not be treated as an empty one. compute_next_run advances the
+    # watermark whenever no incidents are returned, so returning early without touching the
+    # last run is what keeps a failed query from skipping the window it never read.
+    if status_code not in (200, 201, 204):
+        error_message = resp.get("error") or "Could not determine the error reason."
+        raise DemistoException(
+            f"Failed to query incidents, got status code {status_code}. {error_message} "
+            "The last run was left unchanged, so this time window is re-queried on the next fetch."
+        )
+
+    # The backend can acknowledge a query before its results are ready. Rather than polling
+    # within the fetch, the same window is re-queried on the next fetch, widened to "now".
+    if resp.get("status") == "PENDING" and not rows:
+        demisto.debug("Query results are not ready yet. Leaving the last run unchanged to re-query this window.")
+        return last_run, []
+
     query_token = resp.get("query_token") or ""
     total_rows = resp.get("total_rows") or 0
-    rows: list[dict] = resp.get("rows") or []
-    demisto.debug(f"First page: {len(rows)} rows, {total_rows=}, status={resp.get('status')}.")
-
-    # The backend can acknowledge the query before its results are ready.
-    attempts = 0
-    while resp.get("status") == "PENDING" and not rows and query_token and attempts < V4_PENDING_ATTEMPTS:
-        attempts += 1
-        demisto.debug(f"Query is PENDING, re-polling the query token (attempt {attempts}).")
-        time.sleep(V4_PENDING_SLEEP)
-        resp, _ = client.get_incidents_next_page(query_token, 0)
-        rows = resp.get("rows") or []
-        total_rows = resp.get("total_rows") or total_rows
 
     offset = 0
     while rows:
@@ -862,9 +871,6 @@ def fetch_notifications(
 
     demisto.debug(f"Finished fetching. Got {len(new_incidents)} new incidents.")
     demisto.debug(f"Fetched incidents: {[inc.get('name') for inc in new_incidents]}.")
-
-    demisto.debug("Updating integration context with access token.")
-    demisto.setIntegrationContext({ACCESS_TOKEN: client.access_token})
 
     next_run = compute_next_run(
         fetched_incident_ids_committed_timestamps,

--- a/Packs/Palo_Alto_Networks_Enterprise_DLP/Integrations/Palo_Alto_Networks_Enterprise_DLP/Palo_Alto_Networks_Enterprise_DLP.py
+++ b/Packs/Palo_Alto_Networks_Enterprise_DLP/Integrations/Palo_Alto_Networks_Enterprise_DLP/Palo_Alto_Networks_Enterprise_DLP.py
@@ -251,7 +251,7 @@ class Client(BaseClient):
         self,
         start_time_ms: int,
         end_time_ms: int,
-        regions: str = "",
+        regions: str | list[str] | None = None,
         page_size: int = V4_PAGE_SIZE,
     ) -> tuple[dict[str, Any], int]:
         """Start a v4 incident inventory query and fetch its first page.
@@ -259,7 +259,7 @@ class Client(BaseClient):
         Args:
             start_time_ms: Start time in epoch milliseconds (inclusive).
             end_time_ms: End time in epoch milliseconds (inclusive).
-            regions: Comma-separated DLP regions. Empty = all regions.
+            regions: DLP regions, as a list or a comma-separated string. Empty = all regions.
             page_size: Rows per page.
 
         Returns:
@@ -546,7 +546,7 @@ def parse_incident_details(compressed_details: str):
     return details_obj
 
 
-def build_region_filter(regions: str) -> str:
+def build_region_filter(regions: str | list[str] | None) -> str:
     """
     Build the v4 server-side filter expression for the configured regions.
 
@@ -554,12 +554,14 @@ def build_region_filter(regions: str) -> str:
     cannot alter the filter expression.
 
     Args:
-        regions: Comma-separated DLP regions (e.g. "us,eu").
+        regions: DLP regions, either as a list (the *DLP Regions* multi-select
+            parameter is handed to the integration as a list) or as a
+            comma-separated string.
 
     Returns:
         str: Filter expression, or an empty string when no valid region is configured.
     """
-    tokens = [region.strip().upper() for region in regions.split(",")] if regions else []
+    tokens = [str(region).strip().upper() for region in argToList(regions)]
     tokens = [region for region in tokens if re.fullmatch(r"[A-Z0-9_]+", region)]
     if not tokens:
         return ""
@@ -761,7 +763,7 @@ def _migrate_last_run(last_run: dict[str, Any], start_timestamp: int) -> dict[st
 
 def fetch_notifications(
     client: Client,
-    regions: str,
+    regions: str | list[str] | None,
     first_fetch_timestamp: int,
     incident_type: str = "Data Loss Prevention",
     max_fetch: int = DEFAULT_MAX_FETCH,
@@ -772,7 +774,7 @@ def fetch_notifications(
 
     Args:
         client (Client): DLP API client.
-        regions (str): Comma-separated DLP regions to fetch from.
+        regions (str | list[str] | None): DLP regions to fetch from, as a list or a comma-separated string.
         first_fetch_timestamp (int): Timestamp to use for first fetch (unix epoch seconds).
         incident_type (str): Type of incident to create (default: "Data Loss Prevention").
         max_fetch (int): Maximum number of incidents to fetch (default: DEFAULT_MAX_FETCH).

--- a/Packs/Palo_Alto_Networks_Enterprise_DLP/Integrations/Palo_Alto_Networks_Enterprise_DLP/Palo_Alto_Networks_Enterprise_DLP.py
+++ b/Packs/Palo_Alto_Networks_Enterprise_DLP/Integrations/Palo_Alto_Networks_Enterprise_DLP/Palo_Alto_Networks_Enterprise_DLP.py
@@ -24,6 +24,10 @@ INCIDENTS_URL = "public/incident-notifications"
 REFRESH_TOKEN_URL = "public/oauth/refreshToken"
 UPDATE_INCIDENT_URL = "public/incident-feedback"
 SLEEP_TIME_URL = "public/seconds-between-incident-notifications-pull"
+V4_INCIDENTS_PATH = "/v4/api/incidents"
+V4_PAGE_SIZE = 1000
+V4_PENDING_ATTEMPTS = 3  # times to re-poll the query token while the backend reports PENDING
+V4_PENDING_SLEEP = 2  # seconds between PENDING polls
 FETCH_SLEEP = 5  # sleep between fetches (in seconds)
 LAST_FETCH_TIME = "last_fetch_time"
 DEFAULT_FIRST_FETCH = "60 minutes"
@@ -132,28 +136,36 @@ class Client(BaseClient):
         except Exception:
             pass
 
-    def _get_dlp_api_call(self, url_suffix: str, extra_headers: dict[str, str] | None = None) -> tuple[dict[str, Any], int]:
+    def _get_dlp_api_call(
+        self, url_suffix: str = "", full_url: str = "", extra_headers: dict[str, str] | None = None
+    ) -> tuple[dict[str, Any], int]:
         """
         Makes a HTTPS Get call on the DLP API
         Args:
             url_suffix: URL suffix for dlp api call
+            full_url: Absolute URL (takes precedence over url_suffix)
             extra_headers: Optional additional request headers
         """
         count = 0
-        print_debug_msg(f"Calling GET method on {self._base_url}{url_suffix}")
+        log_url = full_url or f"{self._base_url}{url_suffix}"
+        print_debug_msg(f"Calling GET method on {log_url}")
         while count < MAX_ATTEMPTS:
             headers = {"Authorization": "Bearer " + self.access_token}
             if extra_headers:
                 headers.update(extra_headers)
-            res = self._http_request(
-                method="GET",
-                headers=headers,
-                url_suffix=url_suffix,
-                ok_codes=[200, 201, 204],
-                error_handler=self._handle_4xx_errors,
-                resp_type="",
-                return_empty_response=True,
-            )
+            http_kwargs: dict[str, Any] = {
+                "method": "GET",
+                "headers": headers,
+                "ok_codes": [200, 201, 204],
+                "error_handler": self._handle_4xx_errors,
+                "resp_type": "",
+                "return_empty_response": True,
+            }
+            if full_url:
+                http_kwargs["full_url"] = full_url
+            else:
+                http_kwargs["url_suffix"] = url_suffix
+            res = self._http_request(**http_kwargs)
             if res.status_code < 400 or res.status_code >= 500:
                 break
             count += 1
@@ -168,12 +180,13 @@ class Client(BaseClient):
 
         return result_json, res.status_code
 
-    def _post_dlp_api_call(self, url_suffix: str, payload: dict = None):
+    def _post_dlp_api_call(self, url_suffix: str = "", payload: dict = None, full_url: str = ""):
         """
         Makes a POST HTTP(s) call to the DLP API
         Args:
             url_suffix: URL suffix for dlp api call
             payload: Optional JSON payload
+            full_url: Absolute URL (takes precedence over url_suffix)
         """
         count = 0
 
@@ -182,6 +195,7 @@ class Client(BaseClient):
                 method="POST",
                 headers={"Authorization": f"Bearer {self.access_token}"},
                 url_suffix=url_suffix,
+                full_url=full_url or None,
                 json_data=payload,
                 ok_codes=[200, 201, 204],
                 error_handler=self._handle_4xx_errors,
@@ -221,26 +235,64 @@ class Client(BaseClient):
             url = url + "?fetchSnippets=true"
 
         extra_headers = {SERVICE_NAME_HEADER: service_name} if service_name else None
-        return self._get_dlp_api_call(url, extra_headers)
+        return self._get_dlp_api_call(url, extra_headers=extra_headers)
 
-    def get_dlp_incidents(
+    def _v4_incidents_url(self) -> str:
+        """Build the absolute v4 incidents URL from the configured base URL's host.
+
+        The v4 API is not versioned under the v1 base path, so only the scheme and
+        host are reused. Deriving the path by string replacement on ``base_url``
+        silently no-ops when the URL is customized, so it is not used here.
+        """
+        parsed = urllib.parse.urlparse(self._base_url)
+        return f"{parsed.scheme}://{parsed.netloc}{V4_INCIDENTS_PATH}"
+
+    def get_incidents_first_page(
         self,
-        regions: str,
-        start_time: int | None = None,
-        end_time: int | None = None,
+        start_time_ms: int,
+        end_time_ms: int,
+        regions: str = "",
+        page_size: int = V4_PAGE_SIZE,
     ) -> tuple[dict[str, Any], int]:
-        url = INCIDENTS_URL
-        params = {}
-        if regions:
-            params["regions"] = regions
-        if start_time:
-            params["start_timestamp"] = str(start_time)
-        if end_time:
-            params["end_timestamp"] = str(end_time)
-        query_string = urllib.parse.urlencode(params)
-        url = f"{url}?{query_string}"
-        resp, status_code = self._get_dlp_api_call(url)
-        return resp, status_code
+        """Start a v4 incident inventory query and fetch its first page.
+
+        Args:
+            start_time_ms: Start time in epoch milliseconds (inclusive).
+            end_time_ms: End time in epoch milliseconds (inclusive).
+            regions: Comma-separated DLP regions. Empty = all regions.
+            page_size: Rows per page.
+
+        Returns:
+            (response_json, status_code) — response contains ``rows``, ``status``,
+            ``query_token`` and ``total_rows``.
+        """
+        payload: dict[str, Any] = {
+            "time_range": "CUSTOM",
+            "start_time": start_time_ms,
+            "end_time": end_time_ms,
+            "sort_by": "IncidentCreatedDate",
+            "sort_order": "ASC",
+            "page_size": page_size,
+        }
+        region_filter = build_region_filter(regions)
+        if region_filter:
+            payload["filter"] = region_filter
+
+        return self._post_dlp_api_call(full_url=self._v4_incidents_url(), payload=payload)
+
+    def get_incidents_next_page(self, token: str, offset: int, page_size: int = V4_PAGE_SIZE) -> tuple[dict[str, Any], int]:
+        """Fetch a subsequent page of an already-started v4 inventory query.
+
+        Args:
+            token: Query token returned by ``get_incidents_first_page``.
+            offset: Zero-indexed row offset into the query result set.
+            page_size: Rows per page.
+
+        Returns:
+            (response_json, status_code)
+        """
+        query_string = urllib.parse.urlencode({"token": token, "offset": offset, "pageSize": page_size})
+        return self._get_dlp_api_call(full_url=f"{self._v4_incidents_url()}?{query_string}")
 
     def update_dlp_incident(
         self,
@@ -433,8 +485,11 @@ def get_dlp_report_command(client: Client, args: dict) -> CommandResults:
 
 def test(client: Client, params: dict):
     """Test Function to test validity of access and refresh tokens"""
-    dlp_regions = params.get("dlp_regions", "")
-    report_json, status_code = client.get_dlp_incidents(regions=dlp_regions)
+    now_ms = int(datetime.now(tz=UTC).timestamp() * 1000)
+    one_hour_ago_ms = now_ms - 3_600_000
+    report_json, status_code = client.get_incidents_first_page(
+        start_time_ms=one_hour_ago_ms, end_time_ms=now_ms, regions=params.get("dlp_regions", ""), page_size=1
+    )
     if status_code in [200, 204]:
         return_results("ok")
     else:
@@ -491,41 +546,109 @@ def parse_incident_details(compressed_details: str):
     return details_obj
 
 
-def create_incident(notification: dict, region: str, incident_type: str = "Data Loss Prevention") -> dict[str, Any]:
+def build_region_filter(regions: str) -> str:
     """
-    Create an XSOAR incident from a DLP notification.
+    Build the v4 server-side filter expression for the configured regions.
+
+    Region tokens are whitelisted to ``[A-Z0-9_]`` so an operator-supplied value
+    cannot alter the filter expression.
 
     Args:
-        notification: DLP notification containing incident data and previous notifications
-        region: DLP region where the incident occurred
-        incident_type: Type of incident to create (default: "Data Loss Prevention")
+        regions: Comma-separated DLP regions (e.g. "us,eu").
 
     Returns:
-        dict[str, Any]: XSOAR incident object with name, type, occurred time, and raw JSON data
+        str: Filter expression, or an empty string when no valid region is configured.
     """
-    raw_incident = notification["incident"]
-    previous_notifications = notification["previous_notifications"]
-    raw_incident["region"] = region
-    raw_incident["previousNotification"] = previous_notifications[0] if len(previous_notifications) > 0 else None
-    parsed_details = parse_incident_details(raw_incident["incidentDetails"])
-    raw_incident["incidentDetails"] = parsed_details
-    if not raw_incident.get("userId"):
-        for header in parsed_details.get("headers", []):
-            attribute_name = header.get("attribute_name")
-            attribute_value = header.get("attribute_value")
-            if attribute_name == "username" and attribute_value:
-                raw_incident["userId"] = attribute_value
+    tokens = [region.strip().upper() for region in regions.split(",")] if regions else []
+    tokens = [region for region in tokens if re.fullmatch(r"[A-Z0-9_]+", region)]
+    if not tokens:
+        return ""
+    return "Region in ({})".format(", ".join(f"'{region}'" for region in tokens))
 
-    incident_creation_time = cast(datetime, dateparser.parse(raw_incident["createdAt"]))
-    incident_id = raw_incident["incidentId"]
-    incident_timestamp = int(incident_creation_time.timestamp())
-    demisto.debug(f"Creating new incident with {incident_id=} and {incident_timestamp=} in {region=}.")
+
+def parse_created_date(value: Any) -> datetime | None:
+    """
+    Normalize a v4 ``created_date`` into a timezone-aware datetime.
+
+    The field is typed as a number but the unit is not pinned by the contract —
+    seconds, milliseconds and microseconds all appear — so the magnitude decides.
+    Strings are handed to ``dateparser``.
+
+    Args:
+        value: Raw ``created_date`` value from a v4 inventory row.
+
+    Returns:
+        datetime | None: Parsed timestamp, or None when it cannot be parsed.
+    """
+    if value is None or value == "":
+        return None
+
+    if isinstance(value, (int, float)) or (isinstance(value, str) and value.strip().lstrip("-").isdigit()):
+        seconds = float(value)
+        if abs(seconds) >= 1e14:  # microseconds
+            seconds /= 1_000_000
+        elif abs(seconds) >= 1e11:  # milliseconds
+            seconds /= 1_000
+        try:
+            return datetime.fromtimestamp(seconds, tz=UTC)
+        except (OverflowError, OSError, ValueError):
+            return None
+
+    return dateparser.parse(str(value), settings={"TIMEZONE": "UTC", "RETURN_AS_TIMEZONE_AWARE": True})
+
+
+def create_incident(row: dict, created_at: datetime, incident_type: str = "Data Loss Prevention") -> dict[str, Any]:
+    """
+    Create an XSOAR incident from a v4 incident inventory row.
+
+    Maps the flat v4 row onto the rawJSON keys the v1 fetch emitted — including the
+    nested ``previousNotification`` and ``incidentDetails.headers`` shapes — so that
+    downstream classifiers, layouts and playbooks keep resolving unchanged.
+
+    Args:
+        row: Single item from the v4 ``rows`` array.
+        created_at: Parsed incident creation time.
+        incident_type: Incident type label (default: "Data Loss Prevention").
+
+    Returns:
+        dict[str, Any]: XSOAR incident dict.
+    """
+    incident_id = row.get("incident_id", "")
+    control_point = row.get("control_point") or ""
+    # The server unwraps the data profiles JSON and derives data_profile_id from the
+    # last element, so the matching name/version come from the same element.
+    data_profiles = row.get("data_profiles") or []
+    data_profile = data_profiles[-1] if data_profiles else {}
+
+    raw_incident: dict[str, Any] = {
+        "incidentId": incident_id,
+        "userId": row.get("source"),
+        "tenantId": None,
+        "reportId": row.get("report_id"),
+        "dataProfileId": row.get("data_profile_id"),
+        "dataProfileName": data_profile.get("name"),
+        "dataProfileVersion": data_profile.get("version"),
+        "action": row.get("action"),
+        "channel": control_point.lower().replace("_", "-"),
+        "filename": row.get("asset_name"),
+        "checksum": None,
+        "fileType": None,
+        "source": control_point,
+        "appId": None,
+        "appName": None,
+        "createdAt": created_at.isoformat(),
+        "region": row.get("source_region"),
+        "previousNotification": {"feedback_status": row.get("feedback_status")},
+        "incidentDetails": {"headers": [{"attribute_name": "severity", "attribute_value": row.get("severity")}]},
+    }
+
+    demisto.debug(f"Creating new incident with {incident_id=} in region={raw_incident['region']}.")
     event_dump = json.dumps(raw_incident)
 
     return {
         "name": f"Palo Alto Networks DLP Incident {incident_id}",
         "type": incident_type,
-        "occurred": incident_creation_time.isoformat(),
+        "occurred": created_at.isoformat(),
         "rawJSON": event_dump,
         "details": event_dump,
     }
@@ -685,51 +808,58 @@ def fetch_notifications(
     )
 
     new_incidents: list[dict] = []
-    last_queried_end_time: int = effective_start_timestamp
 
-    # Query the API in 3 minute start/end time window, this filters incidents according to their "committedAt" timestamps
-    start_end_time_intervals = get_start_end_time_intervals(effective_start_timestamp, end_timestamp, seconds_delta=180)
-    for api_call_number, (start_time, end_time) in enumerate(start_end_time_intervals, start=1):
-        if len(new_incidents) >= max_fetch:
-            demisto.debug(f"Reached or exceeded fetch limit. Fetched {len(new_incidents)} incidents. Breaking...")
-            break
+    # Convert to milliseconds for the v4 API
+    start_time_ms = effective_start_timestamp * 1000
+    end_time_ms = end_timestamp * 1000
 
-        if api_call_number > MAX_API_CALLS_PER_FETCH:
-            demisto.debug(f"Reached or exceeded maximum number of API calls per fetch. Fetched {len(new_incidents)} incidents. ")
-            break
+    # A single query covers every configured region, so the watermark below is derived
+    # from all of them rather than from whichever region happened to be queried last.
+    resp, _ = client.get_incidents_first_page(start_time_ms=start_time_ms, end_time_ms=end_time_ms, regions=regions)
+    query_token = resp.get("query_token") or ""
+    total_rows = resp.get("total_rows") or 0
+    rows: list[dict] = resp.get("rows") or []
+    demisto.debug(f"First page: {len(rows)} rows, {total_rows=}, status={resp.get('status')}.")
 
-        demisto.debug(f"Getting incidents between {start_time=} and {end_time=} from {regions=}.")
-        notification_map, _ = client.get_dlp_incidents(regions, start_time, end_time)
-        last_queried_end_time = end_time
+    # The backend can acknowledge the query before its results are ready.
+    attempts = 0
+    while resp.get("status") == "PENDING" and not rows and query_token and attempts < V4_PENDING_ATTEMPTS:
+        attempts += 1
+        demisto.debug(f"Query is PENDING, re-polling the query token (attempt {attempts}).")
+        time.sleep(V4_PENDING_SLEEP)
+        resp, _ = client.get_incidents_next_page(query_token, 0)
+        rows = resp.get("rows") or []
+        total_rows = resp.get("total_rows") or total_rows
 
-        notifications = [
-            {**raw_notification, "region": region}
-            for region, raw_notifications in notification_map.items()
-            for raw_notification in raw_notifications
-        ]
-        demisto.debug(f"Received {len(notifications)} notifications between {start_time=} and {end_time=}.")
-        notifications.sort(key=lambda x: x["incident"]["committedAt"])
-
-        for notification in notifications:
-            # Use "incidentId" and "committedAt" fields for deduplication and last run tracking
-            # These are required fields that are guaranteed to exist for each DLP incident
-            region = notification["region"]
-            incident_id = notification["incident"]["incidentId"]
-            incident_committed_timestamp = int(dateparser.parse(notification["incident"]["committedAt"]).timestamp())  # type: ignore
-            if incident_id in fetched_incident_ids_committed_timestamps:
-                demisto.debug(f"Skipping duplicate {incident_id=} with {incident_committed_timestamp=} in {region=}.")
-                continue
-
+    offset = 0
+    while rows:
+        offset += len(rows)
+        for row in rows:
             if len(new_incidents) >= max_fetch:
-                demisto.debug(f"Reached or exceeded fetch limit. Fetched {len(new_incidents)} incidents. Breaking...")
                 break
 
-            incident = create_incident(notification, region, incident_type)
-            new_incidents.append(incident)
-            fetched_incident_ids_committed_timestamps[incident_id] = incident_committed_timestamp
+            incident_id = row.get("incident_id", "")
+            if incident_id in fetched_incident_ids_committed_timestamps:
+                demisto.debug(f"Skipping duplicate {incident_id=}.")
+                continue
 
-    demisto.debug(f"Finished fetching incidents using {max_fetch=} between {effective_start_timestamp=} and {end_timestamp=}.")
-    demisto.debug(f"Fetched {len(new_incidents)} deduplicated incidents: {[inc.get('name') for inc in new_incidents]}.")
+            created_at = parse_created_date(row.get("created_date"))
+            if created_at is None:
+                demisto.debug(f"Skipping {incident_id=}, unparsable created_date={row.get('created_date')!r}.")
+                continue
+
+            new_incidents.append(create_incident(row, created_at, incident_type))
+            fetched_incident_ids_committed_timestamps[incident_id] = int(created_at.timestamp())
+
+        if len(new_incidents) >= max_fetch or not query_token or (total_rows and offset >= total_rows):
+            break
+
+        resp, _ = client.get_incidents_next_page(query_token, offset)
+        rows = resp.get("rows") or []
+        demisto.debug(f"Fetched {len(rows)} rows at {offset=}.")
+
+    demisto.debug(f"Finished fetching. Got {len(new_incidents)} new incidents.")
+    demisto.debug(f"Fetched incidents: {[inc.get('name') for inc in new_incidents]}.")
 
     demisto.debug("Updating integration context with access token.")
     demisto.setIntegrationContext({ACCESS_TOKEN: client.access_token})
@@ -739,7 +869,7 @@ def fetch_notifications(
         last_run=last_run,
         look_back_minutes=look_back_minutes,
         has_new_incidents=bool(new_incidents),
-        last_queried_end_time=last_queried_end_time,
+        last_queried_end_time=end_timestamp,
     )
     demisto.debug(f"Computed updated {next_run=}.")
     return next_run, new_incidents

--- a/Packs/Palo_Alto_Networks_Enterprise_DLP/Integrations/Palo_Alto_Networks_Enterprise_DLP/Palo_Alto_Networks_Enterprise_DLP_test.py
+++ b/Packs/Palo_Alto_Networks_Enterprise_DLP/Integrations/Palo_Alto_Networks_Enterprise_DLP/Palo_Alto_Networks_Enterprise_DLP_test.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime
 
 import demistomock as demisto
 import pytest
+from CommonServerPython import DemistoException
 from freezegun import freeze_time
 from Palo_Alto_Networks_Enterprise_DLP import (
     DEFAULT_BASE_URL as DLP_URL,
@@ -1021,33 +1022,46 @@ def test_fetch_notifications_pages_until_empty_when_total_rows_missing(requests_
 
 
 @freeze_time("2022-04-01 20:25:00 UTC")
-def test_fetch_notifications_repolls_pending_query(requests_mock, mocker):
+def test_fetch_notifications_pending_query_holds_watermark(requests_mock, mocker):
     """
     Given:
         - A first page that is acknowledged as PENDING with no rows.
     When:
         - Calling fetch_notifications.
     Then:
-        - Ensure the query token is re-polled until rows are ready, rather than treating the
-          empty PENDING page as an empty result set.
+        - Ensure the last run is returned unchanged, so the same window is re-queried on the
+          next fetch rather than being skipped as an empty one.
     """
-    mocker.patch("Palo_Alto_Networks_Enterprise_DLP.time.sleep")
     requests_mock.post(V4_INCIDENTS_URL, json={"rows": [], "status": "PENDING", "query_token": "tok-1"})
-    requests_mock.get(
-        V4_INCIDENTS_URL,
-        [
-            {"json": {"rows": [], "status": "PENDING"}},
-            {"json": {"rows": [V4_ROW], "status": "READY", "total_rows": 1}},
-        ],
-    )
 
-    _mock_fetch_env(mocker)
+    last_run = {START_TIMESTAMP_KEY: 1648844000, LAST_IDS_TIMESTAMPS_KEY: {"seen-1": 1648844000}}
+    _mock_fetch_env(mocker, last_run)
 
     client = Client(DLP_URL, AUTH_URL, CREDENTIALS, True, False)
-    _, incidents = fetch_notifications(client, "us", first_fetch_timestamp=1648844000)
+    next_run, incidents = fetch_notifications(client, "us", first_fetch_timestamp=1648844000)
 
-    assert len(incidents) == 1
-    assert V4_ROW["incident_id"] in incidents[0]["name"]
+    assert incidents == []
+    assert next_run == last_run
+
+
+@freeze_time("2022-04-01 20:25:00 UTC")
+def test_fetch_notifications_raises_on_query_failure(requests_mock, mocker):
+    """
+    Given:
+        - An incident query that fails with a server error.
+    When:
+        - Calling fetch_notifications.
+    Then:
+        - Ensure it raises rather than returning an empty result set, so the last run is never
+          advanced past a window that was not read.
+    """
+    requests_mock.post(V4_INCIDENTS_URL, json={"error": "internal error"}, status_code=500)
+
+    _mock_fetch_env(mocker, {START_TIMESTAMP_KEY: 1648844000})
+
+    client = Client(DLP_URL, AUTH_URL, CREDENTIALS, True, False)
+    with pytest.raises(DemistoException, match="500"):
+        fetch_notifications(client, "us", first_fetch_timestamp=1648844000)
 
 
 @freeze_time("2022-04-01 20:25:00 UTC")

--- a/Packs/Palo_Alto_Networks_Enterprise_DLP/Integrations/Palo_Alto_Networks_Enterprise_DLP/Palo_Alto_Networks_Enterprise_DLP_test.py
+++ b/Packs/Palo_Alto_Networks_Enterprise_DLP/Integrations/Palo_Alto_Networks_Enterprise_DLP/Palo_Alto_Networks_Enterprise_DLP_test.py
@@ -360,6 +360,24 @@ def test_get_incidents_first_page_without_regions(requests_mock):
     assert "filter" not in requests_mock.last_request.json()
 
 
+def test_get_incidents_first_page_with_regions_as_list(requests_mock):
+    """
+    Given:
+        - The regions value as the *DLP Regions* multi-select parameter supplies it, a list.
+    When:
+        - Calling get_incidents_first_page.
+    Then:
+        - Ensure the region filter is built from the list, so a configured multi-select
+          does not break the fetch.
+    """
+    requests_mock.post(V4_INCIDENTS_URL, json={"rows": [], "status": "READY"})
+
+    client = Client(DLP_URL, AUTH_URL, CREDENTIALS, True, False)
+    client.get_incidents_first_page(start_time_ms=1000, end_time_ms=2000, regions=["US", "EU"])
+
+    assert requests_mock.last_request.json()["filter"] == "Region in ('US', 'EU')"
+
+
 def test_get_incidents_next_page(requests_mock):
     """
     Given:
@@ -407,12 +425,16 @@ def test_v4_url_ignores_custom_base_path(requests_mock):
         pytest.param("", "", id="empty_string"),
         pytest.param("us,'; DROP TABLE--", "Region in ('US')", id="injection_token_dropped"),
         pytest.param("!!!", "", id="all_tokens_invalid"),
+        pytest.param(["us", "eu"], "Region in ('US', 'EU')", id="list_as_sent_by_multiselect_param"),
+        pytest.param([], "", id="empty_list"),
+        pytest.param(None, "", id="unset"),
     ],
 )
 def test_build_region_filter(regions, expected):
     """
     Given:
-        - A comma-separated region configuration value.
+        - A region configuration value, either as the list the *DLP Regions* multi-select
+          parameter produces or as a comma-separated string.
     When:
         - Calling build_region_filter.
     Then:

--- a/Packs/Palo_Alto_Networks_Enterprise_DLP/Integrations/Palo_Alto_Networks_Enterprise_DLP/Palo_Alto_Networks_Enterprise_DLP_test.py
+++ b/Packs/Palo_Alto_Networks_Enterprise_DLP/Integrations/Palo_Alto_Networks_Enterprise_DLP/Palo_Alto_Networks_Enterprise_DLP_test.py
@@ -1,5 +1,5 @@
 import json
-from datetime import UTC
+from datetime import UTC, datetime
 
 import demistomock as demisto
 import pytest
@@ -8,15 +8,16 @@ from Palo_Alto_Networks_Enterprise_DLP import (
     DEFAULT_BASE_URL as DLP_URL,
     DEFAULT_AUTH_URL as AUTH_URL,
     Client,
+    build_region_filter,
     exemption_eligible_command,
     fetch_notifications,
     main,
+    parse_created_date,
     parse_dlp_report,
     parse_incident_details,
     slack_bot_message_command,
     update_incident_command,
     create_incident,
-    arg_to_datetime,
     compute_next_run,
     get_start_end_time_intervals,
     _migrate_last_run,
@@ -309,12 +310,147 @@ def test_parse_dlp_report(mocker):
     assert data_profiles[0]["DataPatterns"][1]["OccurrenceHigh"] == 10
 
 
-def test_get_dlp_incidents(requests_mock):
-    requests_mock.get(f"{DLP_URL}public/incident-notifications?regions=us", json={"us": []})
+V4_INCIDENTS_URL = "https://api.dlp.paloaltonetworks.com/v4/api/incidents"
+
+
+def test_get_incidents_first_page(requests_mock):
+    """
+    Given:
+        - A client configured with the default base URL.
+    When:
+        - Calling get_incidents_first_page.
+    Then:
+        - Ensure a POST is issued to the v4 incidents URL with a CUSTOM time range in
+          milliseconds, ascending creation-date sort and a region filter expression.
+    """
+    mock_resp = {"rows": [], "status": "READY", "query_token": "tok-1", "total_rows": 0}
+    requests_mock.post(V4_INCIDENTS_URL, json=mock_resp)
+
     client = Client(DLP_URL, AUTH_URL, CREDENTIALS, True, False)
-    result, status_code = client.get_dlp_incidents(regions="us")
-    assert result == {"us": []}
+    result, status_code = client.get_incidents_first_page(start_time_ms=1000, end_time_ms=2000, regions="us,eu")
+
+    assert result == mock_resp
     assert status_code == 200
+    assert requests_mock.last_request.url == V4_INCIDENTS_URL
+    assert requests_mock.last_request.json() == {
+        "time_range": "CUSTOM",
+        "start_time": 1000,
+        "end_time": 2000,
+        "sort_by": "IncidentCreatedDate",
+        "sort_order": "ASC",
+        "page_size": 1000,
+        "filter": "Region in ('US', 'EU')",
+    }
+
+
+def test_get_incidents_first_page_without_regions(requests_mock):
+    """
+    Given:
+        - A client and no configured regions.
+    When:
+        - Calling get_incidents_first_page.
+    Then:
+        - Ensure no filter is sent, so the query covers every region the tenant can see.
+    """
+    requests_mock.post(V4_INCIDENTS_URL, json={"rows": [], "status": "READY"})
+
+    client = Client(DLP_URL, AUTH_URL, CREDENTIALS, True, False)
+    client.get_incidents_first_page(start_time_ms=1000, end_time_ms=2000, regions="")
+
+    assert "filter" not in requests_mock.last_request.json()
+
+
+def test_get_incidents_next_page(requests_mock):
+    """
+    Given:
+        - A query token minted by a previous first-page call.
+    When:
+        - Calling get_incidents_next_page.
+    Then:
+        - Ensure a GET is issued with token, offset and pageSize on the query string.
+    """
+    mock_resp = {"rows": [{"incident_id": "id-1"}], "status": "READY", "total_rows": 5}
+    requests_mock.get(V4_INCIDENTS_URL, json=mock_resp)
+
+    client = Client(DLP_URL, AUTH_URL, CREDENTIALS, True, False)
+    result, status_code = client.get_incidents_next_page("tok-1", 100, page_size=50)
+
+    assert result == mock_resp
+    assert status_code == 200
+    assert requests_mock.last_request.qs == {"token": ["tok-1"], "offset": ["100"], "pagesize": ["50"]}
+
+
+def test_v4_url_ignores_custom_base_path(requests_mock):
+    """
+    Given:
+        - A base URL that is not versioned under /v1/.
+    When:
+        - Calling get_incidents_first_page.
+    Then:
+        - Ensure the v4 path is still appended to the configured host, rather than being
+          derived by string replacement (which would silently no-op and fetch nothing).
+    """
+    requests_mock.post("https://dlp.customer.example/v4/api/incidents", json={"rows": [], "status": "READY"})
+
+    client = Client("https://dlp.customer.example/api/", AUTH_URL, CREDENTIALS, True, False)
+    client.get_incidents_first_page(start_time_ms=1000, end_time_ms=2000)
+
+    assert requests_mock.last_request.url == "https://dlp.customer.example/v4/api/incidents"
+
+
+@pytest.mark.parametrize(
+    "regions, expected",
+    [
+        pytest.param("us", "Region in ('US')", id="single_region_uppercased"),
+        pytest.param("us, eu ,ap", "Region in ('US', 'EU', 'AP')", id="multiple_regions_trimmed"),
+        pytest.param("US_STG", "Region in ('US_STG')", id="underscore_allowed"),
+        pytest.param("", "", id="empty_string"),
+        pytest.param("us,'; DROP TABLE--", "Region in ('US')", id="injection_token_dropped"),
+        pytest.param("!!!", "", id="all_tokens_invalid"),
+    ],
+)
+def test_build_region_filter(regions, expected):
+    """
+    Given:
+        - A comma-separated region configuration value.
+    When:
+        - Calling build_region_filter.
+    Then:
+        - Ensure valid tokens are uppercased into a filter expression and anything outside
+          [A-Z0-9_] is discarded, so an operator value cannot alter the expression.
+    """
+    assert build_region_filter(regions) == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected_epoch",
+    [
+        pytest.param(1648844510, 1648844510, id="seconds"),
+        pytest.param(1648844510000, 1648844510, id="milliseconds"),
+        pytest.param(1648844510000000, 1648844510, id="microseconds"),
+        pytest.param("1648844510000", 1648844510, id="numeric_string"),
+        pytest.param("2022-04-01 20:21:50 UTC", 1648844510, id="date_string"),
+        pytest.param(None, None, id="none"),
+        pytest.param("", None, id="empty_string"),
+        pytest.param("not a date", None, id="unparsable"),
+    ],
+)
+def test_parse_created_date(value, expected_epoch):
+    """
+    Given:
+        - A created_date value in any of the units and formats the v4 API may return.
+    When:
+        - Calling parse_created_date.
+    Then:
+        - Ensure numeric values are normalized by magnitude, strings are parsed, and
+          unparsable input returns None rather than raising.
+    """
+    result = parse_created_date(value)
+
+    if expected_epoch is None:
+        assert result is None
+    else:
+        assert int(result.timestamp()) == expected_epoch
 
 
 @pytest.mark.parametrize(
@@ -499,6 +635,25 @@ def test_query_sleep_time(requests_mock):
     assert time == 10
 
 
+V4_ROW = {
+    "incident_id": "1fd24b1e-05ff-46c1-b638-a79d284dc727",
+    "report_id": "2573778324",
+    "created_date": 1648844510000,
+    "action": "block",
+    "control_point": "NGFW",
+    "asset_name": "Test_file.txt",
+    "source": "test-user@example.com",
+    "source_region": "US",
+    "severity": "HIGH",
+    "feedback_status": "PENDING_RESPONSE",
+    "data_profile_id": 11995149,
+    "data_profiles": [
+        {"id": 11995148, "name": "Parent Profile", "version": 2, "is_parent": True},
+        {"id": 11995149, "name": "Credit Card Match 2", "version": 1, "is_parent": False},
+    ],
+}
+
+
 @pytest.mark.parametrize(
     "incident_type_input, expected_type",
     [
@@ -509,43 +664,74 @@ def test_query_sleep_time(requests_mock):
 def test_create_incident(incident_type_input, expected_type):
     """
     Given:
-        - A DLP notification containing an incident.
+        - A v4 incident inventory row.
     When:
         - Calling `create_incident` with or without specifying an incident type.
     Then:
-        - Ensure no errors due to the lack of `userId` in `INCIDENT_JSON`.
-        - Ensure the incident is created with the correct type.
+        - Ensure the incident is created with the correct type and that rawJSON keeps the
+          v1 key names, including the nested previousNotification and incidentDetails
+          shapes the incoming mapper reads.
     """
-    import copy
+    created_at = parse_created_date(V4_ROW["created_date"])
 
-    # Inputs
-    notification = {"incident": copy.deepcopy(INCIDENT_JSON), "previous_notifications": []}
-    region = "us"
-
-    # Prepare
-    parsed_details = parse_incident_details(INCIDENT_JSON["incidentDetails"])
-    occurred_time = arg_to_datetime(INCIDENT_JSON["createdAt"]).isoformat()
-    user_id = parsed_details["headers"][0]["attribute_value"]  # Take `attribute_value` where `attribute_name` = "username"
-    raw_data = {
-        **INCIDENT_JSON,
-        "userId": user_id,
-        "incidentDetails": parsed_details,
-        "region": region,
-        "previousNotification": None,
+    expected_raw = {
+        "incidentId": V4_ROW["incident_id"],
+        "userId": V4_ROW["source"],
+        "tenantId": None,
+        "reportId": V4_ROW["report_id"],
+        "dataProfileId": V4_ROW["data_profile_id"],
+        # The server derives data_profile_id from the last element, so name/version follow it.
+        "dataProfileName": "Credit Card Match 2",
+        "dataProfileVersion": 1,
+        "action": V4_ROW["action"],
+        "channel": "ngfw",
+        "filename": V4_ROW["asset_name"],
+        "checksum": None,
+        "fileType": None,
+        "source": V4_ROW["control_point"],
+        "appId": None,
+        "appName": None,
+        "createdAt": created_at.isoformat(),
+        "region": V4_ROW["source_region"],
+        "previousNotification": {"feedback_status": V4_ROW["feedback_status"]},
+        "incidentDetails": {"headers": [{"attribute_name": "severity", "attribute_value": V4_ROW["severity"]}]},
     }
 
     # Act
     if incident_type_input is None:
-        result = create_incident(notification, region=region)
+        result = create_incident(V4_ROW, created_at)
     else:
-        result = create_incident(notification, region=region, incident_type=incident_type_input)
+        result = create_incident(V4_ROW, created_at, incident_type=incident_type_input)
 
-    # Assert - check standard fields
-    assert result["name"] == f"Palo Alto Networks DLP Incident {INCIDENT_JSON['incidentId']}"
+    # Assert
+    assert result["name"] == f"Palo Alto Networks DLP Incident {V4_ROW['incident_id']}"
     assert result["type"] == expected_type
-    assert result["occurred"] == occurred_time
-    assert result["rawJSON"] == json.dumps(raw_data)
-    assert result["details"] == json.dumps(raw_data)
+    assert result["occurred"] == created_at.isoformat()
+    assert result["rawJSON"] == json.dumps(expected_raw)
+    assert result["details"] == json.dumps(expected_raw)
+
+
+def test_create_incident_normalizes_channel_and_tolerates_missing_fields():
+    """
+    Given:
+        - A sparse row whose control_point uses the underscored server form and which
+          carries no data profiles.
+    When:
+        - Calling create_incident.
+    Then:
+        - Ensure the channel is normalized to the hyphenated v1 form and the profile keys
+          are present but empty rather than raising.
+    """
+    row = {"incident_id": "id-1", "control_point": "SAAS_API"}
+    created_at = parse_created_date(1648844510)
+
+    raw = json.loads(create_incident(row, created_at)["rawJSON"])
+
+    assert raw["channel"] == "saas-api"
+    assert raw["source"] == "SAAS_API"
+    assert raw["dataProfileName"] is None
+    assert raw["dataProfileVersion"] is None
+    assert raw["previousNotification"] == {"feedback_status": None}
 
 
 @pytest.mark.parametrize(
@@ -668,52 +854,40 @@ def test_get_start_end_time_intervals(start, end, delta, expected_intervals):
     assert result == expected_intervals
 
 
+def _mock_fetch_env(mocker, last_run=None):
+    """Patch the demisto side effects fetch_notifications performs."""
+    mocker.patch.object(demisto, "getIntegrationContext", return_value={})
+    mocker.patch.object(demisto, "getLastRun", return_value=last_run if last_run is not None else {})
+    mocker.patch.object(demisto, "setIntegrationContext")
+
+
 @freeze_time("2022-04-01 20:25:00 UTC")
 def test_fetch_notifications_basic(requests_mock, mocker):
     """
     Given:
-        - A client and basic parameters with frozen time.
+        - A single-page v4 inventory response with no previous last_run.
     When:
-        - Calling fetch_notifications with no previous last_run.
+        - Calling fetch_notifications.
     Then:
-        - Ensure incidents are created and last_run is updated.
+        - Ensure an incident is created from the row and last_run carries the created_date
+          watermark plus the ID for deduplication.
     """
-    import re
-    from datetime import datetime
-    from Palo_Alto_Networks_Enterprise_DLP import LOCAL_LAST_RUN
+    mock_resp = {"rows": [V4_ROW], "status": "READY", "query_token": "tok-1", "total_rows": 1}
+    requests_mock.post(V4_INCIDENTS_URL, json=mock_resp)
 
-    LOCAL_LAST_RUN.clear()
-
-    # Mock API response
-    mock_notification = {
-        "incident": {
-            "incidentId": "test-id-1",
-            "committedAt": "2022-Apr-01 20:21:50 UTC",
-            "createdAt": "2022-Apr-01 20:21:50 UTC",
-            "incidentDetails": INCIDENT_JSON["incidentDetails"],
-            "tenantId": "1128505801991063552",
-            "reportId": "2573778324",
-        },
-        "previous_notifications": [],
-    }
-
-    requests_mock.get(re.compile(f"{DLP_URL}public/incident-notifications.*"), json={"us": [mock_notification]})
-
-    mocker.patch.object(demisto, "getIntegrationContext", return_value={})
-    mocker.patch.object(demisto, "getLastRun", return_value={})
-    mocker.patch.object(demisto, "createIncidents")
-    mocker.patch.object(demisto, "setIntegrationContext")
+    _mock_fetch_env(mocker)
 
     client = Client(DLP_URL, AUTH_URL, CREDENTIALS, True, False)
-    # Use timestamp very close to frozen time (just 2 minutes before to minimize intervals)
     first_fetch_timestamp = int(datetime(2022, 4, 1, 20, 23, 0, tzinfo=UTC).timestamp())
 
     next_run, incidents = fetch_notifications(client, "us", first_fetch_timestamp)
 
     assert len(incidents) == 1
-    assert "test-id-1" in incidents[0]["name"]
-
-    assert next_run == {"start_timestamp": 1648844510, LAST_IDS_TIMESTAMPS_KEY: {"test-id-1": 1648844510}}
+    assert V4_ROW["incident_id"] in incidents[0]["name"]
+    assert next_run == {
+        START_TIMESTAMP_KEY: 1648844510,
+        LAST_IDS_TIMESTAMPS_KEY: {V4_ROW["incident_id"]: 1648844510},
+    }
 
 
 @freeze_time("2026-04-01 20:25:00 UTC")
@@ -724,58 +898,183 @@ def test_fetch_notifications_lookback(requests_mock, mocker):
     When:
         - Calling fetch_notifications.
     Then:
-        - The first API interval starts at T - 5*60 (i.e. lookback is applied).
+        - The POST body uses start_time = (T - 5*60) * 1000, so late-indexed incidents
+          created before the watermark are re-queried.
     """
-    import re
-    from datetime import datetime
-
     start_timestamp = int(datetime(2026, 4, 1, 20, 23, 0, tzinfo=UTC).timestamp())  # T
-    look_back_seconds = 5 * 60
-    expected_effective_start = start_timestamp - look_back_seconds
+    expected_effective_start_ms = (start_timestamp - 5 * 60) * 1000
 
-    requests_mock.get(re.compile(f"{DLP_URL}public/incident-notifications.*"), json={})
+    requests_mock.post(V4_INCIDENTS_URL, json={"rows": [], "status": "READY", "total_rows": 0})
 
-    mocker.patch.object(demisto, "getIntegrationContext", return_value={})
-    mocker.patch.object(demisto, "getLastRun", return_value={START_TIMESTAMP_KEY: start_timestamp})
-    mocker.patch.object(demisto, "setIntegrationContext")
+    _mock_fetch_env(mocker, {START_TIMESTAMP_KEY: start_timestamp})
 
     client = Client(DLP_URL, AUTH_URL, CREDENTIALS, True, False)
     fetch_notifications(client, "us", first_fetch_timestamp=start_timestamp, look_back_minutes=5)
 
-    # The very first request must use start_timestamp=expected_effective_start
-    first_request_url = requests_mock.request_history[0].url
-    assert f"start_timestamp={expected_effective_start}" in first_request_url
+    assert requests_mock.request_history[0].json()["start_time"] == expected_effective_start_ms
 
 
 @freeze_time("2026-04-01 20:25:00 UTC")
 def test_fetch_notifications_advances_start_timestamp_when_no_new_incidents(requests_mock, mocker):
     """
     Given:
-        - A last_run with a stale start_timestamp and all API responses returning empty results.
+        - A last_run with a stale start_timestamp and an empty result set.
     When:
         - Calling fetch_notifications.
     Then:
-        - Ensure start_timestamp in next_run is advanced to the end_time of the last queried interval,
+        - Ensure start_timestamp in next_run is advanced to end_timestamp (now - buffer),
           preventing the query window from growing unboundedly on subsequent fetches.
     """
-    import re
-    from datetime import datetime
-
     start_timestamp = int(datetime(2026, 4, 1, 20, 23, 0, tzinfo=UTC).timestamp())
 
-    requests_mock.get(re.compile(f"{DLP_URL}public/incident-notifications.*"), json={})
+    requests_mock.post(V4_INCIDENTS_URL, json={"rows": [], "status": "READY", "total_rows": 0})
 
-    mocker.patch.object(demisto, "getIntegrationContext", return_value={})
-    mocker.patch.object(demisto, "getLastRun", return_value={START_TIMESTAMP_KEY: start_timestamp, LAST_IDS_TIMESTAMPS_KEY: {}})
-    mocker.patch.object(demisto, "setIntegrationContext")
+    _mock_fetch_env(mocker, {START_TIMESTAMP_KEY: start_timestamp, LAST_IDS_TIMESTAMPS_KEY: {}})
 
     client = Client(DLP_URL, AUTH_URL, CREDENTIALS, True, False)
     next_run, incidents = fetch_notifications(client, "us", first_fetch_timestamp=start_timestamp)
 
     assert incidents == []
-    # start_timestamp must advance beyond the stale value — it should equal the end_time of the
-    # last queried interval (start_timestamp + MAX_API_CALLS_PER_FETCH * 180s), not remain frozen.
+    # start_timestamp must advance beyond the stale value — it should equal end_timestamp (now - buffer).
     assert next_run[START_TIMESTAMP_KEY] > start_timestamp
+
+
+@freeze_time("2022-04-01 20:25:00 UTC")
+def test_fetch_notifications_covers_all_regions_in_one_query(requests_mock, mocker):
+    """
+    Given:
+        - Two configured regions and one incident in each.
+    When:
+        - Calling fetch_notifications.
+    Then:
+        - Ensure a single query covers both regions, so the watermark is derived from all of
+          them rather than from whichever region happened to be queried last.
+    """
+    us_row = {**V4_ROW, "incident_id": "us-1", "source_region": "US", "created_date": 1648844510000}
+    eu_row = {**V4_ROW, "incident_id": "eu-1", "source_region": "EU", "created_date": 1648844400000}
+    requests_mock.post(
+        V4_INCIDENTS_URL, json={"rows": [eu_row, us_row], "status": "READY", "query_token": "tok-1", "total_rows": 2}
+    )
+
+    _mock_fetch_env(mocker)
+
+    client = Client(DLP_URL, AUTH_URL, CREDENTIALS, True, False)
+    next_run, incidents = fetch_notifications(client, "us,eu", first_fetch_timestamp=1648844000)
+
+    assert len(requests_mock.request_history) == 1
+    assert requests_mock.request_history[0].json()["filter"] == "Region in ('US', 'EU')"
+    assert {json.loads(incident["rawJSON"])["region"] for incident in incidents} == {"US", "EU"}
+    # The watermark is the max across both regions, not whichever happened to be queried last.
+    assert next_run[START_TIMESTAMP_KEY] == 1648844510
+
+
+@freeze_time("2022-04-01 20:25:00 UTC")
+def test_fetch_notifications_pages_until_empty_when_total_rows_missing(requests_mock, mocker):
+    """
+    Given:
+        - A response whose total_rows is null, which the server may return.
+    When:
+        - Calling fetch_notifications.
+    Then:
+        - Ensure the walk degrades to paging until an empty page rather than raising or
+          stopping after the first page.
+    """
+    page_1 = {**V4_ROW, "incident_id": "id-1"}
+    page_2 = {**V4_ROW, "incident_id": "id-2"}
+    requests_mock.post(V4_INCIDENTS_URL, json={"rows": [page_1], "status": "READY", "query_token": "tok-1", "total_rows": None})
+    requests_mock.get(
+        V4_INCIDENTS_URL,
+        [
+            {"json": {"rows": [page_2], "status": "READY"}},
+            {"json": {"rows": [], "status": "READY"}},
+        ],
+    )
+
+    _mock_fetch_env(mocker)
+
+    client = Client(DLP_URL, AUTH_URL, CREDENTIALS, True, False)
+    _, incidents = fetch_notifications(client, "us", first_fetch_timestamp=1648844000)
+
+    assert [json.loads(incident["rawJSON"])["incidentId"] for incident in incidents] == ["id-1", "id-2"]
+
+
+@freeze_time("2022-04-01 20:25:00 UTC")
+def test_fetch_notifications_repolls_pending_query(requests_mock, mocker):
+    """
+    Given:
+        - A first page that is acknowledged as PENDING with no rows.
+    When:
+        - Calling fetch_notifications.
+    Then:
+        - Ensure the query token is re-polled until rows are ready, rather than treating the
+          empty PENDING page as an empty result set.
+    """
+    mocker.patch("Palo_Alto_Networks_Enterprise_DLP.time.sleep")
+    requests_mock.post(V4_INCIDENTS_URL, json={"rows": [], "status": "PENDING", "query_token": "tok-1"})
+    requests_mock.get(
+        V4_INCIDENTS_URL,
+        [
+            {"json": {"rows": [], "status": "PENDING"}},
+            {"json": {"rows": [V4_ROW], "status": "READY", "total_rows": 1}},
+        ],
+    )
+
+    _mock_fetch_env(mocker)
+
+    client = Client(DLP_URL, AUTH_URL, CREDENTIALS, True, False)
+    _, incidents = fetch_notifications(client, "us", first_fetch_timestamp=1648844000)
+
+    assert len(incidents) == 1
+    assert V4_ROW["incident_id"] in incidents[0]["name"]
+
+
+@freeze_time("2022-04-01 20:25:00 UTC")
+def test_fetch_notifications_skips_duplicates_and_unparsable_rows(requests_mock, mocker):
+    """
+    Given:
+        - A page containing an already-seen incident and one with an unparsable created_date.
+    When:
+        - Calling fetch_notifications.
+    Then:
+        - Ensure both are skipped and the fetch completes, rather than re-creating the
+          duplicate or dying on the bad timestamp.
+    """
+    seen_row = {**V4_ROW, "incident_id": "seen-1"}
+    bad_row = {**V4_ROW, "incident_id": "bad-1", "created_date": "not a date"}
+    good_row = {**V4_ROW, "incident_id": "good-1"}
+    requests_mock.post(
+        V4_INCIDENTS_URL,
+        json={"rows": [seen_row, bad_row, good_row], "status": "READY", "query_token": "tok-1", "total_rows": 3},
+    )
+
+    _mock_fetch_env(mocker, {START_TIMESTAMP_KEY: 1648844000, LAST_IDS_TIMESTAMPS_KEY: {"seen-1": 1648844000}})
+
+    client = Client(DLP_URL, AUTH_URL, CREDENTIALS, True, False)
+    _, incidents = fetch_notifications(client, "us", first_fetch_timestamp=1648844000)
+
+    assert [json.loads(incident["rawJSON"])["incidentId"] for incident in incidents] == ["good-1"]
+
+
+@freeze_time("2022-04-01 20:25:00 UTC")
+def test_fetch_notifications_stops_at_max_fetch(requests_mock, mocker):
+    """
+    Given:
+        - A result set larger than max_fetch.
+    When:
+        - Calling fetch_notifications.
+    Then:
+        - Ensure the walk stops at the limit and does not request a further page.
+    """
+    rows = [{**V4_ROW, "incident_id": f"id-{i}"} for i in range(5)]
+    requests_mock.post(V4_INCIDENTS_URL, json={"rows": rows, "status": "READY", "query_token": "tok-1", "total_rows": 50})
+
+    _mock_fetch_env(mocker)
+
+    client = Client(DLP_URL, AUTH_URL, CREDENTIALS, True, False)
+    _, incidents = fetch_notifications(client, "us", first_fetch_timestamp=1648844000, max_fetch=2)
+
+    assert len(incidents) == 2
+    assert len(requests_mock.request_history) == 1
 
 
 @pytest.mark.parametrize(

--- a/Packs/Palo_Alto_Networks_Enterprise_DLP/ReleaseNotes/2_4_0.md
+++ b/Packs/Palo_Alto_Networks_Enterprise_DLP/ReleaseNotes/2_4_0.md
@@ -1,0 +1,8 @@
+#### Integrations
+
+##### Palo Alto Networks Enterprise DLP
+
+- Updated the incident fetch to use the v4 incident inventory API instead of the deprecated v1 incident notifications API. Incident fields are mapped internally, so no mapper or layout changes are required.
+- All configured regions are now covered by a single query, fixing incidents being skipped when the fetch limit was reached before every region was queried.
+- Fixed an issue where a customized **Server URL** caused the fetch to silently return no incidents.
+- Fixed an issue where an incident with a missing or malformed creation timestamp caused the entire fetch to fail.

--- a/Packs/Palo_Alto_Networks_Enterprise_DLP/ReleaseNotes/2_4_0.md
+++ b/Packs/Palo_Alto_Networks_Enterprise_DLP/ReleaseNotes/2_4_0.md
@@ -6,3 +6,4 @@
 - All configured regions are now covered by a single query, fixing incidents being skipped when the fetch limit was reached before every region was queried.
 - Fixed an issue where a customized **Server URL** caused the fetch to silently return no incidents.
 - Fixed an issue where an incident with a missing or malformed creation timestamp caused the entire fetch to fail.
+- Fixed an issue where a failed or incomplete incident query advanced the fetch time window, causing incidents in that window to be skipped.

--- a/Packs/Palo_Alto_Networks_Enterprise_DLP/pack_metadata.json
+++ b/Packs/Palo_Alto_Networks_Enterprise_DLP/pack_metadata.json
@@ -5,7 +5,7 @@
     "support": "xsoar",
     "author": "Palo Alto Networks Enterprise DLP",
     "url": "https://www.paloaltonetworks.com/enterprise-data-loss-prevention",
-    "currentVersion": "2.3.1",
+    "currentVersion": "2.4.0",
     "categories": [
         "Network Security"
     ],


### PR DESCRIPTION
## Contributing to Cortex XSOAR Content

Contribution registration form: **not yet submitted.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues

_None linked yet._

## Description

Migrates the Enterprise DLP incident fetch off the v1 notification drain
(`/public/incident-notifications`) and onto the token-paged
`POST`/`GET /v4/api/incidents` inventory query, ahead of the v1 endpoint's
deprecation.

The v4 rows are mapped back onto the existing `rawJSON` keys inside the
integration, so **no classifier, layout, incident field or playbook changes are
required** — the change is intended to be invisible to existing instances.

Fetch flow now:

1. One `POST` covering every configured region via a `Region in (...)` filter,
   sorted `IncidentCreatedDate ASC`.
2. Walk `query_token` with `GET ?token=&offset=&pageSize=` until `total_rows` is
   reached, the page comes back empty, or `max_fetch` is hit.
3. If the query fails, or is acknowledged `PENDING` with no rows, the last run
   is left untouched so the same window is re-queried on the next cycle.

Four pre-existing fetch defects are fixed along the way:

- **Regions could be skipped.** The old per-region loop could exhaust
  `max_fetch` before the last region was queried, while still advancing the
  shared watermark past it. A single query removes the class of bug.
- **A customized Server URL silently fetched nothing.** The v4 path was derived
  by string replacement on `base_url`, which no-ops when the URL is customized.
  It is now built from the scheme and host only.
- **One bad timestamp killed the whole cycle.** An unparsable creation
  timestamp raised and aborted the fetch; the offending row is now skipped.
- **A window that was never read was treated as an empty one.** The client's
  error handler swallows HTTP failures, so a 5xx — or a 4xx surviving the token
  refresh retries — returned no rows without raising, and the watermark advanced
  past incidents nothing had looked at. The fetch now raises on a failed query
  and returns the last run untouched on a `PENDING` acknowledgement, so the
  window is re-queried instead of skipped.

The *DLP Regions* parameter is a multi-select, so the platform hands it to the
integration as a list rather than a string. The region filter is built with
`argToList` and accepts either form.

### Reviewer notes / open items

Flagging these explicitly rather than leaving them to be discovered:

- **Watermark clock changed.** Dedup and the next-run watermark now key off
  `created_date` (occurrence time) where v1 used `committedAt` (indexing time).
  Incidents indexed later than they occurred can fall outside a subsequent
  window; only `look_back` absorbs this, and it defaults to `0`.
- **A failing query now surfaces as a failing instance.** Holding the watermark
  means a query error has to be raised rather than swallowed, so a tenant that
  is genuinely broken shows a red instance instead of looking quiet. That is the
  intended trade — silently losing incidents is worse — but it is a visible
  change in behaviour.
- **Channel filtering is no longer applied server-side.** The v1 notifications
  path was restricted server-side to `ngfw`, `prisma_access` and `endpoint_dlp`.
  The v4 inventory endpoint applies no such filter, so instances may begin
  seeing incidents from additional control points. Since the DLP incident type
  has `autorun: True`, those would auto-run the feedback playbook. A
  `Channel in (...)` clause can restore the old behaviour if that is preferred.
- **Currently unmapped fields:** `tenantId`, `checksum` (File SHA256),
  `fileType`, `appId`, `appName`. These are emitted as `null` pending
  confirmation of their v4 column names against a live tenant.
- **`created_date` unit is not pinned by the contract.** The parser normalizes
  seconds / milliseconds / microseconds by magnitude; the exact unit should be
  confirmed against a live tenant.
- **Region filter tokens** are compared against the raw `source_region` column.
  The exact vocabulary (e.g. `US` vs `US_STG`) still needs confirming, and the
  yml offers `BR`/`PAR`/`SUI`, which do not appear in the server-side filter
  documentation.

## Must have
- [x] Tests — 67 unit tests pass, including new coverage for multi-region
      single-query, missing `total_rows`, a `PENDING` first response holding the
      watermark, a failed query raising rather than advancing it, custom
      `base_url`, duplicate and unparsable rows, the `max_fetch` bound, and the
      *DLP Regions* multi-select arriving as a list.
- [x] Documentation — release note `2_4_0.md`, pack version `2.3.1` → `2.4.0`.


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-17857
