### PR TITLE
Fixed the reset command to run before getting the refresh token

### DIFF
--- a/Packs/MicrosoftManagementActivity/Integrations/MicrosoftManagementActivity/MicrosoftManagementActivity.py
+++ b/Packs/MicrosoftManagementActivity/Integrations/MicrosoftManagementActivity/MicrosoftManagementActivity.py
@@ -614,7 +614,7 @@ def main():
             return_results(test_module(client=client, auth_code=auth_code))
 
         # in the generate login url command we still don't't have the auth code do get the token
-        if command != "ms-management-activity-generate-login-url":
+        if command != "ms-management-activity-generate-login-url" or "ms-management-activity-auth-reset":
             access_token, token_data = client.get_access_token_data()
             client.access_token = access_token
             client.tenant_id = token_data["tid"]

--- a/Packs/MicrosoftManagementActivity/Integrations/MicrosoftManagementActivity/MicrosoftManagementActivity.py
+++ b/Packs/MicrosoftManagementActivity/Integrations/MicrosoftManagementActivity/MicrosoftManagementActivity.py
@@ -613,8 +613,8 @@ def main():
         if command == "test-module":
             return_results(test_module(client=client, auth_code=auth_code))
 
-        # in the generate login url command we still don't't have the auth code do get the token
-        if command != "ms-management-activity-generate-login-url" or "ms-management-activity-auth-reset":
+        # in the generate-login-url and auth-reset commands we still don't have the auth code to get the token
+        if command not in ("ms-management-activity-generate-login-url", "ms-management-activity-auth-reset"):
             access_token, token_data = client.get_access_token_data()
             client.access_token = access_token
             client.tenant_id = token_data["tid"]

--- a/Packs/MicrosoftManagementActivity/Integrations/MicrosoftManagementActivity/MicrosoftManagementActivity_test.py
+++ b/Packs/MicrosoftManagementActivity/Integrations/MicrosoftManagementActivity/MicrosoftManagementActivity_test.py
@@ -822,3 +822,39 @@ def test_fetch_advance_window_empty_results(mock_content_records):
     assert next_timestamp == end_time
 
     assert next_dedup_ids == []
+
+
+def test_auth_reset(mocker):
+    """
+    Given:
+        - An instance configured with self-deployed auth flow.
+    When:
+        - Calling the ms-management-activity-auth-reset command.
+    Then:
+        - Ensure reset_auth() is called (the integration context is cleared).
+        - Ensure the access token is NOT fetched, since auth is being reset.
+    """
+    import demistomock as demisto
+    import MicrosoftManagementActivity
+    from MicrosoftManagementActivity import Client, main
+
+    mocked_params = {
+        "redirect_uri": "redirect_uri",
+        "auth_type": "Authorization Code",
+        "self_deployed": "True",
+        "refresh_token": "tenant_id",
+        "auth_id": "client_id",
+        "enc_key": "client_secret",
+    }
+    mocker.patch.object(demisto, "params", return_value=mocked_params)
+    mocker.patch.object(demisto, "command", return_value="ms-management-activity-auth-reset")
+    return_results_mock = mocker.patch.object(MicrosoftManagementActivity, "return_results")
+    reset_auth_mock = mocker.patch.object(MicrosoftManagementActivity, "reset_auth")
+    get_access_token_mock = mocker.patch.object(Client, "get_access_token_data")
+
+    main()
+
+    # auth-reset must reset the auth and must not attempt to fetch an access token
+    reset_auth_mock.assert_called_once()
+    get_access_token_mock.assert_not_called()
+    assert return_results_mock.called

--- a/Packs/MicrosoftManagementActivity/ReleaseNotes/1_3_71.md
+++ b/Packs/MicrosoftManagementActivity/ReleaseNotes/1_3_71.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Microsoft Management Activity API (O365 Azure Events)
+
+- Fixed an issue where the ***ms-management-activity-auth-reset*** command failed because it attempted to retrieve an access token before resetting the authentication.

--- a/Packs/MicrosoftManagementActivity/pack_metadata.json
+++ b/Packs/MicrosoftManagementActivity/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Microsoft Management Activity API (O365/Azure Events)",
     "description": "An integration for Microsoft's management activity API, which enables you to fetch content records and manage your subscriptions.",
     "support": "xsoar",
-    "currentVersion": "1.3.70",
+    "currentVersion": "1.3.71",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
Fixed the reset command to run before getting the refresh token

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
related: [link to the issue](https://jira-dc.paloaltonetworks.com/browse/XSUP-74547)

## Must have
- [ ] Tests
- [ ] Documentation
