### PR TITLE
[Doppel] API V2 support with OAuth 2.0 client credentials (pack v1.3.0)

### DIFF
--- a/Packs/Doppel/Integrations/Doppel/Doppel.py
+++ b/Packs/Doppel/Integrations/Doppel/Doppel.py
@@ -3,6 +3,7 @@ from CommonServerPython import *
 from CommonServerUserPython import *
 
 import json
+import time
 import traceback
 from datetime import datetime, UTC
 
@@ -50,8 +51,20 @@ ACTIVE_QUEUE_STATES = {"doppel_review", "actioned", "needs_confirmation"}
 # Client attribution sent with every Doppel API request (usage attribution only; the header
 # is optional server-side and never affects request handling). The version is the pack
 # version and must be bumped on each release (pack_metadata.json is not readable at runtime).
-PACK_VERSION = "1.2.0"
+PACK_VERSION = "1.3.0"
 CLIENT_ATTRIBUTION = f"xsoar/{PACK_VERSION}"
+
+# --- API V2 (OAuth 2.0 client credentials) constants ---
+API_VERSION_V1 = "v1"
+API_VERSION_V2 = "v2"
+OAUTH_TOKEN_PATH = "/oauth/token"
+OAUTH_AUDIENCE = "doppel-external"
+# Key under which the minted token is cached in the integration context.
+OAUTH_CONTEXT_KEY = "oauth_token"
+# Tokens are valid for 24h; refresh a bit early so a token never expires mid-request.
+OAUTH_EXPIRY_SAFETY_MARGIN_SECONDS = 300
+# Fallback if the token response omits expires_in (documented value: 86400 = 24h).
+OAUTH_DEFAULT_EXPIRES_IN_SECONDS = 86400
 
 
 """ CLIENT CLASS """
@@ -70,7 +83,7 @@ class Client(BaseClient):
     def __init__(
         self,
         base_url,
-        api_key,
+        api_key=None,
         user_api_key=None,
         organization_code=None,
         verify=None,
@@ -78,19 +91,33 @@ class Client(BaseClient):
         retry_total=DEFAULT_RETRY_TOTAL,
         retry_backoff_factor=DEFAULT_RETRY_BACKOFF_FACTOR,
         retry_status_list=DEFAULT_RETRY_STATUS_LIST,
+        api_version=API_VERSION_V1,
+        oauth_client_id=None,
+        oauth_client_secret=None,
+        token_url=None,
     ):
         super().__init__(base_url, verify=verify, proxy=proxy)
 
+        self._api_version = api_version
+        self._oauth_client_id = oauth_client_id
+        self._oauth_client_secret = oauth_client_secret
+        self._token_url = token_url
+
         self._headers = {
             "accept": "application/json",
-            "x-api-key": api_key,
             "x-doppel-client": CLIENT_ATTRIBUTION,
             "User-Agent": f"doppel-{CLIENT_ATTRIBUTION}",
         }
-        if user_api_key:
-            self._headers["x-user-api-key"] = user_api_key
-        if organization_code:
-            self._headers["x-organization-code"] = organization_code
+        if api_version == API_VERSION_V2:
+            # The Authorization: Bearer header is attached lazily per request
+            # (see _http_request) so the token is only minted when needed.
+            pass
+        else:
+            self._headers["x-api-key"] = api_key
+            if user_api_key:
+                self._headers["x-user-api-key"] = user_api_key
+            if organization_code:
+                self._headers["x-organization-code"] = organization_code
 
         # Store retry configuration on the client and leverage BaseClient._http_request parameters
         self._retries = retry_total
@@ -98,9 +125,102 @@ class Client(BaseClient):
         self._status_list_to_retry = retry_status_list
 
         demisto.debug(
-            f"Initialized HTTP client using BaseClient._http_request retry params: total={retry_total}, "
-            f"backoff_factor={retry_backoff_factor}, status_list={retry_status_list}"
+            f"Initialized HTTP client (api_version={api_version}) using BaseClient._http_request retry params: "
+            f"total={retry_total}, backoff_factor={retry_backoff_factor}, status_list={retry_status_list}"
         )
