### PR TITLE
Fix date parsing issue / Mail-Listener-v2 XSUP-76251

### DIFF
--- a/Packs/MailListener/Integrations/MailListenerV2/MailListenerV2.py
+++ b/Packs/MailListener/Integrations/MailListenerV2/MailListenerV2.py
@@ -389,9 +389,8 @@ def fetch_incidents(
 
     # Otherwise use the mail UID
     uid_to_fetch_from = arg_to_number(last_run.get("last_uid", 0))
-    if date_fetch and last_run:
-        time_to_fetch_from = last_run.get("last_date")
-        time_to_fetch_from = datetime.fromisoformat(time_to_fetch_from)  # type: ignore[arg-type]
+    if date_fetch and last_run and last_run.get("last_date"):
+        time_to_fetch_from = datetime.fromisoformat(last_run["last_date"])
         demisto.debug(f"last_date as date: {time_to_fetch_from}")
     mails_fetched, messages, uid_to_fetch_from = fetch_mails(
         client=client,
@@ -409,7 +408,12 @@ def fetch_incidents(
     for mail in mails_fetched:
         incidents.append(mail.convert_to_incident())
         uid_to_fetch_from = max(uid_to_fetch_from, mail.id)
-        time_to_fetch_from = max(time_to_fetch_from, mail.date)
+        # Skip None dates so max() never compares a datetime with None (UID cursor still tracks progress).
+        if mail.date is None:
+            demisto.debug(f"Email with UID {mail.id} has no parseable Date header; excluded from date cursor.")
+        candidate_dates = [date for date in (time_to_fetch_from, mail.date) if date is not None]
+        if candidate_dates:
+            time_to_fetch_from = max(candidate_dates)
     next_run: dict = {}
     demisto.debug(f"introducing {next_run=}")
     if time_to_fetch_from:

--- a/Packs/MailListener/Integrations/MailListenerV2/MailListenerV2.py
+++ b/Packs/MailListener/Integrations/MailListenerV2/MailListenerV2.py
@@ -410,7 +410,7 @@ def fetch_incidents(
         uid_to_fetch_from = max(uid_to_fetch_from, mail.id)
         # Skip None dates so max() never compares a datetime with None (UID cursor still tracks progress).
         if mail.date is None:
-            demisto.debug(f"Email with UID {mail.id} has no parseable Date header; excluded from date cursor.")
+            demisto.debug(f"[MailListenerV2] Email with UID {mail.id} has no parseable Date header; excluded from date cursor.")
         candidate_dates = [date for date in (time_to_fetch_from, mail.date) if date is not None]
         if candidate_dates:
             time_to_fetch_from = max(candidate_dates)

--- a/Packs/MailListener/Integrations/MailListenerV2/MailListenerV2_test.py
+++ b/Packs/MailListener/Integrations/MailListenerV2/MailListenerV2_test.py
@@ -236,6 +236,18 @@ def mock_email():
         return email
 
 
+def mock_email_without_date(mail_id=0):
+    """Build a mock Email whose Date header could not be parsed, so its date is None."""
+    from unittest.mock import patch
+    from MailListenerV2 import Email
+
+    with patch.object(Email, "__init__", lambda a, b, c, d, e: None):
+        email = Email("data", False, False, 0)
+        email.id = mail_id
+        email.date = None
+        return email
+
+
 @pytest.mark.parametrize(
     "src_data, expected", [({1: {b"RFC822": rb"C:\User\u"}}, rb"C:\User\u"), ({2: {b"RFC822": rb"C:\User\u"}}, rb"C:\User\u")]
 )
@@ -580,14 +592,7 @@ LINE2
         ),
         # credentials with human readable text
         (
-            "text1 "
-            "text2 "
-            "-----BEGIN EC PRIVATE KEY----- "
-            "LINE1 "
-            "LINE2 "
-            "-----END EC PRIVATE KEY----- "
-            "text1 "
-            "text2",
+            "text1 text2 -----BEGIN EC PRIVATE KEY----- LINE1 LINE2 -----END EC PRIVATE KEY----- text1 text2",
             """text1 text2
 -----BEGIN EC PRIVATE KEY-----
 LINE1
@@ -705,6 +710,87 @@ def test_fetch_incidents__last_uid_was_zero(mocker):
         date_fetch=False,
     )
     assert next_run == {"last_date": "2022-01-01T00:00:00+00:00"}
+
+
+def test_fetch_incidents__email_without_date(mocker):
+    """
+    Given:
+        - A fetched email whose Date header could not be parsed (Email.date is None),
+          together with a dated email, while fetching by date (date_fetch=True) with an existing last_date.
+    When:
+        - Fetching incidents.
+    Then:
+        - Ensure the fetch does not raise a TypeError from max(datetime, None),
+          the undated email is still returned as an incident, and the date cursor
+          advances to the newest available (dated) email.
+    """
+    from MailListenerV2 import fetch_incidents
+
+    mocker.patch("MailListenerV2.Email.convert_to_incident", return_value={})
+    dated_email = mock_email()
+    dated_email.id = 6
+    undated_email = mock_email_without_date(mail_id=7)
+    mocker.patch("MailListenerV2.fetch_mails", return_value=([dated_email, undated_email], [dated_email, undated_email], 7))
+
+    next_run, incidents = fetch_incidents(
+        client=mocker.Mock(),
+        last_run={"last_uid": "5", "last_date": "2020-01-01T00:00:00+00:00"},
+        first_fetch_time="2022-01-01 00:00:00",
+        include_raw_body=False,
+        with_headers=False,
+        permitted_from_addresses="test@example.com",
+        permitted_from_domains="example.com",
+        delete_processed=False,
+        limit=10,
+        save_file=False,
+        date_fetch=True,
+    )
+    # Both emails are ingested (undated one is not dropped).
+    assert len(incidents) == 2
+    # Cursor advanced to the dated email's date, ignoring the None date.
+    assert next_run["last_date"] == "2020-10-01T00:00:00+00:00"
+    assert next_run["last_uid"] == "7"
+
+
+def test_fetch_incidents__only_email_without_date(mocker):
+    """
+    Given:
+        - The only fetched email has no parseable Date header (Email.date is None),
+          with date_fetch disabled and no prior last_date. In this first-fetch path
+          time_to_fetch_from is initialized from first_fetch_time, while mail.date is None.
+    When:
+        - Fetching incidents.
+    Then:
+        - Ensure the fetch does not raise (the None mail.date is ignored in the max()),
+          the undated email is still ingested, and the date cursor keeps the
+          first_fetch_time value while the UID cursor advances.
+    """
+    import demistomock as demisto
+    from MailListenerV2 import fetch_incidents
+
+    mocker.patch("MailListenerV2.Email.convert_to_incident", return_value={})
+    debug_mocker = mocker.patch.object(demisto, "debug")
+    undated_email = mock_email_without_date(mail_id=7)
+    mocker.patch("MailListenerV2.fetch_mails", return_value=([undated_email], [undated_email], 7))
+
+    next_run, incidents = fetch_incidents(
+        client=mocker.Mock(),
+        last_run={"last_uid": "5"},
+        first_fetch_time="2022-01-01 00:00:00",
+        include_raw_body=False,
+        with_headers=False,
+        permitted_from_addresses="test@example.com",
+        permitted_from_domains="example.com",
+        delete_processed=False,
+        limit=10,
+        save_file=False,
+        date_fetch=False,
+    )
+    assert len(incidents) == 1
+    assert next_run["last_date"] == "2022-01-01T00:00:00+00:00"
+    assert next_run["last_uid"] == "7"
+    # Ensure we logged evidence that the email had no parseable Date header.
+    assert any("has no parseable Date header" in str(call.args[0]) for call in debug_mocker.call_args_list if call.args)
 
 
 def test_fetch_mails__mail_id_is_greater(mocker):

--- a/Packs/MailListener/ReleaseNotes/1_0_71.md
+++ b/Packs/MailListener/ReleaseNotes/1_0_71.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Mail Listener v2
+
+- Fixed an issue where fetching incidents failed with the error `'>' not supported between instances of 'datetime.datetime' and 'NoneType'` when a fetched email did not contain a parseable *Date* header.

--- a/Packs/MailListener/pack_metadata.json
+++ b/Packs/MailListener/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Mail Listener",
     "description": "Listen to a mailbox, enable incident triggering via e-mail",
     "support": "xsoar",
-    "currentVersion": "1.0.70",
+    "currentVersion": "1.0.71",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes:https://jira-dc.paloaltonetworks.com/browse/XSUP-76251
## Description
Fixed an issue where fetching incidents failed with the error `'>' not supported between instances of 'datetime.datetime' and 'NoneType'` when a fetched email did not contain a parseable *Date* header
## Must have
- [ ] Tests
- [ ] Documentation
