### PR TITLE
Add oauth2_private_key_jwt support to UCP credential dispatcher

### DIFF
--- a/Packs/Base/ReleaseNotes/1_42_27.md
+++ b/Packs/Base/ReleaseNotes/1_42_27.md
@@ -1,0 +1,5 @@
+#### Scripts
+
+##### CommonServerPython
+
+- Added support for the *oauth2_private_key_jwt* profile type (RFC 7523 private-key JWT) to the Unified Connector Platform (UCP) credential dispatcher in **BaseClient**, so integrations using this profile receive a bearer *Authorization* header instead of an error.

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython.py
@@ -10184,7 +10184,7 @@ if 'requests' in sys.modules:
             cred_type = credentials.get('type')
 
             # Bug on UCP side where they return different types for the same credential type. To be fixed in July'26 version
-            if cred_type == 'oauth2_client_credentials' or cred_type == 'oauth2_authorization_code' or cred_type == 'oauth2':
+            if cred_type in ['oauth2_client_credentials', 'oauth2_authorization_code', 'oauth2_private_key_jwt', 'oauth2']:
                 self._apply_ucp_oauth2(credentials, ctx)
             elif cred_type == 'api_key':
                 self._apply_ucp_api_key(credentials, ctx)

--- a/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
+++ b/Packs/Base/Scripts/CommonServerPython/CommonServerPython_test.py
@@ -13173,6 +13173,41 @@ class TestUcpCredentialApplication:
         ctx = self._make_ctx()
         client._apply_ucp_credentials(creds, ctx)
         assert ctx.headers['Authorization'] == 'Bearer auth-code-token-abc'
+        
+    def test_dispatch_oauth2_private_key_jwt(self):
+        """oauth2_private_key_jwt should route to _apply_ucp_oauth2.
+
+        The platform (unified-connector-platform) brokers the RFC 7523 private-key JWT
+        client-assertion flow and returns a standard OAuth2 access_token envelope, so the
+        integration side only needs to place it as a bearer token — identical to the other
+        oauth2 grants. No bespoke _apply_ucp_private_key_jwt method exists.
+        """
+        creds = load_ucp_test_data('ucp_credentials.json')['oauth2_private_key_jwt']
+        client = self._make_client()
+        ctx = self._make_ctx()
+        client._apply_ucp_credentials(creds, ctx)
+        assert ctx.headers['Authorization'] == 'Bearer pkjwt-token-def'
+
+    def test_dispatch_oauth2_private_key_jwt_flat_envelope(self):
+        """oauth2_private_key_jwt should also work with a flat (non-nested) envelope."""
+        creds = {
+            'type': 'oauth2_private_key_jwt',
+            'access_token': 'flat-pkjwt-token',
+            'token_type': 'Bearer',
+        }
+        client = self._make_client()
+        ctx = self._make_ctx()
+        client._apply_ucp_credentials(creds, ctx)
+        assert ctx.headers['Authorization'] == 'Bearer flat-pkjwt-token'
+
+    def test_dispatch_oauth2_private_key_jwt_empty_token_raises(self, mocker):
+        """oauth2_private_key_jwt with an empty access_token should still raise UcpException."""
+        mocker.patch.object(demisto, 'error')
+        creds = {'type': 'oauth2_private_key_jwt', 'oauth2': {'access_token': '', 'token_type': 'Bearer'}}
+        client = self._make_client()
+        ctx = self._make_ctx()
+        with pytest.raises(CommonServerPython.UcpException):
+            client._apply_ucp_credentials(creds, ctx)
 
     def test_dispatch_api_key(self, ucp_creds_api_key):
         """Should dispatch api_key type to _apply_ucp_api_key."""

--- a/Packs/Base/Scripts/CommonServerPython/test_data/ucp_credentials.json
+++ b/Packs/Base/Scripts/CommonServerPython/test_data/ucp_credentials.json
@@ -35,5 +35,13 @@
             "token_type": "Bearer"
         },
         "type": "oauth2_authorization_code"
+    },
+    "oauth2_private_key_jwt": {
+        "oauth2": {
+            "access_token": "pkjwt-token-def",
+            "expires_at": "2099-12-31T23:59:59+00:00",
+            "token_type": "Bearer"
+        },
+        "type": "oauth2_private_key_jwt"
     }
 }

--- a/Packs/Base/pack_metadata.json
+++ b/Packs/Base/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Base",
     "description": "The base pack for Cortex XSOAR.",
     "support": "xsoar",
-    "currentVersion": "1.42.26",
+    "currentVersion": "1.42.27",
     "author": "Cortex XSOAR",
     "serverMinVersion": "6.0.0",
     "url": "https://www.paloaltonetworks.com/cortex",


### PR DESCRIPTION
## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CRTX-267603

## Description
Add first-class support for the oauth2_private_key_jwt profile to the UCP credential dispatcher in CommonServerPython, so integrations that authenticate with Okta's private-key JWT profile receive a working Authorization header instead of a UcpException.

## Must have
- [x] Tests
- [ ] Documentation
