### PR TITLE
GSuiteAdmin - Extend Command

### DIFF
--- a/Packs/GSuiteAdmin/.pack-ignore
+++ b/Packs/GSuiteAdmin/.pack-ignore
@@ -1,6 +1,9 @@
 [file:GSuiteAdmin_image.png]
 ignore=IM111
 
+[file:README.md]
+ignore=RM108
+
 [known_words]
 g
 gsuite

--- a/Packs/GSuiteAdmin/Integrations/GSuiteAdmin/GSuiteAdmin.py
+++ b/Packs/GSuiteAdmin/Integrations/GSuiteAdmin/GSuiteAdmin.py
@@ -943,12 +943,16 @@ def token_revoke_command(client: Client, args: dict[str, str]) -> CommandResults
 
     client.set_authorized_http(scopes=SCOPES["USER_SECURITY"])
 
-    user_key = urllib.parse.quote(args.get("user_key", ""))
-    client_id = urllib.parse.quote(args.get("client_id", ""))
+    raw_user_key = args.get("user_key", "")
+    raw_client_id = args.get("client_id", "")
+    user_key = urllib.parse.quote(raw_user_key)
+    client_id = urllib.parse.quote(raw_client_id)
+
+    demisto.debug(f"gsuite-token-revoke: revoking tokens for user_key={raw_user_key!r}, client_id={raw_client_id!r}")
 
     client.http_request(url_suffix=URL_SUFFIX["TOKEN_REVOKE"].format(user_key, client_id), method="DELETE")
 
-    return CommandResults(readable_output=HR_MESSAGES["TOKEN_REVOKE_SUCCESS"].format(args.get("client_id", "")))
+    return CommandResults(readable_output=HR_MESSAGES["TOKEN_REVOKE_SUCCESS"].format(raw_client_id))
 
 
 @logger

--- a/Packs/GSuiteAdmin/Integrations/GSuiteAdmin/GSuiteAdmin.py
+++ b/Packs/GSuiteAdmin/Integrations/GSuiteAdmin/GSuiteAdmin.py
@@ -1678,7 +1678,11 @@ def user_reset_password_command(client: Client, args: dict[str, str]) -> Command
     client.set_authorized_http(scopes=SCOPES["DIRECTORY_USER"])
     user_key = args.get("user_key", "")
     url_suffix = urljoin(URL_SUFFIX["USER"], urllib.parse.quote(user_key))
-    body = {"changePasswordAtNextLogin": True}
+    body: dict[str, Any] = {"changePasswordAtNextLogin": True}
+    if password := args.get("password"):
+        body["password"] = hashlib.md5(password.encode()).hexdigest()  # nosec
+        body["hashFunction"] = "MD5"
+    demisto.debug(f"gsuite-user-reset-password: updating {user_key!r}, temporary password provided: {bool(password)}")
     response = client.http_request(url_suffix=url_suffix, method="PUT", body=body)
 
     # Context

--- a/Packs/GSuiteAdmin/Integrations/GSuiteAdmin/GSuiteAdmin.yml
+++ b/Packs/GSuiteAdmin/Integrations/GSuiteAdmin/GSuiteAdmin.yml
@@ -2232,7 +2232,10 @@ script:
     - description: 'One of the following: user email address, alias email address, or the unique user ID.'
       name: user_key
       required: true
-    description: Forces the user to change their password at next login.
+    - description: A temporary password to set for the user. A password can contain any combination of ASCII characters. A minimum of 8 characters is required. The maximum length is 100 characters. The password will be sent in MD5 hash format. If not provided, the user's password remains unchanged and only the "change password at next login" flag is set.
+      name: password
+      secret: true
+    description: Forces the user to change their password at next login, and optionally sets a temporary password for the user.
     name: gsuite-user-reset-password
     outputs:
     - contextPath: GSuite.User.id

--- a/Packs/GSuiteAdmin/Integrations/GSuiteAdmin/GSuiteAdmin.yml
+++ b/Packs/GSuiteAdmin/Integrations/GSuiteAdmin/GSuiteAdmin.yml
@@ -2232,7 +2232,7 @@ script:
     - description: 'One of the following: user email address, alias email address, or the unique user ID.'
       name: user_key
       required: true
-    description: Indicates if the user is forced to change their password at next login.
+    description: Forces the user to change their password at next login.
     name: gsuite-user-reset-password
     outputs:
     - contextPath: GSuite.User.id

