### PR TITLE
XSUP-75661: SplunkPy v2 - include note in finding update on ES 8.4+ (MC_0206)

### DIFF
--- a/Packs/SplunkPy/Integrations/SplunkPyV2/SplunkPyV2.py
+++ b/Packs/SplunkPy/Integrations/SplunkPyV2/SplunkPyV2.py
@@ -59,6 +59,10 @@ DEFAULT_STATUSES = {
 MIRROR_DIRECTION = {"None": None, "Incoming": "In", "Outgoing": "Out", "Incoming And Outgoing": "Both"}
 OUTGOING_MIRRORED_FIELDS = ["note", "status", "owner", "urgency", "reviewer", "disposition"]
 ES_APP_NAME = "SplunkEnterpriseSecuritySuite"
+# From Splunk ES 8.4, update requests to the v2 investigations endpoint must include an
+# ``incident_note`` field (with nested ``content``) whenever the tenant enforces the
+# "note required on update" constraint. Earlier versions (8.2/8.3) do not support this field.
+ES_INCIDENT_NOTE_MIN_VERSION = "8.4"
 
 # === Note Tag Globals ===
 NOTE_TAG_TO_SPLUNK = params.get("note_tag_to_splunk", "FROM XSOAR")
@@ -3452,8 +3456,11 @@ def update_remote_system_command(
 
         if any(changed_data.values()):
             demisto.debug(f"Sending update request to Splunk for entity {entity_id}, data: {changed_data}")
+            note_content = f"{changed_data['note']}\n{COMMENT_MIRRORED_FROM_XSOAR}" if changed_data.get("note") else None
             try:
                 # Use the v2 API for field updates (handles both findings and investigations).
+                # Note handling (embedding it in the same request on ES >=8.4 vs. a separate call on
+                # older versions) is done inside update_investigation_or_finding.
                 demisto.debug(f"Using v2 API to update entity {entity_id}")
                 response_info = update_investigation_or_finding(
                     service=service,
@@ -3463,22 +3470,9 @@ def update_remote_system_command(
                     status=changed_data.get("status"),
                     disposition=changed_data.get("disposition"),
                     finding_time=finding_time,
+                    note=note_content,
                 )
                 demisto.debug(f"update-remote-system for entity {entity_id} via v2 API: {response_info}")
-
-                # Handle notes separately using the new add_investigation_note function
-                if changed_data.get("note"):
-                    demisto.debug(f"Adding note to entity {entity_id} via add_investigation_note")
-                    try:
-                        note_content = f"{changed_data['note']}\n{COMMENT_MIRRORED_FROM_XSOAR}"
-                        add_investigation_note(
-                            service=service,
-                            investigation_or_finding_id=entity_id,
-                            content=note_content,
-                        )
-                        demisto.debug(f"Note added successfully to entity {entity_id}")
-                    except Exception as e:
-                        demisto.error(f"Failed adding note to entity {entity_id}: {e!s}")
 
             except Exception as e:
                 demisto.error(
@@ -4176,6 +4170,7 @@ def update_investigation_or_finding(
     finding_time: str | None = None,
     name: str | None = None,
     description: str | None = None,
+    note: str | None = None,
 ):
     """
     Update a Splunk investigation or finding via the v2 investigations API endpoint.
@@ -4195,6 +4190,12 @@ def update_investigation_or_finding(
             call is made without notable_time and falls back to notable_time="now" on failure.
         name (str | None): New name for the investigation (investigations only).
         description (str | None): New description for the investigation (investigations only).
+        note (str | None): Note content to apply to the investigation/finding. Version handling
+            is done internally: on Splunk ES >=8.4 the note is embedded in the same update request
+            as an ``incident_note`` field (with nested ``content``), satisfying the mandatory-note
+            constraint on updates (error code MC_0206); on earlier ES versions (where the
+            ``incident_note`` field is unsupported) the note is added via a separate
+            ``add_investigation_note`` call after the field update.
 
     Returns:
         dict: The JSON response from the API
@@ -4202,8 +4203,24 @@ def update_investigation_or_finding(
     Raises:
         Exception: If the API request fails
     """
+    # From Splunk ES 8.4 the note must be part of the same update request (as an ``incident_note``
+    # field) when the tenant enforces a mandatory note on updates (error code MC_0206). On earlier
+    # versions the field is unsupported, so the note is added via a separate ``add_investigation_note``
+    # call after the field update (preserving the legacy behavior).
+    embed_note_in_update = False
+    if note is not None:
+        es_version = get_enterprise_security_version(service)
+        try:
+            embed_note_in_update = Version(es_version) >= Version(ES_INCIDENT_NOTE_MIN_VERSION)
+        except (InvalidVersion, TypeError):
+            embed_note_in_update = False
+        demisto.debug(
+            f"update_investigation_or_finding: ES version={es_version}, "
+            f"embedding note in update request={embed_note_in_update}"
+        )
+
     # Build the request body with only the fields that are provided
-    body = {}
+    body: dict[str, Any] = {}
     if owner is not None:
         body["owner"] = owner
     if urgency is not None:
@@ -4217,10 +4234,24 @@ def update_investigation_or_finding(
     if description is not None:
         body["description"] = description
 
-    # If no fields to update, return early
+    # If there are no fields to update, add the note (if any) on its own and return early.
+    # A request carrying only an incident_note is not a real field update, so it is always
+    # applied via add_investigation_note regardless of ES version.
     if not body:
+        if note is not None:
+            demisto.debug(f"Only a note to apply for investigation/finding {investigation_or_finding_id}")
+            return add_investigation_note(
+                service=service,
+                investigation_or_finding_id=investigation_or_finding_id,
+                content=note,
+                finding_time=finding_time,
+            )
         demisto.debug(f"No fields to update for investigation/finding {investigation_or_finding_id}")
         return {"success": False, "message": "No fields provided to update"}
+
+    # On ES >=8.4 embed the note in the same request as the field update.
+    if note is not None and embed_note_in_update:
+        body["incident_note"] = {"content": note}
 
     endpoint = f"public/v2/investigations/{investigation_or_finding_id}"
 
@@ -4246,6 +4277,17 @@ def update_investigation_or_finding(
     response_data = response.body.read()
     result = json.loads(response_data)
     demisto.debug(f"Successfully updated investigation/finding {investigation_or_finding_id}: {result}")
+
+    # On ES <8.4 the note is not part of the update request; add it via a separate call.
+    if note is not None and not embed_note_in_update:
+        demisto.debug(f"Adding note to investigation/finding {investigation_or_finding_id} via add_investigation_note")
+        add_investigation_note(
+            service=service,
+            investigation_or_finding_id=investigation_or_finding_id,
+            content=note,
+            finding_time=finding_time,
+        )
+
     return result
 
 
@@ -5320,7 +5362,9 @@ def splunk_edit_event_command(service: client.Service, args: dict) -> None:
     for event_id in event_ids:
         event_id = event_id.strip()
         try:
-            # Update the finding using the v2 API
+            # Update the finding using the v2 API. Note handling (embedding it in the same request
+            # on ES >=8.4 vs. a separate call on older versions) is done inside
+            # update_investigation_or_finding.
             update_investigation_or_finding(
                 service=service,
                 investigation_or_finding_id=event_id,
@@ -5329,21 +5373,11 @@ def splunk_edit_event_command(service: client.Service, args: dict) -> None:
                 status=status,
                 disposition=disposition,
                 finding_time=finding_time,
+                note=note,
             )
 
-            # Add note separately if provided
             if note:
-                try:
-                    add_investigation_note(
-                        service=service,
-                        investigation_or_finding_id=event_id,
-                        content=note,
-                        finding_time=finding_time,
-                    )
-                    results.append(f"Successfully updated Splunk ES event {event_id} (including note)")
-                except Exception as e:
-                    demisto.error(f"Failed to add note to Splunk ES event {event_id}: {e!s}")
-                    results.append(f"Successfully updated Splunk ES event {event_id} (note failed: {e!s})")
+                results.append(f"Successfully updated Splunk ES event {event_id} (including note)")
             else:
                 results.append(f"Successfully updated Splunk ES event {event_id}")
 

--- a/Packs/SplunkPy/Integrations/SplunkPyV2/SplunkPyV2.yml
+++ b/Packs/SplunkPy/Integrations/SplunkPyV2/SplunkPyV2.yml
@@ -1,7 +1,7 @@
 category: Analytics & SIEM
 provider: Cisco Systems
 commonfields:
-  id: SplunkPy v2FIX_UPDATE
+  id: SplunkPy v2
   version: -1
 sectionorder:
 - Connect
@@ -345,8 +345,8 @@ configuration:
   - agentix
   - xsiam
 description: Run queries on Splunk and fetch Splunk ES Findings and Investigations (Splunk ES 8.2+).
-display: SplunkPy v2 (FIX_UPDATE)
-name: SplunkPy v2FIX_UPDATE
+display: SplunkPy v2
+name: SplunkPy v2
 script:
   commands:
   - arguments:

--- a/Packs/SplunkPy/Integrations/SplunkPyV2/SplunkPyV2.yml
+++ b/Packs/SplunkPy/Integrations/SplunkPyV2/SplunkPyV2.yml
@@ -1,7 +1,7 @@
 category: Analytics & SIEM
 provider: Cisco Systems
 commonfields:
-  id: SplunkPy v2
+  id: SplunkPy v2FIX_UPDATE
   version: -1
 sectionorder:
 - Connect
@@ -345,8 +345,8 @@ configuration:
   - agentix
   - xsiam
 description: Run queries on Splunk and fetch Splunk ES Findings and Investigations (Splunk ES 8.2+).
-display: SplunkPy v2
-name: SplunkPy v2
+display: SplunkPy v2 (FIX_UPDATE)
+name: SplunkPy v2FIX_UPDATE
 script:
   commands:
   - arguments:

--- a/Packs/SplunkPy/Integrations/SplunkPyV2/SplunkPyV2_test.py
+++ b/Packs/SplunkPy/Integrations/SplunkPyV2/SplunkPyV2_test.py
@@ -2705,6 +2705,33 @@ def test_edit_finding_event__failed_to_update(mocker):
     assert "Failed to update Splunk ES event ID100: ValueError: Invalid owner value." in error_message
 
 
+def test_splunk_edit_event_command_forwards_note_to_update(mocker):
+    """
+    Given
+    - splunk-finding-event-edit args with status and a note.
+
+    When
+    - splunk_edit_event_command is called.
+
+    Then
+    - The note is forwarded to update_investigation_or_finding (which centralizes the version-aware
+      note handling), instead of being applied via a separate add_investigation_note call here.
+    """
+    test_args = {"event_ids": "ID100", "status": "In Progress", "note": "Handled by SOC"}
+    mock_update = mocker.patch.object(splunk, "update_investigation_or_finding")
+    mocker.patch.object(demisto, "results")
+    mocker.patch.object(demisto, "debug")
+
+    splunk.splunk_edit_event_command(service=MagicMock(), args=test_args)
+
+    mock_update.assert_called_once()
+    call_kwargs = mock_update.call_args.kwargs
+    assert call_kwargs["investigation_or_finding_id"] == "ID100"
+    assert call_kwargs["note"] == "Handled by SOC"
+    # status label mapped to its id
+    assert call_kwargs["status"] == splunk.DEFAULT_STATUSES["In Progress"]
+
+
 NOTABLE = {
     "rule_name": "string",
     "rule_title": "string",
@@ -4815,8 +4842,10 @@ def test_update_remote_system_command_with_note_in_delta(mocker):
         - update_remote_system_command is called
 
     Then:
-        - add_investigation_note is called with the note content
-        - Note includes COMMENT_MIRRORED_FROM_XSOAR marker
+        - The note is forwarded to update_investigation_or_finding (which centralizes note
+          handling: embedding it in the same request on ES >=8.4, or adding it via a separate
+          call on older versions).
+        - Note includes COMMENT_MIRRORED_FROM_XSOAR marker.
     """
     # Setup
     finding_id = "test_finding_note"
@@ -4836,8 +4865,8 @@ def test_update_remote_system_command_with_note_in_delta(mocker):
     mock_mapper = MagicMock()
     mock_mapper.should_map = False
 
-    mocker.patch("SplunkPyV2.update_investigation_or_finding")
-    mock_add_note = mocker.patch("SplunkPyV2.add_investigation_note")
+    mocker.patch("SplunkPyV2.get_enterprise_security_version", return_value="8.4.0")
+    mock_update = mocker.patch("SplunkPyV2.update_investigation_or_finding")
     mocker.patch.object(demisto, "debug")
 
     # Execute
@@ -4845,11 +4874,11 @@ def test_update_remote_system_command_with_note_in_delta(mocker):
 
     # Verify
     assert result == finding_id
-    mock_add_note.assert_called_once()
-    call_args = mock_add_note.call_args
+    mock_update.assert_called_once()
+    call_args = mock_update.call_args
     assert call_args[1]["investigation_or_finding_id"] == finding_id
-    assert note_content in call_args[1]["content"]
-    assert splunk.COMMENT_MIRRORED_FROM_XSOAR in call_args[1]["content"]
+    assert note_content in call_args[1]["note"]
+    assert splunk.COMMENT_MIRRORED_FROM_XSOAR in call_args[1]["note"]
 
 
 def test_update_remote_system_command_with_entries(mocker):
@@ -5039,11 +5068,11 @@ def test_update_remote_system_command_api_error(mocker):
 
 def test_update_remote_system_command_note_api_error(mocker):
     """
-    Test update_remote_system_command when add_investigation_note fails.
+    Test update_remote_system_command when the update (which now carries the note) fails.
 
     Given:
         - Delta with note field
-        - add_investigation_note raises an exception
+        - update_investigation_or_finding raises an exception (note handling is centralized there)
 
     When:
         - update_remote_system_command is called
@@ -5069,9 +5098,9 @@ def test_update_remote_system_command_note_api_error(mocker):
     mock_mapper = MagicMock()
     mock_mapper.should_map = False
 
-    mocker.patch("SplunkPyV2.update_investigation_or_finding")
     error_message = "Note API Error"
-    mock_add_note = mocker.patch("SplunkPyV2.add_investigation_note", side_effect=Exception(error_message))
+    mocker.patch("SplunkPyV2.get_enterprise_security_version", return_value="8.4.0")
+    mock_update = mocker.patch("SplunkPyV2.update_investigation_or_finding", side_effect=Exception(error_message))
     mock_error = mocker.patch.object(demisto, "error")
     mocker.patch.object(demisto, "debug")
 
@@ -5080,7 +5109,7 @@ def test_update_remote_system_command_note_api_error(mocker):
 
     # Verify
     assert result == finding_id
-    mock_add_note.assert_called_once()
+    mock_update.assert_called_once()
     mock_error.assert_called()
     error_call_args = mock_error.call_args[0][0]
     assert finding_id in error_call_args
@@ -6109,6 +6138,176 @@ def test_update_investigation_or_finding_with_finding_time():
         body=json.dumps({"status": "closed"}),
         notable_time=finding_time,
     )
+
+
+def test_update_investigation_or_finding_note_embedded_on_es_8_4(mocker):
+    """
+    Given:
+        - A Splunk ES tenant reporting version 8.4.0 (>= 8.4).
+        - A status update together with a note.
+    When:
+        - update_investigation_or_finding is called with a note.
+    Then:
+        - The note is embedded as an incident_note field (with nested content) in the same
+          update request, satisfying the MC_0206 mandatory-note constraint.
+        - service.post is called exactly once and no separate add_investigation_note call is made.
+    """
+    mocker.patch("SplunkPyV2.get_enterprise_security_version", return_value="8.4.0")
+    mock_add_note = mocker.patch("SplunkPyV2.add_investigation_note")
+    mock_service = MagicMock()
+    expected_result = {"id": "finding-abc", "status": "105"}
+    mock_response = MagicMock()
+    mock_response.body.read.return_value = json.dumps(expected_result).encode()
+    mock_service.post.return_value = mock_response
+
+    result = splunk.update_investigation_or_finding(
+        service=mock_service,
+        investigation_or_finding_id="finding-abc",
+        status="105",
+        note="Investigated and resolved",
+    )
+
+    assert result == expected_result
+    mock_service.post.assert_called_once_with(
+        "public/v2/investigations/finding-abc",
+        body=json.dumps({"status": "105", "incident_note": {"content": "Investigated and resolved"}}),
+    )
+    mock_add_note.assert_not_called()
+
+
+def test_update_investigation_or_finding_note_separate_on_es_8_3(mocker):
+    """
+    Given:
+        - A Splunk ES tenant reporting version 8.3.1 (< 8.4, incident_note unsupported).
+        - A status update together with a note.
+    When:
+        - update_investigation_or_finding is called with a note.
+    Then:
+        - The update request body does NOT contain an incident_note field.
+        - The note is applied via a separate add_investigation_note call after the update
+          (legacy behavior preserved).
+    """
+    mocker.patch("SplunkPyV2.get_enterprise_security_version", return_value="8.3.1")
+    mock_add_note = mocker.patch("SplunkPyV2.add_investigation_note")
+    mock_service = MagicMock()
+    expected_result = {"id": "finding-abc", "status": "105"}
+    mock_response = MagicMock()
+    mock_response.body.read.return_value = json.dumps(expected_result).encode()
+    mock_service.post.return_value = mock_response
+
+    result = splunk.update_investigation_or_finding(
+        service=mock_service,
+        investigation_or_finding_id="finding-abc",
+        status="105",
+        note="Investigated and resolved",
+        finding_time="2024-01-15T12:34:56.000+00:00",
+    )
+
+    assert result == expected_result
+    mock_service.post.assert_called_once_with(
+        "public/v2/investigations/finding-abc",
+        body=json.dumps({"status": "105"}),
+        notable_time="2024-01-15T12:34:56.000+00:00",
+    )
+    mock_add_note.assert_called_once_with(
+        service=mock_service,
+        investigation_or_finding_id="finding-abc",
+        content="Investigated and resolved",
+        finding_time="2024-01-15T12:34:56.000+00:00",
+    )
+
+
+def test_update_investigation_or_finding_note_only_on_es_8_3(mocker):
+    """
+    Given:
+        - A Splunk ES tenant reporting version 8.3.0 (< 8.4).
+        - Only a note is provided (no other fields to update).
+    When:
+        - update_investigation_or_finding is called with just a note.
+    Then:
+        - No field update request is sent (service.post is not called for a field update).
+        - The note is applied via add_investigation_note only.
+    """
+    mocker.patch("SplunkPyV2.get_enterprise_security_version", return_value="8.3.0")
+    add_note_result = {"note": "added"}
+    mock_add_note = mocker.patch("SplunkPyV2.add_investigation_note", return_value=add_note_result)
+    mock_service = MagicMock()
+
+    result = splunk.update_investigation_or_finding(
+        service=mock_service,
+        investigation_or_finding_id="finding-abc",
+        note="Just a note",
+    )
+
+    assert result == add_note_result
+    mock_service.post.assert_not_called()
+    mock_add_note.assert_called_once_with(
+        service=mock_service,
+        investigation_or_finding_id="finding-abc",
+        content="Just a note",
+        finding_time=None,
+    )
+
+
+def test_update_investigation_or_finding_note_only_on_es_8_4(mocker):
+    """
+    Given:
+        - A Splunk ES tenant reporting version 8.4.2 (>= 8.4).
+        - Only a note is provided (no other fields to update).
+    When:
+        - update_investigation_or_finding is called with just a note.
+    Then:
+        - Since there are no fields to update, the note is applied via add_investigation_note
+          (an empty update request with only incident_note is not sent).
+    """
+    mocker.patch("SplunkPyV2.get_enterprise_security_version", return_value="8.4.2")
+    add_note_result = {"note": "added"}
+    mock_add_note = mocker.patch("SplunkPyV2.add_investigation_note", return_value=add_note_result)
+    mock_service = MagicMock()
+
+    result = splunk.update_investigation_or_finding(
+        service=mock_service,
+        investigation_or_finding_id="finding-abc",
+        note="Just a note",
+    )
+
+    assert result == add_note_result
+    mock_service.post.assert_not_called()
+    mock_add_note.assert_called_once()
+
+
+def test_update_investigation_or_finding_note_unknown_es_version(mocker):
+    """
+    Given:
+        - A Splunk ES tenant whose version cannot be determined ("unknown").
+        - A status update together with a note.
+    When:
+        - update_investigation_or_finding is called with a note.
+    Then:
+        - The version comparison fails safely (treated as < 8.4), so the note is NOT embedded
+          and is added via a separate add_investigation_note call.
+    """
+    mocker.patch("SplunkPyV2.get_enterprise_security_version", return_value="unknown")
+    mock_add_note = mocker.patch("SplunkPyV2.add_investigation_note")
+    mock_service = MagicMock()
+    expected_result = {"id": "finding-abc", "status": "105"}
+    mock_response = MagicMock()
+    mock_response.body.read.return_value = json.dumps(expected_result).encode()
+    mock_service.post.return_value = mock_response
+
+    result = splunk.update_investigation_or_finding(
+        service=mock_service,
+        investigation_or_finding_id="finding-abc",
+        status="105",
+        note="A note",
+    )
+
+    assert result == expected_result
+    mock_service.post.assert_called_once_with(
+        "public/v2/investigations/finding-abc",
+        body=json.dumps({"status": "105"}),
+    )
+    mock_add_note.assert_called_once()
 
 
 # =================================================================================

--- a/Packs/SplunkPy/ReleaseNotes/4_3_5.md
+++ b/Packs/SplunkPy/ReleaseNotes/4_3_5.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### SplunkPy v2
+
+- Fixed an issue where updating a finding failed when Splunk required a note on updates.

--- a/Packs/SplunkPy/pack_metadata.json
+++ b/Packs/SplunkPy/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Splunk",
     "description": "Fetch events as incidents and search Splunk",
     "support": "xsoar",
-    "currentVersion": "4.3.4",
+    "currentVersion": "4.3.5",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Summary
- Fixed SplunkPy v2 `splunk-finding-event-edit` / mirror-out failing with Splunk error **MC_0206** ("A note is required for this update action") on Splunk ES 8.4+ when the tenant enforces a mandatory note on updates.
- On ES >= 8.4 the note is now embedded in the same finding-update request (`incident_note.content`); on earlier ES versions the note is still added via a separate call (legacy behavior preserved).
- Centralized all note handling inside `update_investigation_or_finding`; simplified `splunk_edit_event_command` and the mirror-out path in `update_remote_system_command` to just forward the note.
- Added unit tests for the ES 8.4+/8.3/unknown-version paths and note forwarding.

## Related Issues
fixes: XSUP-75661
