### PR TITLE
CRTX-217351 - map IronScales mitigations affected mailboxes

### DIFF
--- a/Packs/IronscalesEventCollector/ModelingRules/IronscalesModelingRules_2_11/IronscalesModelingRules_2_11.xif
+++ b/Packs/IronscalesEventCollector/ModelingRules/IronscalesModelingRules_2_11/IronscalesModelingRules_2_11.xif
@@ -5,6 +5,7 @@ alter
 | alter
 	xdm.event.id = to_string(incident_id),
 	xdm.event.outcome_reason = classification,
+	xdm.event.description = to_json_string(object_create("mitigation", arraymap(mitigations -> [], json_extract_scalar("@element","$.mailbox_email")))),
 	xdm.email.sender = sender_email,
 	xdm.email.recipients = arraycreate(name),
 	xdm.observer.action = themis_verdict,

--- a/Packs/IronscalesEventCollector/ModelingRules/IronscalesModelingRules_2_11/IronscalesModelingRules_2_11_schema.json
+++ b/Packs/IronscalesEventCollector/ModelingRules/IronscalesModelingRules_2_11/IronscalesModelingRules_2_11_schema.json
@@ -55,6 +55,10 @@
         "original_email_body": {
             "type": "string",
             "is_array": false
+        },
+        "mitigations": {
+            "type": "string",
+            "is_array": false
         }
     }
 }

--- a/Packs/IronscalesEventCollector/ReleaseNotes/1_2_8.md
+++ b/Packs/IronscalesEventCollector/ReleaseNotes/1_2_8.md
@@ -2,4 +2,4 @@
 
 ##### IRONSCALES Modeling Rule
 
-Added mapping for the new **mitigations** field (affected mailboxes) to *xdm.event.description*.
+- Added mapping for the new *`mitigations`* field (affected mailboxes) to *`xdm.event.description`*.

--- a/Packs/IronscalesEventCollector/ReleaseNotes/1_2_8.md
+++ b/Packs/IronscalesEventCollector/ReleaseNotes/1_2_8.md
@@ -1,0 +1,5 @@
+#### Modeling Rules
+
+##### IRONSCALES Modeling Rule
+
+Added mapping for the new **mitigations** field (affected mailboxes) to *xdm.event.description*.

--- a/Packs/IronscalesEventCollector/pack_metadata.json
+++ b/Packs/IronscalesEventCollector/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Ironscales Event Collector",
     "description": "IRONSCALES is a self-learning email security platform, automatically responding to malicious emails.",
     "support": "xsoar",
-    "currentVersion": "1.2.7",
+    "currentVersion": "1.2.8",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
### CRTX-217351 — map IronScales mitigations (affected mailboxes)

Enhancement of the IRONSCALES pack (mapping of CIAC-9765 collector change).

**What**
- Adds mapping for the new `mitigations` field to `xdm.event.description`:
  `to_json_string(object_create("mitigation", arraymap(mitigations -> [], json_extract_scalar("@element","$.mailbox_email"))))`
  → yields `{"mitigation": ["<affected mailbox emails>"]}`.
- Added `mitigations` to both modeling-rule schemas (`type: string`, matching the sibling `attachments`/`links` array fields).
- Applied to `IronscalesModelingRules_2_11`.
- Bumped pack version 1.2.7 → 1.2.8 + release note.

**Testing**
- `demisto-sdk validate` → All validations passed.
- Uploaded pack v1.2.8 to a dev tenant and validated `xdm.event.description` on a real IronScales sample with multiple affected mailboxes → correct object output.