--- a/Packs/GSuiteAdmin/Integrations/GSuiteAdmin/GSuiteAdmin.yml
+++ b/Packs/GSuiteAdmin/Integrations/GSuiteAdmin/GSuiteAdmin.yml
@@ -2232,7 +2232,7 @@ script:
     - description: 'One of the following: user email address, alias email address, or the unique user ID.'
       name: user_key
       required: true
-    - description: A temporary password to set for the user. A password can contain any combination of ASCII characters. A minimum of 8 characters is required. The maximum length is 100 characters. The password will be sent in MD5 hash format. If not provided, the user's password remains unchanged and only the "change password at next login" flag is set.
+    - description: The temporary password to set for the user, which can contain any combination of ASCII characters (8 to 100 characters). The password will be sent as an MD5 hash. If not provided, the user's password remains unchanged, and only sets the "change password at next login" flag.
       name: password
       secret: true
     description: Forces the user to change their password at next login, and optionally sets a temporary password for the user.

--- a/Packs/GSuiteAdmin/Integrations/GSuiteAdmin/GSuiteAdmin.yml
+++ b/Packs/GSuiteAdmin/Integrations/GSuiteAdmin/GSuiteAdmin.yml
@@ -1,3 +1,5 @@
+sectionorder:
+- Connect
 category: IT Services
 provider: Google
 commonfields:
@@ -9,30 +11,36 @@ configuration:
   type: 4
   hidden: true
   required: false
+  section: Connect
 - display: Admin Email
   name: admin_email_creds
   type: 9
   displaypassword: User's Service Account JSON
   required: false
+  section: Connect
 - display: Admin Email
   name: admin_email
   type: 0
   additionalinfo: An admin email is required for the Test validation to run. If not configured, then each command can receive an optional admin_email argument.
   hidden: true
   required: false
+  section: Connect
 - display: Customer ID
   name: customer_id
   type: 0
   additionalinfo: A unique identifier of the customer's Google account.
   required: false
+  section: Connect
 - display: Trust any certificate (not secure)
   name: insecure
   type: 8
   required: false
+  section: Connect
 - display: Use system proxy settings
   name: proxy
   type: 8
   required: false
+  section: Connect
 description: G Suite or Google Workspace Admin is an integration to perform an action on IT infrastructure, create users, update settings, and more administrative tasks.
 display: Google Workspace Admin
 name: GSuiteAdmin

--- a/Packs/GSuiteAdmin/Integrations/GSuiteAdmin/GSuiteAdmin_test.py
+++ b/Packs/GSuiteAdmin/Integrations/GSuiteAdmin/GSuiteAdmin_test.py
@@ -1265,6 +1265,61 @@ def test_gsuite_reset_password(gsuite_client, mocker):
     assert command_result.outputs_prefix == "GSuite.User"
 
 