+
+    def _http_request(self, *args, **kwargs):
+        """Wrap BaseClient._http_request with V2 bearer-token handling.
+
+        For V1 this is a pass-through. For V2, a valid cached token is attached
+        as a Bearer header; on a 401 (token revoked or expired early) the cache
+        is invalidated and the request is retried exactly once with a fresh token.
+        """
+        if self._api_version != API_VERSION_V2:
+            return super()._http_request(*args, **kwargs)
+
+        self._headers["Authorization"] = f"Bearer {self._get_oauth_token()}"
+        try:
+            return super()._http_request(*args, **kwargs)
+        except DemistoException as e:
+            status_code = getattr(getattr(e, "res", None), "status_code", None)
+            if status_code != 401:
+                raise
+            demisto.debug("Received 401 with cached OAuth token; minting a fresh token and retrying once.")
+            self._invalidate_cached_token()
+            self._headers["Authorization"] = f"Bearer {self._mint_oauth_token()}"
+            return super()._http_request(*args, **kwargs)
+
+    def _get_oauth_token(self) -> str:
+        """Return a valid access token, reusing the integration-context cache when possible.
+
+        Token caching is NOT an optimization: Doppel's token endpoint allows only a
+        handful of successful mints per client per hour, so every code path must go
+        through this cache. Do not replace this with a mint-per-request call.
+        """
+        cached = (get_integration_context() or {}).get(OAUTH_CONTEXT_KEY) or {}
+        access_token = cached.get("access_token")
+        expiry_epoch = arg_to_number(cached.get("expiry_epoch")) or 0
+        if access_token and int(time.time()) < expiry_epoch:
+            return access_token
+        return self._mint_oauth_token()
+
+    def _mint_oauth_token(self) -> str:
+        """Mint a new access token via the client-credentials flow and cache it."""
+
+        def _token_error_handler(response):
+            if response.status_code == 429:
+                retry_after = response.headers.get("Retry-After", "3600")
+                raise DemistoException(
+                    f"Doppel token request limit reached (a few successful token requests are allowed per hour "
+                    f"per Client ID). Retry after {retry_after} seconds. If this recurs, check whether other "
+                    f"tools share this Client ID and mint tokens aggressively."
+                )
+            if response.status_code in (401, 403):
+                raise DemistoException(
+                    "Authorization Error while requesting an OAuth token: make sure the Client ID and "
+                    "Client Secret are correctly set."
+                )
+            raise DemistoException(f"Failed to obtain an OAuth token: {response.status_code} {response.text}")
+
+        # Call super() directly: going through self._http_request would try to
+        # attach a Bearer token and recurse back into this method.
+        response = super()._http_request(
+            method="POST",
+            full_url=self._token_url,
+            headers={
+                "accept": "application/json",
+                "Content-Type": "application/json",
+                "x-doppel-client": CLIENT_ATTRIBUTION,
+                "User-Agent": f"doppel-{CLIENT_ATTRIBUTION}",
+            },
+            json_data={
+                "client_id": self._oauth_client_id,
+                "client_secret": self._oauth_client_secret,
+                "audience": OAUTH_AUDIENCE,
+                "grant_type": "client_credentials",
+            },
+            resp_type="response",
+            ok_codes=(200,),
+            error_handler=_token_error_handler,
+        )
+        token_data = response.json()
+        access_token = token_data.get("access_token")
+        if not access_token:
+            raise DemistoException("The Doppel token endpoint returned a response without an access_token.")
+
+        expires_in = arg_to_number(token_data.get("expires_in")) or OAUTH_DEFAULT_EXPIRES_IN_SECONDS
+        expiry_epoch = int(time.time()) + expires_in - OAUTH_EXPIRY_SAFETY_MARGIN_SECONDS
+        context = get_integration_context() or {}
+        context[OAUTH_CONTEXT_KEY] = {"access_token": access_token, "expiry_epoch": expiry_epoch}
+        set_integration_context(context)
+        demisto.debug(f"Minted a new OAuth token; cached until epoch {expiry_epoch}.")
+        return access_token
+
+    def _invalidate_cached_token(self) -> None:
+        context = get_integration_context() or {}
+        if context.pop(OAUTH_CONTEXT_KEY, None) is not None:
+            set_integration_context(context)
 
     def get_alert(self, id: str, entity: str) -> dict[str, Any]:
         """Return the alert's details when provided the Alert ID or Entity as input
@@ -435,7 +555,7 @@ def test_module(client: Client) -> str:
 
     except DemistoException as e:
         if "Forbidden" in str(e) or "Authorization" in str(e):
-            message = "Authorization Error: make sure API Key is correctly set"
+            message = "Authorization Error: make sure the API Key (V1) or the Client ID and Client Secret (V2) are correctly set"
         else:
             raise e
     return message
@@ -1009,16 +1129,25 @@ def get_mapping_fields_command(client: Client, args: dict[str, Any]) -> GetMappi
 
 def main() -> None:
     """Main function, parses params and runs command functions."""
-    api_key = demisto.params().get("credentials", {}).get("password")
-    user_api_key = demisto.params().get("user_credentials", {}).get("password")
-    organization_code = demisto.params().get("organization_code")
-    verify = not demisto.params().get("insecure")
-    proxy = demisto.params().get("proxy")
+    params = demisto.params()
+    api_key = (params.get("credentials") or {}).get("password")
+    user_api_key = (params.get("user_credentials") or {}).get("password")
+    organization_code = params.get("organization_code")
+    oauth_client_id = (params.get("client_credentials") or {}).get("identifier")
+    oauth_client_secret = (params.get("client_credentials") or {}).get("password")
+    verify = not params.get("insecure")
+    proxy = params.get("proxy")
 
-    demisto.debug(f"Verify SSL: {verify} and Proxy: {proxy}")
+    # The dropdown values are display-friendly (e.g. "V2 (OAuth 2.0 Client Credentials)");
+    # anything that does not start with V2 falls back to V1 for backwards compatibility.
+    api_version = API_VERSION_V2 if (params.get("api_version") or "").lower().startswith(API_VERSION_V2) else API_VERSION_V1
+
+    demisto.debug(f"Verify SSL: {verify} and Proxy: {proxy} and API Version: {api_version}")
 
     # Get the service API URL
-    base_url = urljoin(demisto.params()["url"], "/v1")
+    server_url = params["url"]
+    base_url = urljoin(server_url, f"/{api_version}")
+    token_url = urljoin(server_url, OAUTH_TOKEN_PATH)
 
     # Explicitly define the type for the command function dictionary
     supported_commands: dict[str, Callable[[Client, dict[str, Any]], Any]] = {
@@ -1041,6 +1170,12 @@ def main() -> None:
     demisto.info(f"Command being called is {current_command}")
 
     try:
+        if api_version == API_VERSION_V2:
+            if not (oauth_client_id and oauth_client_secret):
+                raise DemistoException("API Version V2 requires both a Client ID and a Client Secret.")
+        elif not api_key:
+            raise DemistoException("API Version V1 requires an API Key.")
+
         client = Client(
             base_url=base_url,
             api_key=api_key,
@@ -1048,6 +1183,10 @@ def main() -> None:
             organization_code=organization_code,
             verify=verify,
             proxy=proxy,
+            api_version=api_version,
+            oauth_client_id=oauth_client_id,
+            oauth_client_secret=oauth_client_secret,
+            token_url=token_url,
         )
 
         if current_command in supported_commands_test_module:

--- a/Packs/Doppel/Integrations/Doppel/Doppel.py
+++ b/Packs/Doppel/Integrations/Doppel/Doppel.py
@@ -82,20 +82,20 @@ class Client(BaseClient):
 
     def __init__(
         self,
-        base_url,
-        api_key=None,
-        user_api_key=None,
-        organization_code=None,
-        verify=None,
-        proxy=None,
-        retry_total=DEFAULT_RETRY_TOTAL,
-        retry_backoff_factor=DEFAULT_RETRY_BACKOFF_FACTOR,
-        retry_status_list=DEFAULT_RETRY_STATUS_LIST,
-        api_version=API_VERSION_V1,
-        oauth_client_id=None,
-        oauth_client_secret=None,
-        token_url=None,
-    ):
+        base_url: str,
+        api_key: str | None = None,
+        user_api_key: str | None = None,
+        organization_code: str | None = None,
+        verify: bool | None = None,
+        proxy: bool | None = None,
+        retry_total: int = DEFAULT_RETRY_TOTAL,
+        retry_backoff_factor: int = DEFAULT_RETRY_BACKOFF_FACTOR,
+        retry_status_list: list[int] = DEFAULT_RETRY_STATUS_LIST,
+        api_version: str = API_VERSION_V1,
+        oauth_client_id: str | None = None,
+        oauth_client_secret: str | None = None,
+        token_url: str | None = None,
+    ) -> None:
         super().__init__(base_url, verify=verify, proxy=proxy)
 
         self._api_version = api_version
@@ -129,7 +129,7 @@ class Client(BaseClient):
             f"total={retry_total}, backoff_factor={retry_backoff_factor}, status_list={retry_status_list}"
         )
 
-    def _http_request(self, *args, **kwargs):
+    def _http_request(self, *args: Any, **kwargs: Any) -> Any:
         """Wrap BaseClient._http_request with V2 bearer-token handling.
 
         For V1 this is a pass-through. For V2, a valid cached token is attached
