### PR TITLE
CRTX-276239  - fix vCenter pid mapping 

### DIFF
--- a/Packs/VMwareVCenter/ModelingRules/VMwareVcenter_2_9/VMwareVcenter_2_9.xif
+++ b/Packs/VMwareVCenter/ModelingRules/VMwareVcenter_2_9/VMwareVcenter_2_9.xif
@@ -299,13 +299,13 @@ alter
                            success = "no" or res = "0", XDM_CONST.OUTCOME_FAILED,
                            XDM_CONST.OUTCOME_UNKNOWN),
     xdm.event.outcome_reason = parsed_fields -> exit,
-    xdm.source.process.pid = to_number(ppid),
+    xdm.source.process.pid = to_integer(ppid),
     xdm.target.user.username = uid,
     xdm.target.user.identifier = uid,
     xdm.target.process.name = comm,
     xdm.target.process.parent_id = if(event_name_clean = "SYSCALL", null, ppid),
     xdm.target.process.executable.path = parsed_fields -> exe,
-    xdm.target.process.pid = to_number(pid),
+    xdm.target.process.pid = to_integer(pid),
     xdm.target.process.command_line = if(event_name_clean = "SYSCALL", null, comm);
 
 // Virtualization Story general field mapping
@@ -319,6 +319,7 @@ alter
 | alter
     xdm.event.tags = arraycreate("VIRTUALIZATION"),
 	xdm.source.process.identifier = process_id,
+	xdm.source.process.pid = to_integer(process_id),
 	xdm.source.process.name = process_name,
     xdm.event.format = if(_raw_log ~= "^<\d+>1\s", "0",
                           _raw_log ~= "^<\d+>\s", "1");  

--- a/Packs/VMwareVCenter/ReleaseNotes/1_0_26.md
+++ b/Packs/VMwareVCenter/ReleaseNotes/1_0_26.md
@@ -1,0 +1,6 @@
+#### Modeling Rules
+
+##### VMware Vcenter 2.9 Modeling Rule
+
+- Fixed an issue where **source_process_pid** was empty for vCenter Virtualization Story events. The syslog-header process id is now mapped to the source process id (`xdm.source.process.pid`) in addition to the source process identifier.
+- Restored mapping of **source_process_pid** and **target_process_pid** for *vcsa-audit* SYSCALL events using `to_integer`, correctly handling process IDs of 1,000,000 or higher.

--- a/Packs/VMwareVCenter/pack_metadata.json
+++ b/Packs/VMwareVCenter/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "VMware vCenter",
     "description": "Modeling Rules for the VMware vCenter logs collector",
     "support": "xsoar",
-    "currentVersion": "1.0.25",
+    "currentVersion": "1.0.26",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Summary

`xdm.source.process.pid` and `xdm.target.process.pid` in the vcsa-audit modeling rule used `to_number()`, which returns a **float**. Both fields map to **INTEGER** columns in `virtualization_data`, and the float form is not stored, so every pid at or above 1,000,000 landed as `NULL`.

vCenter recycles pids up to ~4,194,304, so the appliance spends most of its cycle above 1e6. On the reporting tenant this silently dropped the pid on **15,766 of 20,490** vcsa-audit SYSCALL rows (77%) over 14 days.

## Root cause

```
xdm.source.process.pid = to_number(ppid),   // line 302 -> float -> INTEGER column
xdm.target.process.pid = to_number(pid),    // line 308 -> float -> INTEGER column
```

Parsing is not at fault: `parsed_fields.pid` holds the full value (`"3831040"`) on 100% of rows. The value is lost at the modeling assignment.

The sibling **VMwareESXi** pack already uses `to_integer()` for this same XDM field, and its pid populates correctly for 7-digit values (55,143 / 56,999 rows). This change brings vCenter in line.

## Verification on qa2-test-9996474355035

Pushed a crafted vcsa-audit metablob containing both 7-digit and 6-digit pids as a built-in control:

| pid in log | `target_process_pid` before fix |
|---|---|
| 3831040 (7-digit) | **NULL** |
| 3999888 (7-digit) | **NULL** |
| 999497 (6-digit) | 999497 |
| 888123 (6-digit) | 888123 |

Same rule, same run, same message shape — only magnitude differs. XQL over those ingested rows confirms the mechanism:

```
pid_txt='3831040'  to_number=3831040.0  to_integer=3831040
pid_txt='3999888'  to_number=3999888.0  to_integer=3999888
```

## Related

- CRTX-276239
- Follows the process model set in CRTX-257939 (spawner = source, spawned = target); `target_process_ppid` remains intentionally NULL for SYSCALL records and is unchanged here.