+def test_gsuite_reset_password_without_password_argument(gsuite_client, mocker):
+    """
+    Scenario: User reset password command executed without the optional password argument.
+
+    Given:
+    - Only a user_key argument.
+
+    When:
+    - Calling command gsuite_user_reset_password.
+
+    Then:
+    - Ensure the request body only forces a password change at next login and carries no password.
+    """
+
+    from GSuiteAdmin import user_reset_password_command
+
+    with open("test_data/user_password_reset_response.json") as file:
+        api_response = json.load(file)
+    http_request = mocker.patch("GSuiteAdmin.GSuiteClient.http_request", return_value=api_response)
+
+    user_reset_password_command(gsuite_client, {"user_key": "nikolic@demistodev.com"})
+
+    assert http_request.call_args.kwargs["body"] == {"changePasswordAtNextLogin": True}
+
+
+def test_gsuite_reset_password_with_temporary_password(gsuite_client, mocker):
+    """
+    Scenario: User reset password command executed with a temporary password.
+
+    Given:
+    - A user_key and a password argument.
+
+    When:
+    - Calling command gsuite_user_reset_password.
+
+    Then:
+    - Ensure the password is sent as an MD5 hash alongside the MD5 hashFunction and the change-at-next-login flag.
+    """
+    import hashlib
+
+    from GSuiteAdmin import user_reset_password_command
+
+    with open("test_data/user_password_reset_response.json") as file:
+        api_response = json.load(file)
+    http_request = mocker.patch("GSuiteAdmin.GSuiteClient.http_request", return_value=api_response)
+
+    user_reset_password_command(gsuite_client, {"user_key": "nikolic@demistodev.com", "password": "Temp@Pass123"})
+
+    assert http_request.call_args.kwargs["body"] == {
+        "changePasswordAtNextLogin": True,
+        "password": hashlib.md5(b"Temp@Pass123").hexdigest(),  # nosec
+        "hashFunction": "MD5",
+    }
+
+
 def test_chromebrowser_move_ou_command(gsuite_client, mocker):
     """
     Scenario: chromebrowserdevice move successful execution.

--- a/Packs/GSuiteAdmin/Integrations/GSuiteAdmin/README.md
+++ b/Packs/GSuiteAdmin/Integrations/GSuiteAdmin/README.md
@@ -1945,7 +1945,7 @@ There is no context output for this command.
 ### gsuite-user-reset-password
 
 ***
-Retreive a group's details given a group key.
+Forces the user to change their password at next login.
 
 ##### Required Permissions
 

--- a/Packs/GSuiteAdmin/Integrations/GSuiteAdmin/README.md
+++ b/Packs/GSuiteAdmin/Integrations/GSuiteAdmin/README.md
@@ -1945,7 +1945,7 @@ There is no context output for this command.
 ### gsuite-user-reset-password
 
 ***
-Forces the user to change their password at next login.
+Forces the user to change their password at next login, and optionally sets a temporary password for the user.
 
 ##### Required Permissions
 
@@ -1960,6 +1960,7 @@ Forces the user to change their password at next login.
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | user_key | One of the following: user email address, alias email address, or the unique user ID. | Required |
+| password | A temporary password to set for the user. A password can contain any combination of ASCII characters. A minimum of 8 characters is required. The maximum length is 100 characters. The password will be sent in MD5 hash format. If not provided, the user's password remains unchanged and only the "change password at next login" flag is set. | Optional |
 
 #### Context Output
 

--- a/Packs/GSuiteAdmin/Integrations/GSuiteAdmin/README.md
+++ b/Packs/GSuiteAdmin/Integrations/GSuiteAdmin/README.md
@@ -1960,7 +1960,7 @@ Forces the user to change their password at next login, and optionally sets a te
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | user_key | One of the following: user email address, alias email address, or the unique user ID. | Required |
-| password | A temporary password to set for the user. A password can contain any combination of ASCII characters. A minimum of 8 characters is required. The maximum length is 100 characters. The password will be sent in MD5 hash format. If not provided, the user's password remains unchanged and only the "change password at next login" flag is set. | Optional |
+| password | The temporary password to set for the user, which can contain any combination of ASCII characters (8 to 100 characters). The password will be sent as an MD5 hash. If not provided, the user's password remains unchanged, and only sets the "change password at next login" flag. | Optional |
 
 #### Context Output
 

--- a/Packs/GSuiteAdmin/ReleaseNotes/1_2_16.md
+++ b/Packs/GSuiteAdmin/ReleaseNotes/1_2_16.md
@@ -4,3 +4,4 @@
 ##### Google Workspace Admin
 
 - Fix incorrect description used for the ***gsuite-user-reset-password*** command.
+- Added the *password* argument to the ***gsuite-user-reset-password*** command, which sets a temporary password for the user.

--- a/Packs/GSuiteAdmin/ReleaseNotes/1_2_16.md
+++ b/Packs/GSuiteAdmin/ReleaseNotes/1_2_16.md
@@ -3,5 +3,5 @@
 
 ##### Google Workspace Admin
 
-- Fix incorrect description used for the ***gsuite-user-reset-password*** command.
+- Fixed incorrect description used for the ***gsuite-user-reset-password*** command.
 - Added the *password* argument to the ***gsuite-user-reset-password*** command, which sets a temporary password for the user.

--- a/Packs/GSuiteAdmin/ReleaseNotes/1_2_16.md
+++ b/Packs/GSuiteAdmin/ReleaseNotes/1_2_16.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Google Workspace Admin
+
+- Fix incorrect description used for the ***gsuite-user-reset-password*** command.

--- a/Packs/GSuiteAdmin/pack_metadata.json
+++ b/Packs/GSuiteAdmin/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "G Suite Admin",
     "description": "G Suite Admin integration with Cortex XSOAR. G Suite or Google Workspace Admin is an integration to perform an action on IT infrastructure, create users, update settings, and more administrative tasks.",
     "support": "xsoar",
-    "currentVersion": "1.2.15",
+    "currentVersion": "1.2.16",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION

## Related Issues
fixes: [XSUP-75949](https://jira-dc.paloaltonetworks.com/browse/XSUP-75949)

## Description
- Fix incorrect description used for the ***gsuite-user-reset-password*** command.
- Add the *password* argument to the ***gsuite-user-reset-password*** command, which sets a temporary password for the user.