@@ -168,7 +168,7 @@ class Client(BaseClient):
     def _mint_oauth_token(self) -> str:
         """Mint a new access token via the client-credentials flow and cache it."""
 
-        def _token_error_handler(response):
+        def _token_error_handler(response: requests.Response) -> None:
             if response.status_code == 429:
                 retry_after = response.headers.get("Retry-After", "3600")
                 raise DemistoException(

--- a/Packs/Doppel/Integrations/Doppel/Doppel.yml
+++ b/Packs/Doppel/Integrations/Doppel/Doppel.yml
@@ -127,6 +127,35 @@ configuration:
   type: 8
   section: Connect
   required: false
+triggers:
+- conditions:
+  - name: api_version
+    operator: equal
+    value: V1 (API Key)
+  effects:
+  - name: credentials
+    action:
+      required: true
+  - name: client_credentials
+    action:
+      hidden: true
+- conditions:
+  - name: api_version
+    operator: equal
+    value: V2 (OAuth 2.0 Client Credentials)
+  effects:
+  - name: credentials
+    action:
+      hidden: true
+  - name: user_credentials
+    action:
+      hidden: true
+  - name: organization_code
+    action:
+      hidden: true
+  - name: client_credentials
+    action:
+      required: true
 description: |-
   Doppel is a Modern Digital Risk Protection Solution, that detects the phishing and brand cyber attacks on the emerging channels. Doppel scans millions of channels online which includes, social media, domains, paid ads, dark web, emerging channels, etc. Doppel can identify the malicious content and cyber threats, and enables their customers to take down the digital risks proactively.
   The Cortex XSOAR pack for Doppel mirrors the alerts created by Doppel as Cortex XSOAR incidents. The pack also contains the commands to perform different operations on Doppel alerts.

--- a/Packs/Doppel/Integrations/Doppel/Doppel.yml
+++ b/Packs/Doppel/Integrations/Doppel/Doppel.yml
@@ -14,15 +14,32 @@ configuration:
   required: true
   type: 0
   section: Connect
-- additionalinfo: The API Key to use for connection with Doppel.
+- additionalinfo: 'The Doppel API version to use. V1 authenticates with a static API Key; V2 authenticates with OAuth 2.0 client credentials (Client ID and Client Secret). New Doppel API capabilities are added to V2 only, so V2 is recommended.'
+  defaultvalue: V1 (API Key)
+  display: API Version
+  name: api_version
+  required: true
+  type: 15
+  options:
+  - V1 (API Key)
+  - V2 (OAuth 2.0 Client Credentials)
+  section: Connect
+- additionalinfo: The API Key to use for connection with Doppel. Required when API Version is V1.
   display: ""
   displaypassword: API Key
   hiddenusername: true
   name: credentials
-  required: true
+  required: false
   type: 9
   section: Connect
-- additionalinfo: The User API Key (Optional) to use for connection with Doppel.
+- additionalinfo: 'The OAuth 2.0 client credentials to use for connection with Doppel. Required when API Version is V2. An organization admin can create these from the Version 2 tab on the API Settings page in Doppel Vision.'
+  display: Client ID
+  displaypassword: Client Secret
+  name: client_credentials
+  required: false
+  type: 9
+  section: Connect
+- additionalinfo: The User API Key (Optional) to use for connection with Doppel. Applies to API Version V1 only.
   display: ""
   displaypassword: User API Key
   hiddenusername: true
@@ -35,7 +52,7 @@ configuration:
   required: false
   type: 0
   section: Connect
-  additionalinfo: The Organization Code to use for connection with Doppel.
+  additionalinfo: The Organization Code to use for connection with Doppel. Applies to API Version V1 only; V2 scopes requests to your organization automatically.
 - display: Fetch incidents
   name: isFetch
   required: false

--- a/Packs/Doppel/Integrations/Doppel/Doppel.yml
+++ b/Packs/Doppel/Integrations/Doppel/Doppel.yml
@@ -26,33 +26,33 @@ configuration:
   section: Connect
 - additionalinfo: The API Key to use for connection with Doppel. Required when API Version is V1.
   display: ""
-  displaypassword: API Key
+  displaypassword: API Key (V1)
   hiddenusername: true
   name: credentials
   required: false
   type: 9
   section: Connect
-- additionalinfo: 'The OAuth 2.0 client credentials to use for connection with Doppel. Required when API Version is V2. An organization admin can create these from the Version 2 tab on the API Settings page in Doppel Vision.'
-  display: Client ID
-  displaypassword: Client Secret
-  name: client_credentials
-  required: false
-  type: 9
-  section: Connect
 - additionalinfo: The User API Key (Optional) to use for connection with Doppel. Applies to API Version V1 only.
   display: ""
-  displaypassword: User API Key
+  displaypassword: User API Key (V1)
   hiddenusername: true
   name: user_credentials
   required: false
   type: 9
   section: Connect
-- display: Organization Code
+- display: Organization Code (V1)
   name: organization_code
   required: false
   type: 0
   section: Connect
   additionalinfo: The Organization Code to use for connection with Doppel. Applies to API Version V1 only; V2 scopes requests to your organization automatically.
+- additionalinfo: 'The OAuth 2.0 client credentials to use for connection with Doppel. Required when API Version is V2. An organization admin can create these from the Version 2 tab on the API Settings page in Doppel Vision.'
+  display: Client ID (V2)
+  displaypassword: Client Secret (V2)
+  name: client_credentials
+  required: false
+  type: 9
+  section: Connect
 - display: Fetch incidents
   name: isFetch
   required: false

--- a/Packs/Doppel/Integrations/Doppel/Doppel_description.md
+++ b/Packs/Doppel/Integrations/Doppel/Doppel_description.md
@@ -4,16 +4,16 @@ Doppel is a Modern Digital Risk Protection Solution, that detects the phishing a
 
 
 
-##### Details for Doppel workflow
+### Details for Doppel workflow
 1. Name of the instance.
 2. Doppel Tenant URL that you can use for calling the [Doppel APIs](https://doppel.readme.io/reference/create_alert). e.g. ,*https://api.doppel.com/*
 3. Credentials for the API Version you select (see below).
 
-##### Authentication
+### Authentication
 Select an **API Version**, then fill in only that version's fields. Fields labeled with the other version are ignored.
 
-- **V1 (API Key)**: fill in *API Key (V1)*. *User API Key (V1)* and *Organization Code (V1)* are optional V1 extras.
-- **V2 (OAuth 2.0 Client Credentials)**: fill in *Client ID (V2)* and *Client Secret (V2)*. An organization admin can create these from the **Version 2** tab on the **API Settings** page in Doppel Vision. V2 is recommended: new Doppel API capabilities are added to V2 only.
+- **V1 (API Key)**: Fill in the *API Key (V1)* field. *User API Key (V1)* and *Organization Code (V1)* are optional V1 extras.
+- **V2 (OAuth 2.0 Client Credentials)**: Fill in the *Client ID (V2)* and *Client Secret (V2)* fields. An organization admin can create these from the **Version 2** tab on the **API Settings** page in Doppel Vision. V2 is recommended: new Doppel API capabilities are added to V2 only.
 
 Reach out to Doppel to get access to the above information.
 

--- a/Packs/Doppel/Integrations/Doppel/Doppel_description.md
+++ b/Packs/Doppel/Integrations/Doppel/Doppel_description.md
@@ -7,11 +7,15 @@ Doppel is a Modern Digital Risk Protection Solution, that detects the phishing a
 ##### Details for Doppel workflow
 1. Name of the instance.
 2. Doppel Tenant URL that you can use for calling the [Doppel APIs](https://doppel.readme.io/reference/create_alert). e.g. ,*https://api.doppel.com/*
-3. API Key for calling Doppel.
+3. Credentials for the API Version you select (see below).
+
+##### Authentication
+Select an **API Version**, then fill in only that version's fields. Fields labeled with the other version are ignored.
+
+- **V1 (API Key)**: fill in *API Key (V1)*. *User API Key (V1)* and *Organization Code (V1)* are optional V1 extras.
+- **V2 (OAuth 2.0 Client Credentials)**: fill in *Client ID (V2)* and *Client Secret (V2)*. An organization admin can create these from the **Version 2** tab on the **API Settings** page in Doppel Vision. V2 is recommended: new Doppel API capabilities are added to V2 only.
 
 Reach out to Doppel to get access to the above information.
-
-Once you have the URL and API Key, use the same for configuring the Doppel-XSOAR integration instance.
 
 ## Test Configuration
 

--- a/Packs/Doppel/Integrations/Doppel/Doppel_test.py
+++ b/Packs/Doppel/Integrations/Doppel/Doppel_test.py
@@ -1299,6 +1299,27 @@ def test_client_sends_attribution_headers(requests_mock):
     assert alert_mock.last_request.headers["x-api-key"] == "test-api-key"
 
 
+def test_pack_version_matches_pack_metadata():
+    """PACK_VERSION (used in attribution headers) must match pack_metadata.json.
+
+    pack_metadata.json is not readable at runtime, so Doppel.py carries the version as a
+    hardcoded constant that must be bumped manually on every release. This test makes CI
+    fail if the two ever drift apart.
+    """
+    from pathlib import Path
+
+    from Doppel import PACK_VERSION
+
+    pack_metadata_path = Path(__file__).resolve().parents[2] / "pack_metadata.json"
+    pack_metadata = json.loads(pack_metadata_path.read_text())
+
+    assert pack_metadata["currentVersion"] == PACK_VERSION, (
+        f"pack_metadata.json currentVersion ({pack_metadata['currentVersion']}) does not match "
+        f"PACK_VERSION ({PACK_VERSION}) in Doppel.py; bump the constant so the x-doppel-client "
+        f"attribution header reports the released pack version."
+    )
+
+
 def test_main_function_with_proxy_enabled(mocker):
     """Test main function when proxy is enabled in params."""
     # Mock demisto functions

--- a/Packs/Doppel/Integrations/Doppel/Doppel_test.py
+++ b/Packs/Doppel/Integrations/Doppel/Doppel_test.py
@@ -1586,6 +1586,12 @@ def test_v2_mints_token_and_sends_bearer(mocker, requests_mock):
     }
     assert alert_mock.last_request.headers["Authorization"] == "Bearer tok-1"
     assert store["ctx"]["oauth_token"]["access_token"] == "tok-1"
+    # Attribution headers ride along on both the token mint and the API request.
+    from Doppel import CLIENT_ATTRIBUTION
+
+    assert token_mock.last_request.headers["x-doppel-client"] == CLIENT_ATTRIBUTION
+    assert alert_mock.last_request.headers["x-doppel-client"] == CLIENT_ATTRIBUTION
+    assert alert_mock.last_request.headers["User-Agent"] == f"doppel-{CLIENT_ATTRIBUTION}"
 
 
 def test_v2_reuses_cached_token(mocker, requests_mock):

--- a/Packs/Doppel/Integrations/Doppel/Doppel_test.py
+++ b/Packs/Doppel/Integrations/Doppel/Doppel_test.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import json
+import time
 import pytest
 import demistomock as demisto
 from unittest.mock import MagicMock
@@ -1540,3 +1541,155 @@ def test_reopen_entry_requires_parseable_last_update():
     audit_logs = [{"type": "queue_state_change", "value": "actioned", "timestamp": "2025-03-02T10:00:00"}]
 
     assert _reopen_entry_if_revived(alert, audit_logs, None) is None
+
+
+# ---------------- API V2 (OAuth 2.0 client credentials) ----------------
+
+V2_BASE_URL = "https://api.doppel.com/v2"
+V2_TOKEN_URL = "https://api.doppel.com/oauth/token"
+
+
+def _v2_client():
+    return Client(
+        base_url=V2_BASE_URL,
+        verify=True,
+        api_version="v2",
+        oauth_client_id="test-client-id",
+        oauth_client_secret="test-client-secret",
+        token_url=V2_TOKEN_URL,
+    )
+
+
+def _mock_integration_context(mocker, initial=None):
+    """Replace the integration context with an in-memory store; returns the store."""
+    store = {"ctx": initial or {}}
+    mocker.patch("Doppel.get_integration_context", side_effect=lambda: store["ctx"])
+    mocker.patch("Doppel.set_integration_context", side_effect=lambda ctx: store.update(ctx=ctx))
+    return store
+
+
+def test_v2_mints_token_and_sends_bearer(mocker, requests_mock):
+    """With no cached token, a request first mints a token, caches it, and sends it as a Bearer header."""
+    store = _mock_integration_context(mocker)
+    token_mock = requests_mock.post(V2_TOKEN_URL, json={"access_token": "tok-1", "expires_in": 86400})
+    alert_mock = requests_mock.get(f"{V2_BASE_URL}/alert", json={"id": "TET-1"})
+
+    result = _v2_client().get_alert(id="TET-1", entity="")
+
+    assert result == {"id": "TET-1"}
+    assert token_mock.call_count == 1
+    assert token_mock.last_request.json() == {
+        "client_id": "test-client-id",
+        "client_secret": "test-client-secret",
+        "audience": "doppel-external",
+        "grant_type": "client_credentials",
+    }
+    assert alert_mock.last_request.headers["Authorization"] == "Bearer tok-1"
+    assert store["ctx"]["oauth_token"]["access_token"] == "tok-1"
+
+
+def test_v2_reuses_cached_token(mocker, requests_mock):
+    """A cached, unexpired token is reused without calling the token endpoint."""
+    future_expiry = int(time.time()) + 3600
+    _mock_integration_context(mocker, {"oauth_token": {"access_token": "cached-tok", "expiry_epoch": future_expiry}})
+    token_mock = requests_mock.post(V2_TOKEN_URL, json={"access_token": "should-not-be-minted"})
+    alert_mock = requests_mock.get(f"{V2_BASE_URL}/alert", json={"id": "TET-1"})
+
+    _v2_client().get_alert(id="TET-1", entity="")
+
+    assert token_mock.call_count == 0
+    assert alert_mock.last_request.headers["Authorization"] == "Bearer cached-tok"
+
+
+def test_v2_expired_token_is_reminted(mocker, requests_mock):
+    """A cached token past its expiry is replaced with a freshly minted one."""
+    past_expiry = int(time.time()) - 10
+    store = _mock_integration_context(mocker, {"oauth_token": {"access_token": "old-tok", "expiry_epoch": past_expiry}})
+    requests_mock.post(V2_TOKEN_URL, json={"access_token": "fresh-tok", "expires_in": 86400})
+    alert_mock = requests_mock.get(f"{V2_BASE_URL}/alert", json={"id": "TET-1"})
+
+    _v2_client().get_alert(id="TET-1", entity="")
+
+    assert alert_mock.last_request.headers["Authorization"] == "Bearer fresh-tok"
+    assert store["ctx"]["oauth_token"]["access_token"] == "fresh-tok"
+
+
+def test_v2_401_retries_once_with_fresh_token(mocker, requests_mock):
+    """A 401 on a cached token invalidates the cache, mints once, and retries the request once."""
+    future_expiry = int(time.time()) + 3600
+    _mock_integration_context(mocker, {"oauth_token": {"access_token": "revoked-tok", "expiry_epoch": future_expiry}})
+    token_mock = requests_mock.post(V2_TOKEN_URL, json={"access_token": "fresh-tok", "expires_in": 86400})
+    alert_mock = requests_mock.get(
+        f"{V2_BASE_URL}/alert",
+        [
+            {"status_code": 401, "json": {"error": "unauthorized"}},
+            {"status_code": 200, "json": {"id": "TET-1"}},
+        ],
+    )
+
+    result = _v2_client().get_alert(id="TET-1", entity="")
+
+    assert result == {"id": "TET-1"}
+    assert token_mock.call_count == 1
+    assert alert_mock.call_count == 2
+    assert alert_mock.request_history[0].headers["Authorization"] == "Bearer revoked-tok"
+    assert alert_mock.request_history[1].headers["Authorization"] == "Bearer fresh-tok"
+
+
+def test_v2_token_429_raises_readable_error(mocker, requests_mock):
+    """A 429 from the token endpoint surfaces the mint quota and the Retry-After value."""
+    _mock_integration_context(mocker)
+    requests_mock.post(V2_TOKEN_URL, status_code=429, headers={"Retry-After": "1200"}, json={})
+
+    with pytest.raises(DemistoException, match="token request limit.*1200"):
+        _v2_client().get_alert(id="TET-1", entity="")
+
+
+def test_v2_token_401_raises_credentials_error(mocker, requests_mock):
+    """A 401 from the token endpoint points at the Client ID / Client Secret."""
+    _mock_integration_context(mocker)
+    requests_mock.post(V2_TOKEN_URL, status_code=401, json={})
+
+    with pytest.raises(DemistoException, match="Client ID and.*Client Secret"):
+        _v2_client().get_alert(id="TET-1", entity="")
+
+
+def test_v1_client_sends_api_key_not_bearer(requests_mock):
+    """A V1 client keeps the legacy header auth and never touches the OAuth flow."""
+    client = Client(base_url="https://api.doppel.com/v1", api_key="test-api-key", verify=True)
+    alert_mock = requests_mock.get("https://api.doppel.com/v1/alert", json={"id": "TET-1"})
+
+    client.get_alert(id="TET-1", entity="")
+
+    assert alert_mock.last_request.headers["x-api-key"] == "test-api-key"
+    assert "Authorization" not in alert_mock.last_request.headers
+
+
+def test_main_v2_requires_client_credentials(mocker):
+    """Selecting V2 without client credentials fails fast with a clear message."""
+    from Doppel import main
+
+    mocker.patch.object(
+        demisto,
+        "params",
+        return_value={"url": "https://api.doppel.com/", "api_version": "V2 (OAuth 2.0 Client Credentials)"},
+    )
+    mocker.patch.object(demisto, "command", return_value="test-module")
+    return_error_mock = mocker.patch("Doppel.return_error")
+
+    main()
+
+    assert "Client ID and a Client Secret" in return_error_mock.call_args[0][0]
+
+
+def test_main_v1_requires_api_key(mocker):
+    """The V1 default without an API Key fails fast with a clear message."""
+    from Doppel import main
+
+    mocker.patch.object(demisto, "params", return_value={"url": "https://api.doppel.com/"})
+    mocker.patch.object(demisto, "command", return_value="test-module")
+    return_error_mock = mocker.patch("Doppel.return_error")
+
+    main()
+
+    assert "requires an API Key" in return_error_mock.call_args[0][0]

--- a/Packs/Doppel/Integrations/Doppel/README.md
+++ b/Packs/Doppel/Integrations/Doppel/README.md
@@ -11,9 +11,11 @@ Doppel is a Modern Digital Risk Protection Solution, that detects the phishing a
 | **Parameter** | **Description** | **Required** |
 | --- | --- | --- |
 | Doppel Tenant URL | The Doppel server URL that will be used for calling the APIs. | True |
-| API Key | The API Key to use for connection with Doppel. | True |
-| User API Key | The User API Key \(Optional\) to use for connection with Doppel. | False |
-| Organization Code | Optional organization identifier used when your Doppel environment is organization-scoped. If required by the Doppel API, include the organization code provided by your Doppel administrator. | False |
+| API Version | The Doppel API version to use. V1 authenticates with a static API Key; V2 authenticates with OAuth 2.0 client credentials \(Client ID and Client Secret\). New Doppel API capabilities are added to V2 only, so V2 is recommended. | True |
+| API Key | The API Key to use for connection with Doppel. Required when API Version is V1. | False |
+| Client ID / Client Secret | The OAuth 2.0 client credentials to use for connection with Doppel. Required when API Version is V2. An organization admin can create these from the **Version 2** tab on the **API Settings** page in Doppel Vision. | False |
+| User API Key | The User API Key \(Optional\) to use for connection with Doppel. Applies to API Version V1 only. | False |
+| Organization Code | Optional organization identifier used when your Doppel environment is organization-scoped. Applies to API Version V1 only; V2 scopes requests to your organization automatically. | False |
 | Trust Any Certificate (not secure) | When checked, SSL certificate verification is disabled. Use this only when the Doppel endpoint uses a self-signed or untrusted certificate. | False |
 | Use System Proxy Settings | When checked, the integration uses the system proxy defined in the XSOAR engine configuration (d1.conf). This is required if the engine routes outbound traffic through a local or organizational proxy. | False |
 | Fetch incidents |  | False |
@@ -27,6 +29,13 @@ Doppel is a Modern Digital Risk Protection Solution, that detects the phishing a
 | Use system proxy settings |  | False |
 
 4. Click **Test** to validate the URLs, token, and connection.
+
+### Authentication: API V1 vs V2
+
+- **V1 (API Key)** — the default. Requests are authenticated with the static **API Key** header. Existing instances keep working unchanged after upgrading the pack.
+- **V2 (OAuth 2.0 Client Credentials)** — recommended. The integration exchanges the **Client ID** and **Client Secret** for a short-lived access token (valid 24 hours), caches it, and refreshes it automatically before expiry. New Doppel API capabilities are added to V2 only.
+
+**Note:** Doppel limits the number of successful token requests per Client ID per hour. The integration's built-in token caching stays well within this limit, but if the same Client ID is shared with other tools that request tokens aggressively, token requests may be throttled. Prefer a dedicated OAuth client for this integration (each Doppel organization can create up to 10).
 
 ## Commands
 

--- a/Packs/Doppel/Integrations/Doppel/README.md
+++ b/Packs/Doppel/Integrations/Doppel/README.md
@@ -12,10 +12,10 @@ Doppel is a Modern Digital Risk Protection Solution, that detects the phishing a
 | --- | --- | --- |
 | Doppel Tenant URL | The Doppel server URL that will be used for calling the APIs. | True |
 | API Version | The Doppel API version to use. V1 authenticates with a static API Key; V2 authenticates with OAuth 2.0 client credentials \(Client ID and Client Secret\). New Doppel API capabilities are added to V2 only, so V2 is recommended. | True |
-| API Key | The API Key to use for connection with Doppel. Required when API Version is V1. | False |
-| Client ID / Client Secret | The OAuth 2.0 client credentials to use for connection with Doppel. Required when API Version is V2. An organization admin can create these from the **Version 2** tab on the **API Settings** page in Doppel Vision. | False |
-| User API Key | The User API Key \(Optional\) to use for connection with Doppel. Applies to API Version V1 only. | False |
-| Organization Code | Optional organization identifier used when your Doppel environment is organization-scoped. Applies to API Version V1 only; V2 scopes requests to your organization automatically. | False |
+| API Key \(V1\) | The API Key to use for connection with Doppel. Required when API Version is V1. | False |
+| User API Key \(V1\) | The User API Key \(Optional\) to use for connection with Doppel. Applies to API Version V1 only. | False |
+| Organization Code \(V1\) | Optional organization identifier used when your Doppel environment is organization-scoped. Applies to API Version V1 only; V2 scopes requests to your organization automatically. | False |
+| Client ID \(V2\) / Client Secret \(V2\) | The OAuth 2.0 client credentials to use for connection with Doppel. Required when API Version is V2. An organization admin can create these from the **Version 2** tab on the **API Settings** page in Doppel Vision. | False |
 | Trust Any Certificate (not secure) | When checked, SSL certificate verification is disabled. Use this only when the Doppel endpoint uses a self-signed or untrusted certificate. | False |
 | Use System Proxy Settings | When checked, the integration uses the system proxy defined in the XSOAR engine configuration (d1.conf). This is required if the engine routes outbound traffic through a local or organizational proxy. | False |
 | Fetch incidents |  | False |

--- a/Packs/Doppel/Integrations/Doppel/README.md
+++ b/Packs/Doppel/Integrations/Doppel/README.md
@@ -2,6 +2,13 @@
 
 Doppel is a Modern Digital Risk Protection Solution, that detects the phishing and brand cyber attacks on the emerging channels. Doppel scans millions of channels online which includes, social media, domains, paid ads, dark web, emerging channels, etc. Doppel can identify the malicious content and cyber threats, and enables their customers to take down the digital risks proactively. The Cortex XSOAR pack for Doppel mirrors the alerts created by Doppel as Cortex XSOAR incidents. The pack also contains the commands to perform different operations on Doppel alerts.
 
+## Authentication: API V1 vs V2
+
+- **V1 (API Key)** — the default. Requests are authenticated with the static **API Key** header. Existing instances keep working unchanged after upgrading the pack.
+- **V2 (OAuth 2.0 Client Credentials)** — recommended. The integration exchanges the **Client ID** and **Client Secret** for a short-lived access token (valid 24 hours), caches it, and refreshes it automatically before expiry. New Doppel API capabilities are added to V2 only.
+
+**Note:** Doppel limits the number of successful token requests per Client ID per hour. The integration's built-in token caching stays well within this limit, but if the same Client ID is shared with other tools that request tokens aggressively, token requests may be throttled. Prefer a dedicated OAuth client for this integration (each Doppel organization can create up to 10).
+
 ## Configure Doppel on Cortex XSOAR
 
 1. Navigate to **Settings & Info** > **Settings** > **Integrations** > **Instances**.
@@ -29,13 +36,6 @@ Doppel is a Modern Digital Risk Protection Solution, that detects the phishing a
 | Use system proxy settings |  | False |
 
 4. Click **Test** to validate the URLs, token, and connection.
-
-### Authentication: API V1 vs V2
-
-- **V1 (API Key)** — the default. Requests are authenticated with the static **API Key** header. Existing instances keep working unchanged after upgrading the pack.
-- **V2 (OAuth 2.0 Client Credentials)** — recommended. The integration exchanges the **Client ID** and **Client Secret** for a short-lived access token (valid 24 hours), caches it, and refreshes it automatically before expiry. New Doppel API capabilities are added to V2 only.
-
-**Note:** Doppel limits the number of successful token requests per Client ID per hour. The integration's built-in token caching stays well within this limit, but if the same Client ID is shared with other tools that request tokens aggressively, token requests may be throttled. Prefer a dedicated OAuth client for this integration (each Doppel organization can create up to 10).
 
 ## Commands
 

--- a/Packs/Doppel/ReleaseNotes/1_3_0.md
+++ b/Packs/Doppel/ReleaseNotes/1_3_0.md
@@ -4,5 +4,5 @@
 ##### Doppel
 
 - Added support for the Doppel API V2, which authenticates with OAuth 2.0 client credentials. Access tokens are cached and refreshed automatically before expiry.
-- Added the *API Version* integration parameter to select between **V1 (API Key)** and **V2 (OAuth 2.0 Client Credentials)**. Existing instances continue to use V1 with no configuration changes. Note that new Doppel API capabilities are added to V2 only.
+- Added the *API Version* integration parameter to select between *V1 (API Key)* and *V2 (OAuth 2.0 Client Credentials)*. Existing instances continue to use V1 with no configuration changes. Note that new Doppel API capabilities are added to V2 only.
 - Added the *Client ID* / *Client Secret* integration parameters, used when API Version is V2.

--- a/Packs/Doppel/ReleaseNotes/1_3_0.md
+++ b/Packs/Doppel/ReleaseNotes/1_3_0.md
@@ -1,0 +1,8 @@
+
+#### Integrations
+
+##### Doppel
+
+- Added support for the Doppel API V2, which authenticates with OAuth 2.0 client credentials. Access tokens are cached and refreshed automatically before expiry.
+- Added the *API Version* integration parameter to select between **V1 (API Key)** and **V2 (OAuth 2.0 Client Credentials)**. Existing instances continue to use V1 with no configuration changes. Note that new Doppel API capabilities are added to V2 only.
+- Added the *Client ID* / *Client Secret* integration parameters, used when API Version is V2.

--- a/Packs/Doppel/pack_metadata.json
+++ b/Packs/Doppel/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Doppel",
     "description": "This Content pack for Doppel mirrors the alerts created by Doppel as XSOAR incidents. The pack also contains the commands to perform different operations on Doppel alerts.",
     "support": "partner",
-    "currentVersion": "1.2.0",
+    "currentVersion": "1.3.0",
     "author": "Doppel Inc",
     "url": "https://www.doppel.com/",
     "email": "integrations@doppel.com",


### PR DESCRIPTION
## Contributing to Cortex XSOAR Content

Follow-up to #45756 (pack v1.2.0, merged): adds Doppel API V2 support to the integration.

> **Note for reviewers:** this branch is based on the v1.2.0 contribution. Until internal PR #45809 lands v1.2.0 on master, this diff shows both versions' changes; it will shrink to the v1.3.0 delta automatically once #45809 merges.

## What's in this PR (pack v1.3.0)

**Doppel integration**
- **API V2 support with OAuth 2.0 client credentials**: new *API Version* parameter selects between **V1 (API Key)** and **V2 (OAuth 2.0 Client Credentials)**. V2 mints access tokens from the Doppel token endpoint, caches them in the integration context, and refreshes automatically before expiry. Existing instances keep working on V1 with no configuration changes.
- **Version-scoped configuration UI**: only the auth fields relevant to the selected API version are shown; fields are version-labeled, grouped in setup order, and the instance help text documents both auth flows.
- **Attribution headers everywhere**: the `x-doppel-client: xsoar/<pack version>` header and `doppel-xsoar/<version>` User-Agent are asserted on the V2 token mint and on every V1/V2 API request.

## Testing

- 82 unit tests pass (V2 token mint/caching/refresh, version-scoped params, attribution header assertions on token and data requests).
- Verified end-to-end against a live tenant: V2 instance configured with client credentials, token minted, fetch + commands working.
- Demo video of the V2 auth flow recorded; will be linked via the contribution registration.

## Status
- [x] Ready

Made with [Cursor](https://cursor.com)


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-17974