### PR TITLE
Prisma AIRS 1.0.1: brand spelling fix, DLP UX improvements

### DIFF
--- a/Packs/ApiModules/Scripts/PrismaAirsApiModule/PrismaAirsApiModule.py
+++ b/Packs/ApiModules/Scripts/PrismaAirsApiModule/PrismaAirsApiModule.py
@@ -1,6 +1,6 @@
-"""Prisma AIRs shared API module.
+"""Prisma AIRS shared API module.
 
-Holds the plane-agnostic transport layer shared by every Prisma AIRs integration
+Holds the plane-agnostic transport layer shared by every Prisma AIRS integration
 (AI Red Teaming, AI Runtime Security, AI Model Security, AI Gateway):
 
 * ``Client`` — OAuth2 (client_credentials) auth against Strata Cloud Manager plus
@@ -19,7 +19,7 @@ from CommonServerUserPython import *  # noqa
 
 from typing import Any
 
-# CONSTANTS (shared across all Prisma AIRs integrations)
+# CONSTANTS (shared across all Prisma AIRS integrations)
 DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"  # ISO8601 format with UTC, default in XSOAR
 DEFAULT_LIMIT = 50
 PA_OUTPUT_PREFIX = "PrismaAIRs."
@@ -40,11 +40,11 @@ TOKEN_URL = "https://auth.apps.paloaltonetworks.com/oauth2/access_token"
 
 
 class Client(BaseClient):
-    """Client class to interact with Prisma AIRs API.
+    """Client class to interact with Prisma AIRS API.
 
-    This Client implements the shared transport for the Prisma AIRs platform via Strata
+    This Client implements the shared transport for the Prisma AIRS platform via Strata
     Cloud Manager and does not contain any XSOAR command logic. Handles OAuth2 token
-    retrieval and plane routing for every Prisma AIRs integration.
+    retrieval and plane routing for every Prisma AIRS integration.
 
     All credential/URL fields are optional so an integration that only configures its own
     plane (scoped credentials) constructs cleanly; required fields are validated in each
@@ -232,13 +232,13 @@ class Client(BaseClient):
 
 
 def test_module(client: Client) -> str:
-    """Test connectivity to Prisma AIRs API.
+    """Test connectivity to Prisma AIRS API.
 
     Plane-agnostic OAuth check shared by every integration. Integrations that need a
     stronger, plane-specific probe may wrap this with an additional read.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
 
     Returns:
         str: 'ok' if test passed, error message otherwise.

--- a/Packs/ApiModules/Scripts/PrismaAirsApiModule/PrismaAirsApiModule.yml
+++ b/Packs/ApiModules/Scripts/PrismaAirsApiModule/PrismaAirsApiModule.yml
@@ -8,7 +8,7 @@ subtype: python3
 tags:
 - infra
 - server
-comment: Common Prisma AIRs code (OAuth2 client, plane routing, scanner transport) appended into each Prisma AIRs integration when it's deployed.
+comment: Common Prisma AIRS code (OAuth2 client, plane routing, scanner transport) appended into each Prisma AIRS integration when it's deployed.
 system: true
 scripttarget: 0
 dependson: {}

--- a/Packs/ApiModules/Scripts/PrismaAirsApiModule/PrismaAirsApiModule.yml
+++ b/Packs/ApiModules/Scripts/PrismaAirsApiModule/PrismaAirsApiModule.yml
@@ -8,7 +8,7 @@ subtype: python3
 tags:
 - infra
 - server
-comment: Common Prisma AIRS code (OAuth2 client, plane routing, scanner transport) appended into each Prisma AIRS integration when it's deployed.
+comment: Provides shared Prisma AIRS code (OAuth2 client, plane routing, and scanner transport) that each Prisma AIRS integration reuses.
 system: true
 scripttarget: 0
 dependson: {}

--- a/Packs/ApiModules/Scripts/PrismaAirsApiModule/PrismaAirsApiModule_test.py
+++ b/Packs/ApiModules/Scripts/PrismaAirsApiModule/PrismaAirsApiModule_test.py
@@ -1,4 +1,4 @@
-"""Unit tests for PrismaAirsApiModule (shared Prisma AIRs transport layer)."""
+"""Unit tests for PrismaAirsApiModule (shared Prisma AIRS transport layer)."""
 
 from typing import Any
 from unittest.mock import Mock, patch
@@ -23,7 +23,7 @@ BASE_URL = "https://api.sase.paloaltonetworks.com"
 
 @pytest.fixture
 def mock_client() -> Client:
-    """Create a fully-configured mock Prisma AIRs client."""
+    """Create a fully-configured mock Prisma AIRS client."""
     return Client(
         base_url=BASE_URL,
         client_id="test_client_id",

--- a/Packs/ApiModules/Scripts/PrismaAirsApiModule/README.md
+++ b/Packs/ApiModules/Scripts/PrismaAirsApiModule/README.md
@@ -1,4 +1,4 @@
-Common Prisma AIRS code (OAuth2 client, plane routing, scanner transport) appended into each Prisma AIRS integration when it's deployed.
+Provides shared Prisma AIRS code (OAuth2 client, plane routing, and scanner transport) that each Prisma AIRS integration reuses.
 
 ## Script Data
 

--- a/Packs/ApiModules/Scripts/PrismaAirsApiModule/README.md
+++ b/Packs/ApiModules/Scripts/PrismaAirsApiModule/README.md
@@ -1,4 +1,4 @@
-Common Prisma AIRs code (OAuth2 client, plane routing, scanner transport) appended into each Prisma AIRs integration when it's deployed.
+Common Prisma AIRS code (OAuth2 client, plane routing, scanner transport) appended into each Prisma AIRS integration when it's deployed.
 
 ## Script Data
 

--- a/Packs/PaloAltoNetworks_Prisma_AIRs/Integrations/PrismaAIRsModelSecurity/PrismaAIRsModelSecurity.py
+++ b/Packs/PaloAltoNetworks_Prisma_AIRs/Integrations/PrismaAIRsModelSecurity/PrismaAIRsModelSecurity.py
@@ -14,7 +14,7 @@ def model_security_scans_list_command(client: Client, args: dict[str, Any]) -> C
     """List model security scans.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -52,7 +52,7 @@ def model_security_scans_list_command(client: Client, args: dict[str, Any]) -> C
         scans.append(scan_info)
 
     readable_output = tableToMarkdown(
-        "Prisma AIRs Model Security Scans",
+        "Prisma AIRS Model Security Scans",
         scans,
         headers=["uuid", "model_uri", "eval_outcome", "source_type", "security_group_name", "created_at"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -74,7 +74,7 @@ def model_security_scans_create_command(client: Client, args: dict[str, Any]) ->
     Use prisma-airs-model-security-scans-get to poll for completion.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -191,7 +191,7 @@ def model_security_scans_get_command(client: Client, args: dict[str, Any]) -> Co
     rule evaluation summary, and any error details.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -305,7 +305,7 @@ def model_security_scans_violations_command(client: Client, args: dict[str, Any]
     showing which security rules failed and why.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -399,7 +399,7 @@ def model_security_labels_keys_command(client: Client, args: dict[str, Any]) -> 
     Lists all unique label keys that have been used across scans for organization/filtering.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -452,7 +452,7 @@ def model_security_labels_values_command(client: Client, args: dict[str, Any]) -
     Lists all unique values that have been used for a specific label key across scans.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -520,7 +520,7 @@ def model_security_labels_add_command(client: Client, args: dict[str, Any]) -> C
     Labels are key-value pairs that can be used to tag scans.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -589,7 +589,7 @@ def model_security_labels_set_command(client: Client, args: dict[str, Any]) -> C
     This is different from add which appends to existing labels.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -657,7 +657,7 @@ def model_security_labels_delete_command(client: Client, args: dict[str, Any]) -
     Deletes specific labels from a scan by providing their keys.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -732,7 +732,7 @@ def model_security_scans_evaluation_command(client: Client, args: dict[str, Any]
     Retrieves detailed information about a specific rule evaluation result.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -801,7 +801,7 @@ def model_security_scans_violation_command(client: Client, args: dict[str, Any])
     Retrieves detailed information about a specific security rule violation.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -878,7 +878,7 @@ def model_security_scans_files_command(client: Client, args: dict[str, Any]) -> 
     Lists all files that were scanned within a model, showing file structure and scan results.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -983,7 +983,7 @@ def model_security_scans_evaluations_command(client: Client, args: dict[str, Any
     Lists all rule evaluations for a scan, showing which security rules passed, failed, or had errors.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1080,7 +1080,7 @@ def model_security_models_list_command(client: Client, args: dict[str, Any]) -> 
     """List Model Security model catalog entries (aggregate over their versions).
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1127,7 +1127,7 @@ def model_security_models_list_command(client: Client, args: dict[str, Any]) -> 
     ]
 
     readable_output = tableToMarkdown(
-        "Prisma AIRs Model Security Models",
+        "Prisma AIRS Model Security Models",
         models,
         headers=["uuid", "name", "latest_version_revision", "latest_version_outcome", "latest_version_scan_time"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -1147,7 +1147,7 @@ def model_security_models_get_command(client: Client, args: dict[str, Any]) -> C
     """Get a single Model Security model by UUID.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1175,7 +1175,7 @@ def model_security_models_get_command(client: Client, args: dict[str, Any]) -> C
     }
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs Model Security Model: {model_info.get('name') or uuid}",
+        f"Prisma AIRS Model Security Model: {model_info.get('name') or uuid}",
         model_info,
         headerTransform=lambda h: h.replace("_", " ").title(),
         removeNull=True,
@@ -1194,7 +1194,7 @@ def model_security_models_versions_command(client: Client, args: dict[str, Any])
     """List the versions (revisions) of a Model Security model.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1237,7 +1237,7 @@ def model_security_models_versions_command(client: Client, args: dict[str, Any])
     ]
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs Model Security Model Versions (model {model_uuid})",
+        f"Prisma AIRS Model Security Model Versions (model {model_uuid})",
         versions,
         headers=["uuid", "revision", "file_count", "last_eval_outcome", "latest_scan_time"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -1257,7 +1257,7 @@ def model_security_models_version_get_command(client: Client, args: dict[str, An
     """Get a single Model Security model version by UUID.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1289,7 +1289,7 @@ def model_security_models_version_get_command(client: Client, args: dict[str, An
     }
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs Model Security Model Version: {version_info.get('revision') or uuid}",
+        f"Prisma AIRS Model Security Model Version: {version_info.get('revision') or uuid}",
         version_info,
         headerTransform=lambda h: h.replace("_", " ").title(),
         removeNull=True,
@@ -1308,7 +1308,7 @@ def model_security_models_files_command(client: Client, args: dict[str, Any]) ->
     """List the files of a Model Security model version.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1345,7 +1345,7 @@ def model_security_models_files_command(client: Client, args: dict[str, Any]) ->
     ]
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs Model Security Model Version Files (version {model_version_uuid})",
+        f"Prisma AIRS Model Security Model Version Files (version {model_version_uuid})",
         files,
         headers=["uuid", "path", "type", "result", "formats"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -1365,7 +1365,7 @@ def model_security_groups_list_command(client: Client, args: dict[str, Any]) -> 
     """List model security groups.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1401,7 +1401,7 @@ def model_security_groups_list_command(client: Client, args: dict[str, Any]) -> 
         groups.append(group_info)
 
     readable_output = tableToMarkdown(
-        "Prisma AIRs Model Security Groups",
+        "Prisma AIRS Model Security Groups",
         groups,
         headers=["uuid", "name", "source_type", "state", "created_at"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -1420,7 +1420,7 @@ def model_security_groups_get_command(client: Client, args: dict[str, Any]) -> C
     """Get model security group details by UUID.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1474,7 +1474,7 @@ def model_security_groups_create_command(client: Client, args: dict[str, Any]) -
     """Create a new model security group.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1550,7 +1550,7 @@ def model_security_groups_delete_command(client: Client, args: dict[str, Any]) -
     Removes a security group that is no longer needed.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1605,7 +1605,7 @@ def model_security_groups_update_command(client: Client, args: dict[str, Any]) -
     Updates the name and/or description of a security group.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1683,7 +1683,7 @@ def model_security_rules_list_command(client: Client, args: dict[str, Any]) -> C
     """List model security rules.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1716,7 +1716,7 @@ def model_security_rules_list_command(client: Client, args: dict[str, Any]) -> C
         rules.append(rule_info)
 
     readable_output = tableToMarkdown(
-        "Prisma AIRs Model Security Rules",
+        "Prisma AIRS Model Security Rules",
         rules,
         headers=["uuid", "name", "rule_type", "default_state"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -1738,7 +1738,7 @@ def model_security_rules_get_command(client: Client, args: dict[str, Any]) -> Co
     remediation steps, and editable fields.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1841,7 +1841,7 @@ def model_security_rule_instances_list_command(client: Client, args: dict[str, A
     Each instance has a state (DISABLED/ALLOWING/BLOCKING) and optional field customizations.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1939,7 +1939,7 @@ def model_security_rule_instances_update_command(client: Client, args: dict[str,
     of a rule instance. Use this to enable/disable rules or customize rule parameters.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -2033,7 +2033,7 @@ def model_security_rule_instances_get_command(client: Client, args: dict[str, An
     Retrieves detailed configuration of a specific rule instance.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -2100,7 +2100,7 @@ def model_security_rule_instances_get_command(client: Client, args: dict[str, An
 
 
 def main() -> None:
-    """Main function for Prisma AIRs AI Model Security integration."""
+    """Main function for Prisma AIRS AI Model Security integration."""
     params = demisto.params()
     args = demisto.args()
     command = demisto.command()

--- a/Packs/PaloAltoNetworks_Prisma_AIRs/Integrations/PrismaAIRsModelSecurity/PrismaAIRsModelSecurity_test.py
+++ b/Packs/PaloAltoNetworks_Prisma_AIRs/Integrations/PrismaAIRsModelSecurity/PrismaAIRsModelSecurity_test.py
@@ -1,4 +1,4 @@
-"""Unit tests for the Prisma AIRs AI Model Security integration."""
+"""Unit tests for the Prisma AIRS AI Model Security integration."""
 
 import json
 from unittest.mock import Mock, patch
@@ -39,7 +39,7 @@ from PrismaAIRsModelSecurity import (
 
 @pytest.fixture
 def mock_client() -> Client:
-    """Create a mock Prisma AIRs client scoped to the Model Security plane."""
+    """Create a mock Prisma AIRS client scoped to the Model Security plane."""
     return Client(
         base_url="https://api.sase.paloaltonetworks.com",
         client_id="test_client_id",
@@ -52,7 +52,7 @@ def mock_client() -> Client:
 
 
 class TestModelSecurity:
-    """Test cases for Prisma AIRs AI Model Security commands."""
+    """Test cases for Prisma AIRS AI Model Security commands."""
 
     @patch.object(Client, "http_request")
     def test_model_security_scans_list_command(self, mock_http: Mock, mock_client: Client) -> None:

--- a/Packs/PaloAltoNetworks_Prisma_AIRs/Integrations/PrismaAIRsRedTeam/PrismaAIRsRedTeam.py
+++ b/Packs/PaloAltoNetworks_Prisma_AIRs/Integrations/PrismaAIRsRedTeam/PrismaAIRsRedTeam.py
@@ -57,7 +57,7 @@ def redteam_targets_list_command(client: Client, args: dict[str, Any]) -> Comman
     """List all Red Team targets.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -105,7 +105,7 @@ def redteam_targets_list_command(client: Client, args: dict[str, Any]) -> Comman
         targets.append(target_info)
 
     readable_output = tableToMarkdown(
-        "Prisma AIRs Red Team Targets",
+        "Prisma AIRS Red Team Targets",
         targets,
         headers=["uuid", "name", "target_type", "status", "active", "validated", "created_at"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -124,7 +124,7 @@ def redteam_targets_create_command(client: Client, args: dict[str, Any]) -> Comm
     """Create a new Red Team target.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -211,7 +211,7 @@ def redteam_targets_get_command(client: Client, args: dict[str, Any]) -> Command
     """Get Red Team target details by UUID.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -283,7 +283,7 @@ def redteam_targets_update_command(client: Client, args: dict[str, Any]) -> Comm
     """Update an existing Red Team target.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -386,7 +386,7 @@ def redteam_targets_delete_command(client: Client, args: dict[str, Any]) -> Comm
     """Delete a Red Team target.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -430,7 +430,7 @@ def redteam_instances_create_command(client: Client, args: dict[str, Any]) -> Co
     """Create a new Red Team tenant instance.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -513,7 +513,7 @@ def redteam_instances_get_command(client: Client, args: dict[str, Any]) -> Comma
     """Get a Red Team tenant instance by tenant ID.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -566,7 +566,7 @@ def redteam_instances_update_command(client: Client, args: dict[str, Any]) -> Co
     """Update an existing Red Team tenant instance.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -647,7 +647,7 @@ def redteam_instances_delete_command(client: Client, args: dict[str, Any]) -> Co
     """Delete a Red Team tenant instance.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -697,7 +697,7 @@ def _resolve_device_instance(client: Client, tenant_id: str, args: dict[str, Any
     the tenant_id in the common case.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         tenant_id: The tenant ID of the parent instance.
         args: Command arguments from XSOAR.
 
@@ -789,7 +789,7 @@ def redteam_devices_create_command(client: Client, args: dict[str, Any]) -> Comm
     """Create one or more devices on a Red Team tenant instance.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -822,7 +822,7 @@ def redteam_devices_update_command(client: Client, args: dict[str, Any]) -> Comm
     """Update one or more devices on a Red Team tenant instance.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -855,7 +855,7 @@ def redteam_devices_delete_command(client: Client, args: dict[str, Any]) -> Comm
     """Delete one or more devices from a Red Team tenant instance.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -968,7 +968,7 @@ def _assert_channel_online(client: Client, channel_uuid: str) -> None:
     broker-online check.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         channel_uuid: Network broker channel UUID.
 
     Raises:
@@ -993,7 +993,7 @@ def redteam_adapters_list_command(client: Client, args: dict[str, Any]) -> Comma
     """List Red Team custom target adapters.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1017,7 +1017,7 @@ def redteam_adapters_list_command(client: Client, args: dict[str, Any]) -> Comma
     adapters = [_parse_adapter(adapter) for adapter in response.get("data", [])]
 
     readable_output = tableToMarkdown(
-        "Prisma AIRs Red Team Adapters",
+        "Prisma AIRS Red Team Adapters",
         adapters,
         headers=["uuid", "name", "status", "target_count", "created_at", "updated_at"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -1037,7 +1037,7 @@ def redteam_adapters_get_command(client: Client, args: dict[str, Any]) -> Comman
     """Get a single Red Team custom target adapter by UUID.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1073,7 +1073,7 @@ def redteam_adapters_create_command(client: Client, args: dict[str, Any]) -> Com
     """Create a new Red Team custom target adapter.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1144,7 +1144,7 @@ def redteam_adapters_update_command(client: Client, args: dict[str, Any]) -> Com
     can change one field without wiping the rest.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1238,7 +1238,7 @@ def redteam_adapters_delete_command(client: Client, args: dict[str, Any]) -> Com
     """Delete a Red Team custom target adapter.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1280,7 +1280,7 @@ def redteam_adapters_validate_command(client: Client, args: dict[str, Any]) -> C
     returns the execution outcome (validated + stdout/stderr/traceback), not an adapter record.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1344,7 +1344,7 @@ def redteam_targets_probe_command(client: Client, args: dict[str, Any]) -> Comma
     """Probe a Red Team target to validate connectivity and profiling.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1434,7 +1434,7 @@ def redteam_targets_profile_command(client: Client, args: dict[str, Any]) -> Com
     """Get Red Team target profile (background, context, profiling status).
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1501,7 +1501,7 @@ def redteam_targets_update_profile_command(client: Client, args: dict[str, Any])
     """Update Red Team target profile (background and additional context).
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1586,7 +1586,7 @@ def redteam_targets_metadata_command(client: Client, args: dict[str, Any]) -> Co
     fields are available when creating or updating targets.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1635,7 +1635,7 @@ def redteam_targets_validate_auth_command(client: Client, args: dict[str, Any]) 
     creating a target.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1705,7 +1705,7 @@ def redteam_targets_templates_command(client: Client, args: dict[str, Any]) -> C
     target provider type.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1744,11 +1744,11 @@ def redteam_targets_templates_command(client: Client, args: dict[str, Any]) -> C
 def redteam_targets_error_logs_command(client: Client, args: dict[str, Any]) -> CommandResults:
     """List target-profile (profiling) error logs for a Red Team target.
 
-    Returns the profiling failures recorded while Prisma AIRs was probing/profiling the
+    Returns the profiling failures recorded while Prisma AIRS was probing/profiling the
     target (e.g. connection, probe, or authentication errors), newest first.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1827,7 +1827,7 @@ def redteam_scan_error_logs_command(client: Client, args: dict[str, Any]) -> Com
     logs (which cover profiling), these are scoped to a single scan job.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1905,7 +1905,7 @@ def redteam_dashboard_scan_statistics_command(client: Client, args: dict[str, An
     and risk rating. Optional filters narrow the window (date_range) or a single target (target_id).
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1976,7 +1976,7 @@ def redteam_dashboard_score_trend_command(client: Client, args: dict[str, Any]) 
     given target.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -2032,7 +2032,7 @@ def redteam_metering_quota_command(client: Client, args: dict[str, Any]) -> Comm
     custom). Called as a POST with no body, mirroring the SDK.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR (unused).
 
     Returns:
@@ -2087,7 +2087,7 @@ def redteam_dashboard_overview_command(client: Client, args: dict[str, Any]) -> 
     Returns the total target count and, when available, a breakdown of targets by type.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR (unused).
 
     Returns:
@@ -2138,7 +2138,7 @@ def redteam_scan_create_command(client: Client, args: dict[str, Any]) -> Command
     Use prisma-airs-redteam-scan-get to check status, or implement polling in a playbook.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -2290,7 +2290,7 @@ def redteam_scans_list_command(client: Client, args: dict[str, Any]) -> CommandR
     """List all Red Team scans.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -2336,7 +2336,7 @@ def redteam_scans_list_command(client: Client, args: dict[str, Any]) -> CommandR
         scans.append(scan_info)
 
     readable_output = tableToMarkdown(
-        "Prisma AIRs Red Team Scans",
+        "Prisma AIRS Red Team Scans",
         scans,
         headers=["uuid", "job_type", "status", "target_name", "progress", "created_at"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -2355,7 +2355,7 @@ def redteam_scan_get_command(client: Client, args: dict[str, Any]) -> CommandRes
     """Get Red Team scan status and details.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -2433,7 +2433,7 @@ def redteam_scan_abort_command(client: Client, args: dict[str, Any]) -> CommandR
     """Abort a running Red Team scan.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -2473,7 +2473,7 @@ def redteam_categories_list_command(client: Client, args: dict[str, Any]) -> Com
     """List Red Team attack categories.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -2559,7 +2559,7 @@ def redteam_network_channels_list_command(client: Client, args: dict[str, Any]) 
     """List Red Team network broker channels.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -2592,7 +2592,7 @@ def redteam_network_channels_list_command(client: Client, args: dict[str, Any]) 
     channels = [_parse_network_channel(channel) for channel in response.get("data", [])]
 
     readable_output = tableToMarkdown(
-        "Prisma AIRs Red Team Network Channels",
+        "Prisma AIRS Red Team Network Channels",
         channels,
         headers=["uuid", "name", "status", "description", "last_online_at", "created_at"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -2611,7 +2611,7 @@ def redteam_network_channels_create_command(client: Client, args: dict[str, Any]
     """Create a new Red Team network broker channel.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -2654,7 +2654,7 @@ def redteam_network_channels_stats_command(client: Client, args: dict[str, Any])
     """Get Red Team network broker channel statistics and deployment info.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -2675,7 +2675,7 @@ def redteam_network_channels_stats_command(client: Client, args: dict[str, Any])
     }
 
     readable_output = tableToMarkdown(
-        "Prisma AIRs Red Team Network Channel Stats",
+        "Prisma AIRS Red Team Network Channel Stats",
         [stats_info],
         headers=[
             "network_channels_server_domain",
@@ -2701,7 +2701,7 @@ def redteam_network_channels_get_command(client: Client, args: dict[str, Any]) -
     """Get a single Red Team network broker channel by UUID.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -2719,7 +2719,7 @@ def redteam_network_channels_get_command(client: Client, args: dict[str, Any]) -
     channel_info = _parse_network_channel(response)
 
     readable_output = tableToMarkdown(
-        "Prisma AIRs Red Team Network Channel",
+        "Prisma AIRS Red Team Network Channel",
         [channel_info],
         headers=["uuid", "name", "status", "description", "last_online_at", "created_at", "updated_at"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -2738,7 +2738,7 @@ def redteam_network_channels_update_command(client: Client, args: dict[str, Any]
     """Update a Red Team network broker channel's name and/or description.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -2793,7 +2793,7 @@ def redteam_languages_list_command(client: Client, args: dict[str, Any]) -> Comm
     management plane (identical response shape, possibly a different subset).
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -2822,7 +2822,7 @@ def redteam_languages_list_command(client: Client, args: dict[str, Any]) -> Comm
 
     supported = ", ".join(str(job_type) for job_type in supported_job_types)
     title = (
-        f"Prisma AIRs Red Team Supported Languages "
+        f"Prisma AIRS Red Team Supported Languages "
         f"(multilingual_enabled: {languages_info['multilingual_enabled']}; job types: {supported or 'N/A'})"
     )
     readable_output = tableToMarkdown(
@@ -2845,7 +2845,7 @@ def redteam_report_get_command(client: Client, args: dict[str, Any]) -> CommandR
     """Get Red Team scan report.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -2984,7 +2984,7 @@ def redteam_report_attacks_list_command(client: Client, args: dict[str, Any]) ->
     """List attacks for a Red Team static scan report.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -3036,7 +3036,7 @@ def redteam_report_attacks_list_command(client: Client, args: dict[str, Any]) ->
         )
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs Red Team Attacks - Job {job_id}",
+        f"Prisma AIRS Red Team Attacks - Job {job_id}",
         attacks,
         headers=["uuid", "category_display_name", "sub_category_display_name", "severity", "status", "threat"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -3056,7 +3056,7 @@ def redteam_report_attack_get_command(client: Client, args: dict[str, Any]) -> C
     """Get attack details for a Red Team static scan report.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -3096,7 +3096,7 @@ def redteam_report_attack_get_command(client: Client, args: dict[str, Any]) -> C
     }
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs Red Team Attack - {attack_id}",
+        f"Prisma AIRS Red Team Attack - {attack_id}",
         [attack],
         headers=["uuid", "category_display_name", "sub_category_display_name", "severity", "status", "threat", "goal"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -3127,7 +3127,7 @@ def redteam_report_attack_multi_turn_get_command(client: Client, args: dict[str,
     """Get multi-turn attack details for a Red Team static scan report.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -3167,7 +3167,7 @@ def redteam_report_attack_multi_turn_get_command(client: Client, args: dict[str,
     }
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs Red Team Multi-Turn Attack - {attack_id}",
+        f"Prisma AIRS Red Team Multi-Turn Attack - {attack_id}",
         [attack],
         headers=["uuid", "category_display_name", "sub_category_display_name", "severity", "status", "threat", "goal"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -3205,7 +3205,7 @@ def redteam_report_remediation_get_command(client: Client, args: dict[str, Any])
     """Get remediation recommendations for a Red Team scan report.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -3234,7 +3234,7 @@ def redteam_report_remediation_get_command(client: Client, args: dict[str, Any])
     }
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs Red Team Remediations - Job {job_id}",
+        f"Prisma AIRS Red Team Remediations - Job {job_id}",
         remediations,
         headers=["remediation", "priority_level", "effectiveness_level", "ease_of_implementation_level"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -3254,7 +3254,7 @@ def redteam_report_runtime_policy_get_command(client: Client, args: dict[str, An
     """Get the runtime security profile config derived from a Red Team scan report.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -3283,7 +3283,7 @@ def redteam_report_runtime_policy_get_command(client: Client, args: dict[str, An
     }
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs Red Team Runtime Security Profile - Job {job_id}",
+        f"Prisma AIRS Red Team Runtime Security Profile - Job {job_id}",
         runtime_security_profile,
         headers=["policy_id", "display_name"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -3303,7 +3303,7 @@ def redteam_report_goals_list_command(client: Client, args: dict[str, Any]) -> C
     """List goals for a Red Team dynamic scan report.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -3351,7 +3351,7 @@ def redteam_report_goals_list_command(client: Client, args: dict[str, Any]) -> C
         )
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs Red Team Goals - Job {job_id}",
+        f"Prisma AIRS Red Team Goals - Job {job_id}",
         goals,
         headers=["uuid", "goal", "goal_type", "custom_goal", "threat"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -3371,7 +3371,7 @@ def redteam_report_goal_streams_list_command(client: Client, args: dict[str, Any
     """List streams for a goal in a Red Team dynamic scan report.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -3419,7 +3419,7 @@ def redteam_report_goal_streams_list_command(client: Client, args: dict[str, Any
         )
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs Red Team Goal Streams - Goal {goal_id}",
+        f"Prisma AIRS Red Team Goal Streams - Goal {goal_id}",
         streams,
         headers=["uuid", "goal_id", "target_id", "stream_type", "threat", "marked_safe"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -3439,7 +3439,7 @@ def redteam_report_stream_get_command(client: Client, args: dict[str, Any]) -> C
     """Get stream details for a Red Team dynamic scan report.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -3472,7 +3472,7 @@ def redteam_report_stream_get_command(client: Client, args: dict[str, Any]) -> C
     }
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs Red Team Stream - {stream_id}",
+        f"Prisma AIRS Red Team Stream - {stream_id}",
         [stream],
         headers=["uuid", "job_id", "goal_id", "target_id", "stream_type", "threat", "marked_safe"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -3542,7 +3542,7 @@ def redteam_report_download_command(client: Client, args: dict[str, Any]) -> dic
     the file, then returns it as a War Room attachment.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -3583,7 +3583,7 @@ def redteam_report_generate_partial_command(client: Client, args: dict[str, Any]
     Returns the updated job information reflecting the unlocked report.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -3647,7 +3647,7 @@ def redteam_eula_status_command(client: Client, args: dict[str, Any]) -> Command
     """Get Red Team EULA acceptance status.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -3690,7 +3690,7 @@ def redteam_eula_content_command(client: Client, args: dict[str, Any]) -> Comman
     """Get Red Team EULA content (full text).
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -3734,7 +3734,7 @@ def redteam_eula_accept_command(client: Client, args: dict[str, Any]) -> Command
     """Accept the Red Team EULA.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -3791,7 +3791,7 @@ def redteam_prompts_create_command(client: Client, args: dict[str, Any]) -> Comm
     """Create a new prompt in a prompt set.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
               - prompt_set_uuid (required): UUID of the prompt set
               - prompt (required): The prompt text
@@ -3880,7 +3880,7 @@ def redteam_prompts_list_command(client: Client, args: dict[str, Any]) -> Comman
     """List prompts in a prompt set.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
               - prompt_set_uuid (required): UUID of the prompt set
               - limit (optional): Max records to return
@@ -3982,7 +3982,7 @@ def redteam_prompts_get_command(client: Client, args: dict[str, Any]) -> Command
     """Get a specific prompt by UUID.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
               - prompt_set_uuid (required): UUID of the prompt set
               - prompt_uuid (required): UUID of the prompt
@@ -4063,7 +4063,7 @@ def redteam_prompts_update_command(client: Client, args: dict[str, Any]) -> Comm
     """Update an existing prompt.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
               - prompt_set_uuid (required): UUID of the prompt set
               - prompt_uuid (required): UUID of the prompt to update
@@ -4160,7 +4160,7 @@ def redteam_prompts_delete_command(client: Client, args: dict[str, Any]) -> Comm
     """Delete a prompt from a prompt set.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
               - prompt_set_uuid (required): UUID of the prompt set
               - prompt_uuid (required): UUID of the prompt to delete
@@ -4221,7 +4221,7 @@ def redteam_prompt_sets_create_command(client: Client, args: dict[str, Any]) -> 
     """Create a new Red Team prompt set for custom attack scenarios.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
               - name (required): Name of the prompt set
               - description (optional): Description of the prompt set
@@ -4311,7 +4311,7 @@ def redteam_prompt_sets_list_command(client: Client, args: dict[str, Any]) -> Co
     """List Red Team prompt sets for custom attack scenarios.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
               - limit (optional): Max records to return
               - skip (optional): Number of records to skip
@@ -4414,7 +4414,7 @@ def redteam_prompt_sets_get_command(client: Client, args: dict[str, Any]) -> Com
     """Get details of a specific Red Team prompt set.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
               - uuid (required): UUID of the prompt set
 
@@ -4497,7 +4497,7 @@ def redteam_prompt_sets_update_command(client: Client, args: dict[str, Any]) -> 
     """Update an existing Red Team prompt set.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
               - uuid (required): UUID of the prompt set to update
               - name (optional): Updated name
@@ -4602,7 +4602,7 @@ def redteam_prompt_sets_archive_command(client: Client, args: dict[str, Any]) ->
     """Archive or unarchive a Red Team prompt set.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
               - uuid (required): UUID of the prompt set
               - archive (required): Archive status (true or false)
@@ -4694,7 +4694,7 @@ def redteam_registry_credentials_get_command(client: Client, args: dict[str, Any
     """Get or create Red Team registry credentials for pulling scanner images.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR (no arguments required).
 
     Returns:
@@ -4728,7 +4728,7 @@ def redteam_registry_credentials_get_command(client: Client, args: dict[str, Any
         removeNull=True,
     )
     readable_output += (
-        "\n\n**Note:** These credentials are used to pull Red Team scanner container images from the Prisma AIRs registry."
+        "\n\n**Note:** These credentials are used to pull Red Team scanner container images from the Prisma AIRS registry."
     )
 
     return CommandResults(
@@ -4745,7 +4745,7 @@ def redteam_prompt_sets_download_command(client: Client, args: dict[str, Any]) -
     """Download CSV template for a prompt set.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -4788,7 +4788,7 @@ def redteam_prompt_sets_upload_command(client: Client, args: dict[str, Any]) -> 
     """Upload CSV file with prompts to a prompt set.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -4901,7 +4901,7 @@ def redteam_prompt_sets_reference_command(client: Client, args: dict[str, Any]) 
     """Resolve a prompt set reference (data-plane consumption view).
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
               - uuid (required): UUID of the prompt set.
 
@@ -4944,7 +4944,7 @@ def redteam_prompt_sets_version_info_command(client: Client, args: dict[str, Any
     """Get version information for a prompt set.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
               - uuid (required): UUID of the prompt set.
               - version (optional): A specific version ID to query.
@@ -5022,7 +5022,7 @@ def redteam_prompt_sets_active_list_command(client: Client, args: dict[str, Any]
     """List active prompt sets (data-plane consumption view).
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -5064,7 +5064,7 @@ def redteam_properties_list_command(client: Client, args: dict[str, Any]) -> Com
     filter custom attack prompts. Read-only.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -5102,7 +5102,7 @@ def redteam_properties_values_command(client: Client, args: dict[str, Any]) -> C
     {name, values} entries.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -5171,7 +5171,7 @@ def redteam_properties_create_command(client: Client, args: dict[str, Any]) -> C
     """Create a new custom-attack property name.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -5217,7 +5217,7 @@ def redteam_properties_add_value_command(client: Client, args: dict[str, Any]) -
     """Add an allowed value to an existing custom-attack property name.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -5290,7 +5290,7 @@ def redteam_sentiment_get_command(client: Client, args: dict[str, Any]) -> Comma
     """Get the sentiment (up/down-vote) recorded for a Red Team scan report.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -5328,7 +5328,7 @@ def redteam_sentiment_update_command(client: Client, args: dict[str, Any]) -> Co
     """Update the sentiment (up/down-vote) for a Red Team scan report.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -5454,7 +5454,7 @@ def redteam_custom_attack_report_get_command(client: Client, args: dict[str, Any
     """Get the custom-attack report summary for a scan job.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
               - job_id (required): The job UUID of the custom-attack scan.
 
@@ -5508,7 +5508,7 @@ def redteam_custom_attack_report_prompt_sets_command(client: Client, args: dict[
     """Get the prompt-set breakdown for a custom-attack scan report.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
               - job_id (required): The job UUID of the custom-attack scan.
 
@@ -5561,7 +5561,7 @@ def redteam_custom_attack_report_prompts_command(client: Client, args: dict[str,
     """List prompts for a specific prompt set within a custom-attack scan report.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
               - job_id (required): The job UUID of the custom-attack scan.
               - prompt_set_id (required): The prompt-set UUID.
@@ -5617,7 +5617,7 @@ def redteam_custom_attack_report_prompt_get_command(client: Client, args: dict[s
     """Get details for a single prompt within a custom-attack scan report.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
               - job_id (required): The job UUID of the custom-attack scan.
               - prompt_id (required): The prompt UUID.
@@ -5664,7 +5664,7 @@ def redteam_custom_attacks_list_command(client: Client, args: dict[str, Any]) ->
     """List custom attacks for a scan job.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
               - job_id (required): The job UUID of the custom-attack scan.
               - threat (optional): Filter to threat attacks only.
@@ -5727,7 +5727,7 @@ def redteam_custom_attack_outputs_command(client: Client, args: dict[str, Any]) 
     """List the target outputs for a single custom attack.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
               - job_id (required): The job UUID of the custom-attack scan.
               - attack_id (required): The custom-attack UUID.
@@ -5789,7 +5789,7 @@ def redteam_custom_attack_property_stats_command(client: Client, args: dict[str,
     """Get per-property attack-success statistics for a custom-attack scan.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
               - job_id (required): The job UUID of the custom-attack scan.
 
@@ -5847,7 +5847,7 @@ def redteam_custom_attack_property_stats_command(client: Client, args: dict[str,
 
 
 def main() -> None:
-    """Main function for Prisma AIRs AI Red Teaming integration."""
+    """Main function for Prisma AIRS AI Red Teaming integration."""
     params = demisto.params()
     args = demisto.args()
     command = demisto.command()

--- a/Packs/PaloAltoNetworks_Prisma_AIRs/Integrations/PrismaAIRsRedTeam/PrismaAIRsRedTeam.yml
+++ b/Packs/PaloAltoNetworks_Prisma_AIRs/Integrations/PrismaAIRsRedTeam/PrismaAIRsRedTeam.yml
@@ -399,7 +399,7 @@ script:
       description: The provider-keyed dictionary of target configuration templates.
       type: Unknown
   - name: prisma-airs-redteam-targets-error-logs
-    description: List target-profile (profiling) error logs for a Red Team target. Returns the failures recorded while Prisma AIRs was probing or profiling the target (for example, connection, probe, or authentication errors).
+    description: List target-profile (profiling) error logs for a Red Team target. Returns the failures recorded while Prisma AIRS was probing or profiling the target (for example, connection, probe, or authentication errors).
     arguments:
     - name: target_id
       description: The UUID of the target whose profiling error logs to retrieve.
@@ -2640,7 +2640,7 @@ script:
       description: The version information.
       type: Unknown
   - name: prisma-airs-redteam-registry-credentials-get
-    description: Get or create Red Team registry credentials for pulling scanner container images from the Prisma AIRs registry.
+    description: Get or create Red Team registry credentials for pulling scanner container images from the Prisma AIRS registry.
     outputs:
     - contextPath: PrismaAIRs.RedTeamRegistryCredentials.token
       description: The registry access token for authenticating with the container registry.

--- a/Packs/PaloAltoNetworks_Prisma_AIRs/Integrations/PrismaAIRsRedTeam/PrismaAIRsRedTeam_test.py
+++ b/Packs/PaloAltoNetworks_Prisma_AIRs/Integrations/PrismaAIRsRedTeam/PrismaAIRsRedTeam_test.py
@@ -87,7 +87,7 @@ from PrismaAIRsRedTeam import (
 
 @pytest.fixture
 def mock_client() -> Client:
-    """Create a mock Prisma AIRs client for testing.
+    """Create a mock Prisma AIRS client for testing.
 
     Returns:
         Client: Mock client instance.

--- a/Packs/PaloAltoNetworks_Prisma_AIRs/Integrations/PrismaAIRsRedTeam/README.md
+++ b/Packs/PaloAltoNetworks_Prisma_AIRs/Integrations/PrismaAIRsRedTeam/README.md
@@ -112,7 +112,7 @@ List all Red Team targets.
 
 #### Human Readable Output
 
->### Prisma AIRs Red Team Targets
+>### Prisma AIRS Red Team Targets
 >
 >|Uuid|Name|Target Type|Status|Active|Validated|Created At|
 >|---|---|---|---|---|---|---|
@@ -1069,7 +1069,7 @@ List Red Team custom target adapters. List rows carry no script, description, or
 
 #### Human Readable Output
 
->### Prisma AIRs Red Team Adapters
+>### Prisma AIRS Red Team Adapters
 >
 >|Uuid|Name|Status|Target Count|Created At|Updated At|
 >|---|---|---|---|---|---|
@@ -1422,7 +1422,7 @@ List all Red Team scans.
 
 #### Human Readable Output
 
->### Prisma AIRs Red Team Scans
+>### Prisma AIRS Red Team Scans
 >
 >|Uuid|Job Type|Status|Target Name|Progress|Created At|
 >|---|---|---|---|---|---|
@@ -1710,7 +1710,7 @@ List Red Team network broker channels. Network channels are the data-plane relay
 
 #### Human Readable Output
 
->### Prisma AIRs Red Team Network Channels
+>### Prisma AIRS Red Team Network Channels
 >
 >|Uuid|Name|Status|Description|Last Online At|Created At|
 >|---|---|---|---|---|---|
@@ -1817,7 +1817,7 @@ There are no input arguments for this command.
 
 #### Human Readable Output
 
->### Prisma AIRs Red Team Network Channel Stats
+>### Prisma AIRS Red Team Network Channel Stats
 >
 >|Network Channels Server Domain|Online Channels|Total Channels|Docker Registry|Docker Image|Helm Chart|Client Version|
 >|---|---|---|---|---|---|---|
@@ -1879,7 +1879,7 @@ Get a single Red Team network broker channel by UUID.
 
 #### Human Readable Output
 
->### Prisma AIRs Red Team Network Channel
+>### Prisma AIRS Red Team Network Channel
 >
 >|Uuid|Name|Status|Description|Last Online At|Created At|Updated At|
 >|---|---|---|---|---|---|---|
@@ -1991,7 +1991,7 @@ List the tenant's allowed languages for Red Team scans. Queries the data plane b
 
 #### Human Readable Output
 
->### Prisma AIRs Red Team Supported Languages (multilingual_enabled: True; job types: STATIC, DYNAMIC, CUSTOM)
+>### Prisma AIRS Red Team Supported Languages (multilingual_enabled: True; job types: STATIC, DYNAMIC, CUSTOM)
 >
 >|Code|Name|
 >|---|---|
@@ -2946,7 +2946,7 @@ Archive or unarchive a Red Team prompt set.
 ### prisma-airs-redteam-registry-credentials-get
 
 ***
-Get or create Red Team registry credentials for pulling scanner container images from the Prisma AIRs registry.
+Get or create Red Team registry credentials for pulling scanner container images from the Prisma AIRS registry.
 
 #### Base Command
 

--- a/Packs/PaloAltoNetworks_Prisma_AIRs/Integrations/PrismaAIRsRuntime/PrismaAIRsRuntime.py
+++ b/Packs/PaloAltoNetworks_Prisma_AIRs/Integrations/PrismaAIRsRuntime/PrismaAIRsRuntime.py
@@ -24,7 +24,7 @@ def runtime_scan_command(client: Client, args: dict[str, Any]) -> CommandResults
     """Scan a prompt against a security profile.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -88,7 +88,7 @@ def runtime_scan_command(client: Client, args: dict[str, Any]) -> CommandResults
     if metadata:
         scan_request["metadata"] = metadata
 
-    # Call Prisma AIRs scanner API
+    # Call Prisma AIRS scanner API
     scan_response = client.scanner_request(scan_request)
 
     # Parse detections for both prompt and response
@@ -186,7 +186,7 @@ def runtime_scan_command(client: Client, args: dict[str, Any]) -> CommandResults
         )
 
     # Build readable output
-    readable_output = "## Prisma AIRs Runtime Scan Results\n\n"
+    readable_output = "## Prisma AIRS Runtime Scan Results\n\n"
     readable_output += tableToMarkdown(
         "Scan Summary", scan_summary, headers=["Scan ID", "Report ID", "Profile", "Action", "Category", "Detected"]
     )
@@ -226,7 +226,7 @@ def runtime_api_keys_list_command(client: Client, args: dict[str, Any]) -> Comma
     """List Runtime API Keys.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -259,7 +259,7 @@ def runtime_api_keys_list_command(client: Client, args: dict[str, Any]) -> Comma
         api_keys.append(api_key_info)
 
     readable_output = tableToMarkdown(
-        "Prisma AIRs Runtime API Keys",
+        "Prisma AIRS Runtime API Keys",
         api_keys,
         headers=["id", "name", "last8", "created_at", "expires_at", "revoked"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -278,7 +278,7 @@ def runtime_api_keys_create_command(client: Client, args: dict[str, Any]) -> Com
     """Create a new Runtime API Key.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -412,7 +412,7 @@ def runtime_api_keys_regenerate_command(client: Client, args: dict[str, Any]) ->
     This creates a NEW key with a NEW UUID and invalidates the old key.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -514,7 +514,7 @@ def runtime_api_keys_delete_command(client: Client, args: dict[str, Any]) -> Com
     This permanently deletes the API key and revokes access immediately.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -570,7 +570,7 @@ def runtime_profiles_list_command(client: Client, args: dict[str, Any]) -> Comma
     """List runtime security profiles.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -605,7 +605,7 @@ def runtime_profiles_list_command(client: Client, args: dict[str, Any]) -> Comma
         profiles.append(profile_info)
 
     readable_output = tableToMarkdown(
-        "Prisma AIRs Security Profiles",
+        "Prisma AIRS Security Profiles",
         profiles,
         headers=["id", "name", "revision", "active", "created_by", "updated_by", "last_modified_ts"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -626,7 +626,7 @@ def runtime_profiles_get_command(client: Client, args: dict[str, Any]) -> Comman
     Note: There is no dedicated GET endpoint - this fetches all profiles and filters.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -715,7 +715,7 @@ def runtime_profiles_create_command(client: Client, args: dict[str, Any]) -> Com
     """Create a new security profile.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -801,7 +801,7 @@ def runtime_profiles_update_command(client: Client, args: dict[str, Any]) -> Com
     WARNING: This modifies the profile configuration and can break scanning if misconfigured.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -891,7 +891,7 @@ def runtime_profiles_delete_command(client: Client, args: dict[str, Any]) -> Com
     WARNING: This permanently deletes the security profile. This action cannot be undone.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -955,7 +955,7 @@ def runtime_customer_apps_list_command(client: Client, args: dict[str, Any]) -> 
     """List customer applications.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -988,7 +988,7 @@ def runtime_customer_apps_list_command(client: Client, args: dict[str, Any]) -> 
         apps.append(app_info)
 
     readable_output = tableToMarkdown(
-        "Prisma AIRs Customer Applications",
+        "Prisma AIRS Customer Applications",
         apps,
         headers=["id", "name", "model_name", "cloud_provider", "environment", "ai_agent_framework"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -1007,7 +1007,7 @@ def runtime_customer_apps_get_command(client: Client, args: dict[str, Any]) -> C
     """Get customer application details by name.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1073,7 +1073,7 @@ def runtime_customer_apps_update_command(client: Client, args: dict[str, Any]) -
     """Update a customer application.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1154,7 +1154,7 @@ def runtime_customer_apps_consumption_command(client: Client, args: dict[str, An
     """Get per-application token consumption and session statistics.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1299,7 +1299,7 @@ def runtime_customer_apps_violations_command(client: Client, args: dict[str, Any
     """Get per-detector violation severity breakdown for an application.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1388,7 +1388,7 @@ def runtime_customer_apps_delete_command(client: Client, args: dict[str, Any]) -
     WARNING: This permanently deletes the application and revokes all associated API keys immediately.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1450,7 +1450,7 @@ def runtime_deployment_profiles_list_command(client: Client, args: dict[str, Any
     """List deployment profiles.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1485,7 +1485,7 @@ def runtime_deployment_profiles_list_command(client: Client, args: dict[str, Any
         profiles.append(profile_info)
 
     readable_output = tableToMarkdown(
-        "Prisma AIRs Deployment Profiles",
+        "Prisma AIRS Deployment Profiles",
         profiles,
         headers=["name", "auth_code", "status", "expiration_date", "ave_text_records"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -1504,7 +1504,7 @@ def runtime_dlp_profiles_list_command(client: Client, args: dict[str, Any]) -> C
     """List DLP data profiles (v2 API).
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1550,7 +1550,7 @@ def runtime_dlp_profiles_list_command(client: Client, args: dict[str, Any]) -> C
     total_pages = response.get("page", {}).get("total_pages", 1)
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs DLP Data Profiles (Page {page + 1}/{total_pages}, {len(profiles)} of {total_elements})",
+        f"Prisma AIRS DLP Data Profiles (Page {page + 1}/{total_pages}, {len(profiles)} of {total_elements})",
         profiles,
         headers=["id", "name", "type", "profile_status", "profile_type", "version"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -1569,7 +1569,7 @@ def runtime_dlp_profiles_get_command(client: Client, args: dict[str, Any]) -> Co
     """Get a single DLP data profile by ID.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1605,7 +1605,7 @@ def runtime_dlp_profiles_get_command(client: Client, args: dict[str, Any]) -> Co
     }
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs DLP Data Profile: {profile_info.get('name')}",
+        f"Prisma AIRS DLP Data Profile: {profile_info.get('name')}",
         profile_info,
         headers=["id", "name", "type", "profile_status", "profile_type", "description"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -1624,7 +1624,7 @@ def runtime_dlp_profiles_create_command(client: Client, args: dict[str, Any]) ->
     """Create a new DLP data profile.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1679,7 +1679,7 @@ def runtime_dlp_profiles_create_command(client: Client, args: dict[str, Any]) ->
     }
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs DLP Data Profile Created: {profile_info.get('name')}",
+        f"Prisma AIRS DLP Data Profile Created: {profile_info.get('name')}",
         profile_info,
         headers=["id", "name", "type", "profile_status", "profile_type", "description"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -1698,7 +1698,7 @@ def runtime_dlp_profiles_patch_command(client: Client, args: dict[str, Any]) -> 
     """Partially update a DLP data profile (JSON Merge Patch).
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1765,7 +1765,7 @@ def runtime_dlp_profiles_patch_command(client: Client, args: dict[str, Any]) -> 
     }
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs DLP Data Profile Patched: {profile_info.get('name')}",
+        f"Prisma AIRS DLP Data Profile Patched: {profile_info.get('name')}",
         profile_info,
         headers=["id", "name", "type", "profile_status", "profile_type", "description"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -1784,7 +1784,7 @@ def runtime_dlp_profiles_replace_command(client: Client, args: dict[str, Any]) -
     """Replace (full update) a DLP data profile.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1844,7 +1844,7 @@ def runtime_dlp_profiles_replace_command(client: Client, args: dict[str, Any]) -
     }
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs DLP Data Profile Replaced: {profile_info.get('name')}",
+        f"Prisma AIRS DLP Data Profile Replaced: {profile_info.get('name')}",
         profile_info,
         headers=["id", "name", "type", "profile_status", "profile_type", "description"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -1872,7 +1872,7 @@ def runtime_dlp_profiles_delete_command(client: Client, args: dict[str, Any]) ->
        patch it to a deleted lifecycle state (typically profile_status: 'deleted')."
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1915,7 +1915,7 @@ def runtime_dlp_profiles_delete_command(client: Client, args: dict[str, Any]) ->
     }
 
     readable_output = tableToMarkdown(
-        "Prisma AIRs DLP Data Profile Deleted",
+        "Prisma AIRS DLP Data Profile Deleted",
         [context_output],
         headers=["id", "name", "profile_status", "status"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -1935,7 +1935,7 @@ def runtime_topics_list_command(client: Client, args: dict[str, Any]) -> Command
     """List custom topics.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -1976,7 +1976,7 @@ def runtime_topics_list_command(client: Client, args: dict[str, Any]) -> Command
         topics.append(topic_info)
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs Custom Topics ({len(topics)} of {response.get('total', len(topics))})",
+        f"Prisma AIRS Custom Topics ({len(topics)} of {response.get('total', len(topics))})",
         topics,
         headers=["topic_id", "topic_name", "revision", "description"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -1997,7 +1997,7 @@ def runtime_topics_get_command(client: Client, args: dict[str, Any]) -> CommandR
     Note: There is no dedicated GET endpoint - this fetches all topics and filters.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -2083,7 +2083,7 @@ def runtime_topics_create_command(client: Client, args: dict[str, Any]) -> Comma
     """Create a new custom topic guardrail.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -2161,7 +2161,7 @@ def runtime_topics_update_command(client: Client, args: dict[str, Any]) -> Comma
     WARNING: This modifies the topic definition and can break detection if misconfigured.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -2244,7 +2244,7 @@ def runtime_topics_delete_command(client: Client, args: dict[str, Any]) -> Comma
     WARNING: This permanently deletes the topic. Fails if topic is referenced by a profile.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -2315,7 +2315,7 @@ def runtime_topics_apply_command(client: Client, args: dict[str, Any]) -> Comman
     Omitting revision defaults to revision 0 (original), not latest.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -2492,7 +2492,7 @@ def runtime_bulk_scan_command(client: Client, args: dict[str, Any]) -> CommandRe
     """Perform bulk scanning of prompts via async API.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -2585,7 +2585,7 @@ def runtime_bulk_scan_command(client: Client, args: dict[str, Any]) -> CommandRe
     # Create summary table
     summary = [{"Total Prompts": total, "Blocked": blocked, "Allowed": allowed, "Errors": errors}]
 
-    readable_output = "## Prisma AIRs Bulk Scan Results\n\n"
+    readable_output = "## Prisma AIRS Bulk Scan Results\n\n"
     readable_output += f"**Profile:** {profile_name}\n"
     if session_id:
         readable_output += f"**Session ID:** {session_id}\n"
@@ -2619,7 +2619,7 @@ def runtime_dlp_dictionaries_list_command(client: Client, args: dict[str, Any]) 
     """List DLP dictionaries.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -2667,7 +2667,7 @@ def runtime_dlp_dictionaries_list_command(client: Client, args: dict[str, Any]) 
     total_pages = response.get("total_pages", 1)
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs DLP Dictionaries (Page {page + 1}/{total_pages}, {len(dictionaries)} of {total_elements})",
+        f"Prisma AIRS DLP Dictionaries (Page {page + 1}/{total_pages}, {len(dictionaries)} of {total_elements})",
         dictionaries,
         headers=["id", "name", "category", "type", "number_of_keywords", "region_name"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -2686,7 +2686,7 @@ def runtime_dlp_dictionaries_get_command(client: Client, args: dict[str, Any]) -
     """Get a single DLP dictionary by ID.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -2733,7 +2733,7 @@ def runtime_dlp_dictionaries_get_command(client: Client, args: dict[str, Any]) -
     }
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs DLP Dictionary: {dict_info.get('name')}",
+        f"Prisma AIRS DLP Dictionary: {dict_info.get('name')}",
         dict_info,
         headers=["id", "name", "category", "type", "region_name", "is_case_sensitive", "description"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -2752,7 +2752,7 @@ def runtime_dlp_dictionaries_create_command(client: Client, args: dict[str, Any]
     """Create a new DLP dictionary by uploading a keyword file.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -2832,7 +2832,7 @@ def runtime_dlp_dictionaries_create_command(client: Client, args: dict[str, Any]
     }
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs DLP Dictionary Created: {dict_info.get('name')}",
+        f"Prisma AIRS DLP Dictionary Created: {dict_info.get('name')}",
         dict_info,
         headers=["id", "name", "category", "type", "region_name", "description"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -2851,7 +2851,7 @@ def runtime_dlp_dictionaries_patch_command(client: Client, args: dict[str, Any])
     """Partially update a DLP dictionary (JSON Merge Patch).
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -2921,7 +2921,7 @@ def runtime_dlp_dictionaries_patch_command(client: Client, args: dict[str, Any])
     }
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs DLP Dictionary Patched: {dict_info.get('name')}",
+        f"Prisma AIRS DLP Dictionary Patched: {dict_info.get('name')}",
         dict_info,
         headers=["id", "name", "category", "type", "region_name", "description"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -2940,7 +2940,7 @@ def runtime_dlp_dictionaries_replace_command(client: Client, args: dict[str, Any
     """Replace (full update) a DLP dictionary by uploading a new keyword file.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -3024,7 +3024,7 @@ def runtime_dlp_dictionaries_replace_command(client: Client, args: dict[str, Any
         }
 
         readable_output = tableToMarkdown(
-            f"Prisma AIRs DLP Dictionary Replaced: {dict_info.get('name')}",
+            f"Prisma AIRS DLP Dictionary Replaced: {dict_info.get('name')}",
             dict_info,
             headers=["id", "name", "category", "type", "region_name", "description"],
             headerTransform=lambda h: h.replace("_", " ").title(),
@@ -3040,7 +3040,7 @@ def runtime_dlp_dictionaries_replace_command(client: Client, args: dict[str, Any
     else:
         # 204 No Content response
         readable_output = (
-            f"## Prisma AIRs DLP Dictionary Replaced\n\n"
+            f"## Prisma AIRS DLP Dictionary Replaced\n\n"
             f"Dictionary ID `{dictionary_id}` has been successfully replaced (204 No Content)."
         )
         return CommandResults(readable_output=readable_output)
@@ -3050,7 +3050,7 @@ def runtime_dlp_dictionaries_delete_command(client: Client, args: dict[str, Any]
     """Delete a DLP dictionary.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -3075,7 +3075,7 @@ def runtime_dlp_dictionaries_delete_command(client: Client, args: dict[str, Any]
     context_output = {"id": dictionary_id, "deleted": True, "status": "Successfully deleted"}
 
     readable_output = tableToMarkdown(
-        "Prisma AIRs DLP Dictionary Deleted",
+        "Prisma AIRS DLP Dictionary Deleted",
         context_output,
         headers=["id", "status"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -3094,7 +3094,7 @@ def runtime_dlp_patterns_list_command(client: Client, args: dict[str, Any]) -> C
     """List DLP data patterns.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -3139,7 +3139,7 @@ def runtime_dlp_patterns_list_command(client: Client, args: dict[str, Any]) -> C
     total_pages = response.get("total_pages", 1)
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs DLP Patterns (Page {page + 1}/{total_pages}, {len(patterns)} of {total_elements})",
+        f"Prisma AIRS DLP Patterns (Page {page + 1}/{total_pages}, {len(patterns)} of {total_elements})",
         patterns,
         headers=["id", "name", "category", "type", "detection_technique", "pattern_status"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -3158,7 +3158,7 @@ def runtime_dlp_patterns_get_command(client: Client, args: dict[str, Any]) -> Co
     """Get a single DLP data pattern by ID.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -3195,7 +3195,7 @@ def runtime_dlp_patterns_get_command(client: Client, args: dict[str, Any]) -> Co
     }
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs DLP Pattern: {pattern_info.get('name')}",
+        f"Prisma AIRS DLP Pattern: {pattern_info.get('name')}",
         pattern_info,
         headers=["id", "name", "type", "status", "license_type", "description"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -3214,7 +3214,7 @@ def runtime_dlp_patterns_create_command(client: Client, args: dict[str, Any]) ->
     """Create a new DLP data pattern.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -3293,7 +3293,7 @@ def runtime_dlp_patterns_create_command(client: Client, args: dict[str, Any]) ->
     }
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs DLP Pattern Created: {pattern_info.get('name')}",
+        f"Prisma AIRS DLP Pattern Created: {pattern_info.get('name')}",
         pattern_info,
         headers=["id", "name", "type", "status", "description"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -3312,7 +3312,7 @@ def runtime_dlp_patterns_patch_command(client: Client, args: dict[str, Any]) -> 
     """Partially update a DLP data pattern (JSON Merge Patch).
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -3406,7 +3406,7 @@ def runtime_dlp_patterns_patch_command(client: Client, args: dict[str, Any]) -> 
     }
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs DLP Pattern Patched: {pattern_info.get('name')}",
+        f"Prisma AIRS DLP Pattern Patched: {pattern_info.get('name')}",
         pattern_info,
         headers=["id", "name", "type", "status", "description"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -3425,7 +3425,7 @@ def runtime_dlp_patterns_replace_command(client: Client, args: dict[str, Any]) -
     """Replace (full update) a DLP data pattern.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -3507,7 +3507,7 @@ def runtime_dlp_patterns_replace_command(client: Client, args: dict[str, Any]) -
     }
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs DLP Pattern Replaced: {pattern_info.get('name')}",
+        f"Prisma AIRS DLP Pattern Replaced: {pattern_info.get('name')}",
         pattern_info,
         headers=["id", "name", "type", "status", "description"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -3526,7 +3526,7 @@ def runtime_dlp_patterns_delete_command(client: Client, args: dict[str, Any]) ->
     """Delete (soft-delete/archive) a DLP data pattern.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -3539,19 +3539,34 @@ def runtime_dlp_patterns_delete_command(client: Client, args: dict[str, Any]) ->
     # Call DLP patterns delete endpoint
     # Reference: ./knowledge/prisma-airs-sdk-main/src/management/dlp/data-patterns.ts
     # SDK: DELETE /v2/api/data-patterns/{resourceId}
-    # Returns 204 No Content on success
-    client.http_request(
-        method="DELETE",
-        url_suffix=f"{DLP_PATTERNS_PATH}/{pattern_id}",
-        use_dlp_base=True,
-        return_empty_response=True,  # Proper XSOAR pattern for DELETE operations (204 No Content)
-    )
+    # Returns 204 No Content on success (soft-delete / archive).
+    try:
+        client.http_request(
+            method="DELETE",
+            url_suffix=f"{DLP_PATTERNS_PATH}/{pattern_id}",
+            use_dlp_base=True,
+            return_empty_response=True,  # Proper XSOAR pattern for DELETE operations (204 No Content)
+        )
+    except DemistoException as e:
+        # The DLP API returns a bare HTTP 400 (no detail body) when the pattern is still
+        # referenced by an active data profile - it cannot be archived until the reference is
+        # removed. Surface an actionable message instead of the opaque "Bad Request".
+        # NOTE: this precondition is not documented in the OpenAPI spec (which lists only
+        # 204/401/403/404), and a referencing profile currently cannot be deleted because the
+        # data-profile mutation endpoints return HTTP 500 upstream.
+        if "[400]" in str(e):
+            raise DemistoException(
+                f"Failed to delete DLP data pattern '{pattern_id}' (HTTP 400). The pattern is likely "
+                "still referenced by an active data profile and cannot be deleted until that reference "
+                "is removed. Remove the pattern from any data profile's detection rules first, then retry."
+            ) from e
+        raise
 
     # Action-tracking context so playbooks can confirm the deletion (soft-delete / archive)
     context_output = {"id": pattern_id, "deleted": True, "status": "Successfully archived"}
 
     readable_output = tableToMarkdown(
-        "Prisma AIRs DLP Pattern Deleted",
+        "Prisma AIRS DLP Pattern Deleted",
         context_output,
         headers=["id", "status"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -3570,7 +3585,7 @@ def runtime_dlp_filtering_profiles_list_command(client: Client, args: dict[str, 
     """List DLP filtering profiles.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -3611,7 +3626,7 @@ def runtime_dlp_filtering_profiles_list_command(client: Client, args: dict[str, 
     total_pages = response.get("total_pages", 1)
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs DLP Filtering Profiles (Page {page + 1}/{total_pages}, {len(filtering_profiles)} of {total_elements})",
+        f"Prisma AIRS DLP Filtering Profiles (Page {page + 1}/{total_pages}, {len(filtering_profiles)} of {total_elements})",
         filtering_profiles,
         headers=["id", "name", "type", "default_action", "description"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -3630,7 +3645,7 @@ def runtime_dlp_filtering_profiles_get_command(client: Client, args: dict[str, A
     """Get a single DLP filtering profile by ID.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -3672,7 +3687,7 @@ def runtime_dlp_filtering_profiles_get_command(client: Client, args: dict[str, A
     }
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs DLP Filtering Profile: {profile_info.get('name')}",
+        f"Prisma AIRS DLP Filtering Profile: {profile_info.get('name')}",
         profile_info,
         headers=["id", "name", "type", "direction", "file_based", "non_file_based", "log_severity", "description"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -3691,7 +3706,7 @@ def runtime_dlp_filtering_profiles_replace_command(client: Client, args: dict[st
     """Replace (full update) a DLP filtering profile.
 
     Args:
-        client: Prisma AIRs API client.
+        client: Prisma AIRS API client.
         args: Command arguments from XSOAR.
 
     Returns:
@@ -3779,7 +3794,7 @@ def runtime_dlp_filtering_profiles_replace_command(client: Client, args: dict[st
     }
 
     readable_output = tableToMarkdown(
-        f"Prisma AIRs DLP Filtering Profile Updated: {profile_info.get('name')}",
+        f"Prisma AIRS DLP Filtering Profile Updated: {profile_info.get('name')}",
         profile_info,
         headers=["id", "name", "type", "direction", "file_based", "non_file_based", "log_severity", "description"],
         headerTransform=lambda h: h.replace("_", " ").title(),
@@ -3795,7 +3810,7 @@ def runtime_dlp_filtering_profiles_replace_command(client: Client, args: dict[st
 
 
 def main() -> None:
-    """Main function for Prisma AIRs AI Runtime Security integration."""
+    """Main function for Prisma AIRS AI Runtime Security integration."""
     params = demisto.params()
     args = demisto.args()
     command = demisto.command()

--- a/Packs/PaloAltoNetworks_Prisma_AIRs/Integrations/PrismaAIRsRuntime/PrismaAIRsRuntime.yml
+++ b/Packs/PaloAltoNetworks_Prisma_AIRs/Integrations/PrismaAIRsRuntime/PrismaAIRsRuntime.yml
@@ -24,7 +24,7 @@ configuration:
   name: runtime_api_key
   required: true
   type: 9
-  additionalinfo: Runtime API Key for Prisma AIRs Scanner API. This is used exclusively for runtime scanning operations and is different from the OAuth2 Client ID/Secret used for management operations.
+  additionalinfo: Runtime API Key for Prisma AIRS Scanner API. This is used exclusively for runtime scanning operations and is different from the OAuth2 Client ID/Secret used for management operations.
   hiddenusername: true
   displaypassword: Runtime API Key
 - additionalinfo: 'Default Tenant Services Group ID to use for API calls. Example: 1234567890.'
@@ -63,7 +63,7 @@ configuration:
   section: Connect
   advanced: true
   required: false
-description: Integrate with Palo Alto Networks Prisma AIRs for AI security capabilities including runtime scanning, red teaming, AI supply chain security, and DLP configuration.
+description: Integrate with Palo Alto Networks Prisma AIRS for AI security capabilities including runtime scanning, red teaming, AI supply chain security, and DLP configuration.
 display: Palo Alto Networks Prisma AIRS - AI Runtime Security
 name: Palo Alto Networks Prisma AIRS - AI Runtime Security
 script:
@@ -162,7 +162,7 @@ script:
       description: The list of detection service errors or timeouts.
       type: Unknown
   - name: prisma-airs-runtime-api-keys-list
-    description: List all Runtime API Keys configured in Prisma AIRs.
+    description: List all Runtime API Keys configured in Prisma AIRS.
     arguments:
     - name: limit
       required: false
@@ -975,7 +975,7 @@ script:
     arguments:
     - name: name
       required: true
-      description: The profile name (1-64 characters).
+      description: The profile name. Note that although the API spec states a 64-character maximum, the server rejects names longer than 32 characters with an HTTP 400 error, so keep the name to 1-32 characters.
     - name: detection_rules
       required: true
       description: The detection rules as JSON array. Each rule must have rule_type (expression_tree or multi_profile) and corresponding structure.
@@ -1084,7 +1084,7 @@ script:
       description: The ID of the DLP data profile to replace.
     - name: name
       required: true
-      description: The profile name (1-64 characters).
+      description: The profile name. Note that although the API spec states a 64-character maximum, the server rejects names longer than 32 characters with an HTTP 400 error, so keep the name to 1-32 characters.
     - name: detection_rules
       required: true
       description: The detection rules as JSON array.
@@ -1293,7 +1293,22 @@ script:
       - Source Code
     - name: region_name
       required: true
-      description: The region name (e.g., us-west-2).
+      auto: PREDEFINED
+      predefined:
+      - Australia
+      - Brazil
+      - Canada
+      - France
+      - Germany
+      - India
+      - Japan
+      - Saudi Arabia
+      - Singapore
+      - Switzerland
+      - United Kingdom
+      - United States
+      defaultValue: United States
+      description: The dictionary region. Must be one of the allowed tenant region labels (the UI exposes these as a pick list); any other value (e.g. an AWS-style code such as us-west-2) makes the API return HTTP 400.
     - name: entry_id
       required: true
       description: The war room entry ID of the keyword file to upload.
@@ -1452,7 +1467,22 @@ script:
       - Source Code
     - name: region_name
       required: true
-      description: The region name (e.g., us-west-2).
+      auto: PREDEFINED
+      predefined:
+      - Australia
+      - Brazil
+      - Canada
+      - France
+      - Germany
+      - India
+      - Japan
+      - Saudi Arabia
+      - Singapore
+      - Switzerland
+      - United Kingdom
+      - United States
+      defaultValue: United States
+      description: The dictionary region. Must be one of the allowed tenant region labels (the UI exposes these as a pick list); any other value (e.g. an AWS-style code such as us-west-2) makes the API return HTTP 400.
     - name: entry_id
       required: true
       description: The war room entry ID of the keyword file to upload.
@@ -1871,11 +1901,11 @@ script:
       type: String
   - name: prisma-airs-runtime-dlp-patterns-delete
     execution: true
-    description: Delete (soft-delete/archive) a DLP data pattern. This action cannot be undone.
+    description: 'Delete (soft-delete/archive) a DLP data pattern; returns HTTP 204 on success and the pattern is archived server-side. Note: if the pattern is still referenced by an active data profile, the API returns HTTP 400 and the pattern cannot be deleted until the reference is removed. This action cannot be undone.'
     arguments:
     - name: pattern_id
       required: true
-      description: The ID of the DLP data pattern to delete.
+      description: The ID of the DLP data pattern to delete. The pattern must not be referenced by any active data profile, otherwise the delete fails with HTTP 400.
     outputs:
     - contextPath: PrismaAIRs.DlpPatternDelete.id
       description: The ID of the deleted DLP data pattern.
@@ -2432,4 +2462,5 @@ tests:
 - PaloAltoNetworks_Prisma_AIRs_Runtime_Profiles_Test
 - PaloAltoNetworks_Prisma_AIRs_Runtime_Scan_Test
 - PaloAltoNetworks_Prisma_AIRs_DLP_Patterns_Test
+- PaloAltoNetworks_Prisma_AIRs_DLP_Comprehensive_Test
 fromversion: 6.10.0

--- a/Packs/PaloAltoNetworks_Prisma_AIRs/Integrations/PrismaAIRsRuntime/PrismaAIRsRuntime.yml
+++ b/Packs/PaloAltoNetworks_Prisma_AIRs/Integrations/PrismaAIRsRuntime/PrismaAIRsRuntime.yml
@@ -975,7 +975,7 @@ script:
     arguments:
     - name: name
       required: true
-      description: The profile name. Note that although the API spec states a 64-character maximum, the server rejects names longer than 32 characters with an HTTP 400 error, so keep the name to 1-32 characters.
+      description: The profile name. Keep it to 1-32 characters. The API spec states a 64-character maximum, but the server rejects longer names with an HTTP 400 error.
     - name: detection_rules
       required: true
       description: The detection rules as JSON array. Each rule must have rule_type (expression_tree or multi_profile) and corresponding structure.
@@ -1084,7 +1084,7 @@ script:
       description: The ID of the DLP data profile to replace.
     - name: name
       required: true
-      description: The profile name. Note that although the API spec states a 64-character maximum, the server rejects names longer than 32 characters with an HTTP 400 error, so keep the name to 1-32 characters.
+      description: The profile name. Keep it to 1-32 characters. The API spec states a 64-character maximum, but the server rejects longer names with an HTTP 400 error.
     - name: detection_rules
       required: true
       description: The detection rules as JSON array.
@@ -1308,7 +1308,7 @@ script:
       - United Kingdom
       - United States
       defaultValue: United States
-      description: The dictionary region. Must be one of the allowed tenant region labels (the UI exposes these as a pick list); any other value (e.g. an AWS-style code such as us-west-2) makes the API return HTTP 400.
+      description: The dictionary region. Must be one of the allowed tenant region labels shown in the pick list. Any other value, such as an AWS-style code like us-west-2, makes the API return HTTP 400.
     - name: entry_id
       required: true
       description: The war room entry ID of the keyword file to upload.
@@ -1482,7 +1482,7 @@ script:
       - United Kingdom
       - United States
       defaultValue: United States
-      description: The dictionary region. Must be one of the allowed tenant region labels (the UI exposes these as a pick list); any other value (e.g. an AWS-style code such as us-west-2) makes the API return HTTP 400.
+      description: The dictionary region. Must be one of the allowed tenant region labels shown in the pick list. Any other value, such as an AWS-style code like us-west-2, makes the API return HTTP 400.
     - name: entry_id
       required: true
       description: The war room entry ID of the keyword file to upload.
@@ -1901,7 +1901,7 @@ script:
       type: String
   - name: prisma-airs-runtime-dlp-patterns-delete
     execution: true
-    description: 'Delete (soft-delete/archive) a DLP data pattern; returns HTTP 204 on success and the pattern is archived server-side. Note: if the pattern is still referenced by an active data profile, the API returns HTTP 400 and the pattern cannot be deleted until the reference is removed. This action cannot be undone.'
+    description: 'Delete (soft-delete/archive) a DLP data pattern. Returns HTTP 204 on success and the pattern is archived server-side. Note: if the pattern is still referenced by an active data profile, the API returns HTTP 400 and the pattern cannot be deleted until the reference is removed. This action cannot be undone.'
     arguments:
     - name: pattern_id
       required: true

--- a/Packs/PaloAltoNetworks_Prisma_AIRs/Integrations/PrismaAIRsRuntime/PrismaAIRsRuntime_test.py
+++ b/Packs/PaloAltoNetworks_Prisma_AIRs/Integrations/PrismaAIRsRuntime/PrismaAIRsRuntime_test.py
@@ -54,7 +54,7 @@ from PrismaAIRsRuntime import (
 
 @pytest.fixture
 def mock_client() -> Client:
-    """Create a mock Prisma AIRs client for testing.
+    """Create a mock Prisma AIRS client for testing.
 
     Returns:
         Client: Mock client instance.

--- a/Packs/PaloAltoNetworks_Prisma_AIRs/Integrations/PrismaAIRsRuntime/README.md
+++ b/Packs/PaloAltoNetworks_Prisma_AIRs/Integrations/PrismaAIRsRuntime/README.md
@@ -1179,7 +1179,7 @@ Create a new DLP data profile with detection rules.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| name | The profile name. Note that although the API spec states a 64-character maximum, the server rejects names longer than 32 characters with an HTTP 400 error, so keep the name to 1-32 characters. | Required |
+| name | The profile name. Keep it to 1-32 characters. The API spec states a 64-character maximum, but the server rejects longer names with an HTTP 400 error. | Required |
 | detection_rules | The detection rules as JSON array. Each rule must have rule_type (expression_tree or multi_profile) and corresponding structure. | Required |
 | description | The profile description. | Optional |
 | is_granular_data_profile | Whether this is a granular data profile. Possible values are: true, false. | Optional |
@@ -1248,7 +1248,7 @@ Replace (full update) a DLP data profile. This replaces the entire profile confi
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | profile_id | The ID of the DLP data profile to replace. | Required |
-| name | The profile name. Note that although the API spec states a 64-character maximum, the server rejects names longer than 32 characters with an HTTP 400 error, so keep the name to 1-32 characters. | Required |
+| name | The profile name. Keep it to 1-32 characters. The API spec states a 64-character maximum, but the server rejects longer names with an HTTP 400 error. | Required |
 | detection_rules | The detection rules as JSON array. | Required |
 | description | The profile description. | Optional |
 | is_granular_data_profile | Whether this is a granular data profile. Possible values are: true, false. | Optional |
@@ -1433,7 +1433,7 @@ Create a new DLP dictionary by uploading a keyword file.
 | --- | --- | --- |
 | name | The dictionary name. | Required |
 | category | The dictionary category. Possible values are: Academic, Confidential, Employment, Financial, Government, Healthcare, Legal, Marketing, Source Code. | Required |
-| region_name | The dictionary region. Must be one of the allowed tenant region labels (the UI exposes these as a pick list); any other value (e.g. an AWS-style code such as us-west-2) makes the API return HTTP 400. Possible values are: Australia, Brazil, Canada, France, Germany, India, Japan, Saudi Arabia, Singapore, Switzerland, United Kingdom, United States. Default is United States. | Required |
+| region_name | The dictionary region. Must be one of the allowed tenant region labels shown in the pick list. Any other value, such as an AWS-style code like us-west-2, makes the API return HTTP 400. Possible values are: Australia, Brazil, Canada, France, Germany, India, Japan, Saudi Arabia, Singapore, Switzerland, United Kingdom, United States. Default is United States. | Required |
 | entry_id | The war room entry ID of the keyword file to upload. | Required |
 | description | The dictionary description. | Optional |
 | is_case_sensitive | Whether the dictionary is case sensitive. Possible values are: true, false. | Optional |
@@ -1508,7 +1508,7 @@ Replace (full update) a DLP dictionary by uploading a new keyword file.
 | dictionary_id | The ID of the DLP dictionary to replace. | Required |
 | name | The dictionary name. | Required |
 | category | The dictionary category. Possible values are: Academic, Confidential, Employment, Financial, Government, Healthcare, Legal, Marketing, Source Code. | Required |
-| region_name | The dictionary region. Must be one of the allowed tenant region labels (the UI exposes these as a pick list); any other value (e.g. an AWS-style code such as us-west-2) makes the API return HTTP 400. Possible values are: Australia, Brazil, Canada, France, Germany, India, Japan, Saudi Arabia, Singapore, Switzerland, United Kingdom, United States. Default is United States. | Required |
+| region_name | The dictionary region. Must be one of the allowed tenant region labels shown in the pick list. Any other value, such as an AWS-style code like us-west-2, makes the API return HTTP 400. Possible values are: Australia, Brazil, Canada, France, Germany, India, Japan, Saudi Arabia, Singapore, Switzerland, United Kingdom, United States. Default is United States. | Required |
 | entry_id | The war room entry ID of the keyword file to upload. | Required |
 | description | The dictionary description. | Optional |
 | is_case_sensitive | Whether the dictionary is case sensitive. Possible values are: true, false. | Optional |
@@ -2061,7 +2061,7 @@ Replace (full update) a DLP data pattern. This replaces the entire pattern confi
 ### prisma-airs-runtime-dlp-patterns-delete
 
 ***
-Delete (soft-delete/archive) a DLP data pattern; returns HTTP 204 on success and the pattern is archived server-side. Note: if the pattern is still referenced by an active data profile, the API returns HTTP 400 and the pattern cannot be deleted until the reference is removed. This action cannot be undone.
+Delete (soft-delete/archive) a DLP data pattern. Returns HTTP 204 on success and the pattern is archived server-side. Note: if the pattern is still referenced by an active data profile, the API returns HTTP 400 and the pattern cannot be deleted until the reference is removed. This action cannot be undone.
 
 #### Base Command
 

--- a/Packs/PaloAltoNetworks_Prisma_AIRs/Integrations/PrismaAIRsRuntime/README.md
+++ b/Packs/PaloAltoNetworks_Prisma_AIRs/Integrations/PrismaAIRsRuntime/README.md
@@ -1,4 +1,4 @@
-Integrate with Palo Alto Networks Prisma AIRs for AI security capabilities including runtime scanning, red teaming, AI supply chain security, and DLP configuration.
+Integrate with Palo Alto Networks Prisma AIRS for AI security capabilities including runtime scanning, red teaming, AI supply chain security, and DLP configuration.
 This integration was integrated and tested with Palo Alto Networks Prisma AIRS - AI Runtime Security.
 
 ## Configure Palo Alto Networks Prisma AIRS - AI Runtime Security in Cortex
@@ -8,7 +8,7 @@ This integration was integrated and tested with Palo Alto Networks Prisma AIRS -
 | Server URL |  | True |
 | API Client ID |  | True |
 | API Client Secret |  | True |
-| Runtime API Key | Runtime API Key for Prisma AIRs Scanner API. This is used exclusively for runtime scanning operations and is different from the OAuth2 Client ID/Secret used for management operations. | True |
+| Runtime API Key | Runtime API Key for Prisma AIRS Scanner API. This is used exclusively for runtime scanning operations and is different from the OAuth2 Client ID/Secret used for management operations. | True |
 | Tenant Services Group ID | Default Tenant Services Group ID to use for API calls. Example: 1234567890. | True |
 | Scanner API Base URL | Scanner API base URL for runtime scanning operations. Default is US region. For other regions: EU: https://service-de.api.aisecurity.paloaltonetworks.com, IN: https://service-in.api.aisecurity.paloaltonetworks.com, SG: https://service-sg.api.aisecurity.paloaltonetworks.com. This must match the region selected during deployment profile creation. | False |
 | DLP API Base URL | DLP API base URL for DLP management operations \(dictionaries, patterns, filtering profiles\). Default is the global DLP endpoint. Change only if using a regional or custom DLP endpoint. | False |
@@ -100,7 +100,7 @@ Scan a single prompt against a security profile for AI security threats.
 
 #### Human Readable Output
 
->## Prisma AIRs Runtime Scan Results
+>## Prisma AIRS Runtime Scan Results
 >
 >### Scan Summary
 >
@@ -131,7 +131,7 @@ Scan a single prompt against a security profile for AI security threats.
 ### prisma-airs-runtime-api-keys-list
 
 ***
-List all Runtime API Keys configured in Prisma AIRs.
+List all Runtime API Keys configured in Prisma AIRS.
 
 #### Base Command
 
@@ -185,7 +185,7 @@ List all Runtime API Keys configured in Prisma AIRs.
 
 #### Human Readable Output
 
->### Prisma AIRs Runtime API Keys
+>### Prisma AIRS Runtime API Keys
 >
 >|Id|Name|Last8|Created At|Expires At|Revoked|
 >|---|---|---|---|---|---|
@@ -352,7 +352,7 @@ List all runtime security profiles.
 
 #### Human Readable Output
 
->### Prisma AIRs Security Profiles
+>### Prisma AIRS Security Profiles
 >
 >|Id|Name|Revision|Active|Created By|Updated By|Last Modified Ts|
 >|---|---|---|---|---|---|---|
@@ -811,7 +811,7 @@ List all customer applications.
 
 #### Human Readable Output
 
->### Prisma AIRs Customer Applications
+>### Prisma AIRS Customer Applications
 >
 >|Id|Name|Model Name|Cloud Provider|Environment|Ai Agent Framework|
 >|---|---|---|---|---|---|
@@ -1036,7 +1036,7 @@ List all deployment profiles.
 
 #### Human Readable Output
 
->### Prisma AIRs Deployment Profiles
+>### Prisma AIRS Deployment Profiles
 >
 >|Name|Auth Code|Status|Expiration Date|Ave Text Records|
 >|---|---|---|---|---|
@@ -1124,7 +1124,7 @@ List all DLP data profiles (v2 API).
 
 #### Human Readable Output
 
->### Prisma AIRs DLP Data Profiles (Page 1/1, 36 of 36)
+>### Prisma AIRS DLP Data Profiles (Page 1/1, 36 of 36)
 >
 >|Id|Name|Type|Profile Status|Profile Type|Version|
 >|---|---|---|---|---|---|
@@ -1179,7 +1179,7 @@ Create a new DLP data profile with detection rules.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| name | The profile name (1-64 characters). | Required |
+| name | The profile name. Note that although the API spec states a 64-character maximum, the server rejects names longer than 32 characters with an HTTP 400 error, so keep the name to 1-32 characters. | Required |
 | detection_rules | The detection rules as JSON array. Each rule must have rule_type (expression_tree or multi_profile) and corresponding structure. | Required |
 | description | The profile description. | Optional |
 | is_granular_data_profile | Whether this is a granular data profile. Possible values are: true, false. | Optional |
@@ -1248,7 +1248,7 @@ Replace (full update) a DLP data profile. This replaces the entire profile confi
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
 | profile_id | The ID of the DLP data profile to replace. | Required |
-| name | The profile name (1-64 characters). | Required |
+| name | The profile name. Note that although the API spec states a 64-character maximum, the server rejects names longer than 32 characters with an HTTP 400 error, so keep the name to 1-32 characters. | Required |
 | detection_rules | The detection rules as JSON array. | Required |
 | description | The profile description. | Optional |
 | is_granular_data_profile | Whether this is a granular data profile. Possible values are: true, false. | Optional |
@@ -1373,7 +1373,7 @@ List DLP dictionaries.
 
 #### Human Readable Output
 
->### Prisma AIRs DLP Dictionaries (Page 1/1, 38 of 38)
+>### Prisma AIRS DLP Dictionaries (Page 1/1, 38 of 38)
 >
 >|Id|Name|Category|Type|Number Of Keywords|Region Name|
 >|---|---|---|---|---|---|
@@ -1433,7 +1433,7 @@ Create a new DLP dictionary by uploading a keyword file.
 | --- | --- | --- |
 | name | The dictionary name. | Required |
 | category | The dictionary category. Possible values are: Academic, Confidential, Employment, Financial, Government, Healthcare, Legal, Marketing, Source Code. | Required |
-| region_name | The region name (e.g., us-west-2). | Required |
+| region_name | The dictionary region. Must be one of the allowed tenant region labels (the UI exposes these as a pick list); any other value (e.g. an AWS-style code such as us-west-2) makes the API return HTTP 400. Possible values are: Australia, Brazil, Canada, France, Germany, India, Japan, Saudi Arabia, Singapore, Switzerland, United Kingdom, United States. Default is United States. | Required |
 | entry_id | The war room entry ID of the keyword file to upload. | Required |
 | description | The dictionary description. | Optional |
 | is_case_sensitive | Whether the dictionary is case sensitive. Possible values are: true, false. | Optional |
@@ -1508,7 +1508,7 @@ Replace (full update) a DLP dictionary by uploading a new keyword file.
 | dictionary_id | The ID of the DLP dictionary to replace. | Required |
 | name | The dictionary name. | Required |
 | category | The dictionary category. Possible values are: Academic, Confidential, Employment, Financial, Government, Healthcare, Legal, Marketing, Source Code. | Required |
-| region_name | The region name (e.g., us-west-2). | Required |
+| region_name | The dictionary region. Must be one of the allowed tenant region labels (the UI exposes these as a pick list); any other value (e.g. an AWS-style code such as us-west-2) makes the API return HTTP 400. Possible values are: Australia, Brazil, Canada, France, Germany, India, Japan, Saudi Arabia, Singapore, Switzerland, United Kingdom, United States. Default is United States. | Required |
 | entry_id | The war room entry ID of the keyword file to upload. | Required |
 | description | The dictionary description. | Optional |
 | is_case_sensitive | Whether the dictionary is case sensitive. Possible values are: true, false. | Optional |
@@ -1632,7 +1632,7 @@ List DLP data patterns.
 
 #### Human Readable Output
 
->### Prisma AIRs DLP Patterns (Page 1/23, 50 of 1130)
+>### Prisma AIRS DLP Patterns (Page 1/23, 50 of 1130)
 >
 >|Id|Name|Category|Type|Detection Technique|Pattern Status|
 >|---|---|---|---|---|---|
@@ -1774,7 +1774,7 @@ Get a single DLP data pattern by ID.
 
 #### Human Readable Output
 
->### Prisma AIRs DLP Pattern: readme-example-pattern
+>### Prisma AIRS DLP Pattern: readme-example-pattern
 >
 >|Id|Name|Type|Status|License Type|Description|
 >|---|---|---|---|---|---|
@@ -1866,7 +1866,7 @@ Create a new DLP data pattern.
 
 #### Human Readable Output
 
->### Prisma AIRs DLP Pattern Created: readme-example-pattern
+>### Prisma AIRS DLP Pattern Created: readme-example-pattern
 >
 >|Id|Name|Type|Status|Description|
 >|---|---|---|---|---|
@@ -1959,7 +1959,7 @@ Partially update a DLP data pattern (JSON Merge Patch). Fields set to "null" wil
 
 #### Human Readable Output
 
->### Prisma AIRs DLP Pattern Patched: readme-example-pattern
+>### Prisma AIRS DLP Pattern Patched: readme-example-pattern
 >
 >|Id|Name|Type|Status|Description|
 >|---|---|---|---|---|
@@ -2052,7 +2052,7 @@ Replace (full update) a DLP data pattern. This replaces the entire pattern confi
 
 #### Human Readable Output
 
->### Prisma AIRs DLP Pattern Replaced: readme-example-pattern
+>### Prisma AIRS DLP Pattern Replaced: readme-example-pattern
 >
 >|Id|Name|Type|Status|Description|
 >|---|---|---|---|---|
@@ -2061,7 +2061,7 @@ Replace (full update) a DLP data pattern. This replaces the entire pattern confi
 ### prisma-airs-runtime-dlp-patterns-delete
 
 ***
-Delete (soft-delete/archive) a DLP data pattern. This action cannot be undone.
+Delete (soft-delete/archive) a DLP data pattern; returns HTTP 204 on success and the pattern is archived server-side. Note: if the pattern is still referenced by an active data profile, the API returns HTTP 400 and the pattern cannot be deleted until the reference is removed. This action cannot be undone.
 
 #### Base Command
 
@@ -2071,7 +2071,7 @@ Delete (soft-delete/archive) a DLP data pattern. This action cannot be undone.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| pattern_id | The ID of the DLP data pattern to delete. | Required |
+| pattern_id | The ID of the DLP data pattern to delete. The pattern must not be referenced by any active data profile, otherwise the delete fails with HTTP 400. | Required |
 
 #### Context Output
 
@@ -2099,7 +2099,7 @@ Delete (soft-delete/archive) a DLP data pattern. This action cannot be undone.
 
 #### Human Readable Output
 
->### Prisma AIRs DLP Pattern Deleted
+>### Prisma AIRS DLP Pattern Deleted
 >
 >|Id|Status|
 >|---|---|
@@ -2173,7 +2173,7 @@ List DLP filtering profiles.
 
 #### Human Readable Output
 
->### Prisma AIRs DLP Filtering Profiles (Page 1/1, 35 of 35)
+>### Prisma AIRS DLP Filtering Profiles (Page 1/1, 35 of 35)
 >
 >|Id|Name|Type|Default Action|Description|
 >|---|---|---|---|---|
@@ -2386,7 +2386,7 @@ List custom topic guardrails.
 
 #### Human Readable Output
 
->### Prisma AIRs Custom Topics (13 of 13)
+>### Prisma AIRS Custom Topics (13 of 13)
 >
 >|Topic Id|Topic Name|Revision|Description|
 >|---|---|---|---|

--- a/Packs/PaloAltoNetworks_Prisma_AIRs/README.md
+++ b/Packs/PaloAltoNetworks_Prisma_AIRs/README.md
@@ -1,10 +1,10 @@
-# Palo Alto Networks - Prisma AIRs AI Security
+# Palo Alto Networks - Prisma AIRS AI Security
 
-Integrate with Palo Alto Networks Prisma AIRs for comprehensive AI security capabilities.
+Integrate with Palo Alto Networks Prisma AIRS for comprehensive AI security capabilities.
 
 ## What does this pack do?
 
-The Prisma AIRs AI Security pack provides integration with Palo Alto Networks' AI security portfolio, enabling organizations to:
+The Prisma AIRS AI Security pack provides integration with Palo Alto Networks' AI security portfolio, enabling organizations to:
 
 - **Runtime Scanning**: Scan prompts and responses against security profiles for AI threats
 - **Red Team Operations**: Execute adversarial testing with static, dynamic, and custom attack modes
@@ -46,7 +46,7 @@ The Prisma AIRs AI Security pack provides integration with Palo Alto Networks' A
 
 ### Integrations
 
-- **Palo Alto Networks - Prisma AIRs AI Security**: Main integration providing all AI security capabilities
+- **Palo Alto Networks - Prisma AIRS AI Security**: Main integration providing all AI security capabilities
 
 ### Configuration
 
@@ -60,19 +60,21 @@ The integration requires:
 ## Getting Started
 
 1. Configure API credentials in Strata Cloud Manager
-2. Install the Prisma AIRs AI Security pack
+2. Install the Prisma AIRS AI Security pack
 3. Configure the integration with your credentials
 4. Test connectivity using the Test button
 5. Start using AI security commands in your playbooks
 
 ## Known Limitations
 
-The following DLP configuration operations are currently constrained by the upstream Prisma AIRs DLP API (`https://api.dlp.paloaltonetworks.com`). The integration sends spec-compliant requests; the limitations are server-side:
+The following DLP configuration operations are currently constrained by the upstream Prisma AIRS DLP API (`https://api.dlp.paloaltonetworks.com`). The integration sends spec-compliant requests; the limitations are server-side:
 
-- **DLP dictionary create/replace** (`prisma-airs-runtime-dlp-dictionaries-create` / `-replace`): The multipart upload returns a generic `HTTP 400` against live tenants even with a correctly formed request. Tracking the upstream fix.
-- **DLP data-profile update/delete** (`prisma-airs-runtime-dlp-profiles-patch` / `-replace` / `-delete`): The DLP API exposes no `DELETE` endpoint for data profiles, and `PATCH`/`PUT` currently return `HTTP 500`. As a result, data profiles can be listed, created, and retrieved, but not updated or removed via the API. Delete is implemented as a soft-delete (`profile_status: "deleted"` via merge-patch), which the API does not yet accept.
+- **DLP data-profile update/delete** (`prisma-airs-runtime-dlp-profiles-patch` / `-replace` / `-delete`): The DLP API exposes no `DELETE` endpoint for data profiles, and `PATCH`/`PUT` currently return `HTTP 500` for every well-formed request (verified against the SDK/spec-compliant body; the server returns a bare `Internal Server Error` with no validation detail, so this is a server-side defect rather than an input-format issue). As a result, data profiles can be listed, created, and retrieved, but not updated or removed via the API. Delete is implemented as a soft-delete (`profile_status: "deleted"` via merge-patch), which the API does not yet accept. Note also that a profile **archived via the Strata Cloud Manager UI** keeps its original name reserved (the archived record is hidden from `list` but still holds the name), so re-creating a profile with that name returns `HTTP 409 Conflict`. There is **no public API to restore/un-archive a profile** (the UI "restore" action has no API equivalent — `profile_status` is not writable via patch and no restore endpoint exists), so a name freed only by UI restore cannot be reused via the API.
+- **DLP data-pattern delete while referenced** (`prisma-airs-runtime-dlp-patterns-delete`): Deleting a pattern works normally (`HTTP 204`, soft-delete/archive) **unless** the pattern is still referenced by an active data profile, in which case the API returns `HTTP 400`. Because data-profile delete is blocked (above), a pattern referenced by a profile cannot currently be freed for deletion. Remove the pattern from the profile's detection rules first where possible.
+- **Custom pattern + custom profile cleanup deadlock (UI-only workaround):** These two limitations combine into a lifecycle deadlock. A custom pattern cannot be archived while it is referenced by a profile (`HTTP 400`), and a data profile cannot have empty detection rules — so a custom profile that references only a custom pattern locks both from cleanup via the API. The normal escape (swap the custom pattern out for a predefined pattern such as `Driver License - Ireland`, then archive the freed pattern) **requires modifying the profile's detection rules, which is a `PATCH`/`PUT` and returns `HTTP 500`** (verified live). As a result this cleanup can currently only be performed in the **Strata Cloud Manager UI** (which uses internal endpoints), not through the API/integration. Until the upstream profile-mutation `500` is fixed, any test that creates a custom-pattern-referencing custom profile will leave both artifacts orphaned; clean them up manually in the UI by editing the profile to reference a predefined pattern, then archiving the custom pattern and the profile.
+- **DLP data-profile name length** (`prisma-airs-runtime-dlp-profiles-create`): the DLP API rejects a data-profile `name` longer than **32 characters** with a bare `HTTP 400 Bad Request` (no validation detail). Note that the OpenAPI spec (`DataProfiles.yaml`, `AdvancedDataProfileRequest.name`) documents `maxLength: 64`, but the server enforces a stricter 32-character limit — keep profile names at or under 32 characters. This limit applies only to data profiles; pattern and dictionary names are not affected.
 
-The `list`, `create`, and `get` operations for dictionaries, patterns, and data profiles work as expected, as do all DLP **pattern** CRUD operations.
+The `list`, `create`, and `get` operations for dictionaries, patterns, and data profiles work as expected, as do all DLP **pattern** and **dictionary** CRUD operations (pattern/dictionary delete return `HTTP 204`). Note: DLP dictionary `create`/`replace` require a valid tenant `region_name` label (e.g. `United States`); an AWS-style code such as `us-west-2` returns `HTTP 400`.
 
 ## Support
 

--- a/Packs/PaloAltoNetworks_Prisma_AIRs/ReleaseNotes/1_0_1.md
+++ b/Packs/PaloAltoNetworks_Prisma_AIRs/ReleaseNotes/1_0_1.md
@@ -13,4 +13,4 @@
 
 ##### Palo Alto Networks Prisma AIRS - AI Supply Chain Security
 
-- Corrected the pack brand spelling in all display text from "Prisma AIRs" to "Prisma AIRS".
+- Updated the pack brand spelling in all display text from "Prisma AIRs" to "Prisma AIRS".

--- a/Packs/PaloAltoNetworks_Prisma_AIRs/ReleaseNotes/1_0_1.md
+++ b/Packs/PaloAltoNetworks_Prisma_AIRs/ReleaseNotes/1_0_1.md
@@ -5,7 +5,7 @@
 - Corrected the pack brand spelling in all display text and documentation from "Prisma AIRs" to "Prisma AIRS".
 - Converted the **region_name** argument of ***prisma-airs-runtime-dlp-dictionaries-create*** and ***prisma-airs-runtime-dlp-dictionaries-replace*** from free text to a predefined pick list of valid tenant region labels (default **United States**), preventing the HTTP 400 the API returns for AWS-style codes such as `us-west-2`.
 - Updated the documentation to state that the DLP data-profile *name* is limited to 32 characters server-side (the API spec's 64-character maximum is not enforced), so ***prisma-airs-runtime-dlp-profiles-create*** and ***prisma-airs-runtime-dlp-profiles-replace*** now describe the real limit.
-- ***prisma-airs-runtime-dlp-patterns-delete*** now returns an actionable error when the pattern is still referenced by an active data profile (HTTP 400), and its command and argument descriptions explain the requirement.
+- Improved implementation of ***prisma-airs-runtime-dlp-patterns-delete*** to return an actionable error when the pattern is still referenced by an active data profile (HTTP 400), and its command and argument descriptions explain the requirement.
 
 ##### Palo Alto Networks Prisma AIRS - AI Red Teaming
 

--- a/Packs/PaloAltoNetworks_Prisma_AIRs/ReleaseNotes/1_0_1.md
+++ b/Packs/PaloAltoNetworks_Prisma_AIRs/ReleaseNotes/1_0_1.md
@@ -2,15 +2,15 @@
 
 ##### Palo Alto Networks Prisma AIRS - AI Runtime Security
 
-- Corrected the pack brand spelling in all display text and documentation from "Prisma AIRs" to "Prisma AIRS".
+- Updated the pack brand spelling in all display text and documentation from "Prisma AIRs" to "Prisma AIRS".
 - Converted the **region_name** argument of ***prisma-airs-runtime-dlp-dictionaries-create*** and ***prisma-airs-runtime-dlp-dictionaries-replace*** from free text to a predefined pick list of valid tenant region labels (default **United States**), preventing the HTTP 400 the API returns for AWS-style codes such as `us-west-2`.
-- Documented that the DLP data-profile **name** is limited to 32 characters server-side (the API spec's 64-character maximum is not enforced), so ***prisma-airs-runtime-dlp-profiles-create*** and ***prisma-airs-runtime-dlp-profiles-replace*** now describe the real limit.
-- ***prisma-airs-runtime-dlp-patterns-delete*** now returns an actionable error when the pattern is still referenced by an active data profile (HTTP 400), and its command and argument descriptions explain the requirement.
+- Updated the documentation to state that the DLP data-profile *name* is limited to 32 characters server-side (the API spec's 64-character maximum is not enforced), so ***prisma-airs-runtime-dlp-profiles-create*** and ***prisma-airs-runtime-dlp-profiles-replace*** now describe the real limit.
+- Improved implementation of ***prisma-airs-runtime-dlp-patterns-delete*** to return an actionable error when the pattern is still referenced by an active data profile (HTTP 400), and its command and argument descriptions explain the requirement.
 
 ##### Palo Alto Networks Prisma AIRS - AI Red Teaming
 
-- Corrected the pack brand spelling in all display text from "Prisma AIRs" to "Prisma AIRS".
+- Updated the pack brand spelling in all display text from "Prisma AIRs" to "Prisma AIRS".
 
 ##### Palo Alto Networks Prisma AIRS - AI Supply Chain Security
 
-- Corrected the pack brand spelling in all display text from "Prisma AIRs" to "Prisma AIRS".
+- Updated the pack brand spelling in all display text from "Prisma AIRs" to "Prisma AIRS".

--- a/Packs/PaloAltoNetworks_Prisma_AIRs/ReleaseNotes/1_0_1.md
+++ b/Packs/PaloAltoNetworks_Prisma_AIRs/ReleaseNotes/1_0_1.md
@@ -4,7 +4,7 @@
 
 - Corrected the pack brand spelling in all display text and documentation from "Prisma AIRs" to "Prisma AIRS".
 - Converted the **region_name** argument of ***prisma-airs-runtime-dlp-dictionaries-create*** and ***prisma-airs-runtime-dlp-dictionaries-replace*** from free text to a predefined pick list of valid tenant region labels (default **United States**), preventing the HTTP 400 the API returns for AWS-style codes such as `us-west-2`.
-- Documented that the DLP data-profile **name** is limited to 32 characters server-side (the API spec's 64-character maximum is not enforced), so ***prisma-airs-runtime-dlp-profiles-create*** and ***prisma-airs-runtime-dlp-profiles-replace*** now describe the real limit.
+- Updated the documentation to state that the DLP data-profile *name* is limited to 32 characters server-side (the API spec's 64-character maximum is not enforced), so ***prisma-airs-runtime-dlp-profiles-create*** and ***prisma-airs-runtime-dlp-profiles-replace*** now describe the real limit.
 - ***prisma-airs-runtime-dlp-patterns-delete*** now returns an actionable error when the pattern is still referenced by an active data profile (HTTP 400), and its command and argument descriptions explain the requirement.
 
 ##### Palo Alto Networks Prisma AIRS - AI Red Teaming

--- a/Packs/PaloAltoNetworks_Prisma_AIRs/ReleaseNotes/1_0_1.md
+++ b/Packs/PaloAltoNetworks_Prisma_AIRs/ReleaseNotes/1_0_1.md
@@ -9,7 +9,7 @@
 
 ##### Palo Alto Networks Prisma AIRS - AI Red Teaming
 
-- Corrected the pack brand spelling in all display text from "Prisma AIRs" to "Prisma AIRS".
+- Updated the pack brand spelling in all display text from "Prisma AIRs" to "Prisma AIRS".
 
 ##### Palo Alto Networks Prisma AIRS - AI Supply Chain Security
 

--- a/Packs/PaloAltoNetworks_Prisma_AIRs/ReleaseNotes/1_0_1.md
+++ b/Packs/PaloAltoNetworks_Prisma_AIRs/ReleaseNotes/1_0_1.md
@@ -1,0 +1,16 @@
+#### Integrations
+
+##### Palo Alto Networks Prisma AIRS - AI Runtime Security
+
+- Corrected the pack brand spelling in all display text and documentation from "Prisma AIRs" to "Prisma AIRS".
+- Converted the **region_name** argument of ***prisma-airs-runtime-dlp-dictionaries-create*** and ***prisma-airs-runtime-dlp-dictionaries-replace*** from free text to a predefined pick list of valid tenant region labels (default **United States**), preventing the HTTP 400 the API returns for AWS-style codes such as `us-west-2`.
+- Documented that the DLP data-profile **name** is limited to 32 characters server-side (the API spec's 64-character maximum is not enforced), so ***prisma-airs-runtime-dlp-profiles-create*** and ***prisma-airs-runtime-dlp-profiles-replace*** now describe the real limit.
+- ***prisma-airs-runtime-dlp-patterns-delete*** now returns an actionable error when the pattern is still referenced by an active data profile (HTTP 400), and its command and argument descriptions explain the requirement.
+
+##### Palo Alto Networks Prisma AIRS - AI Red Teaming
+
+- Corrected the pack brand spelling in all display text from "Prisma AIRs" to "Prisma AIRS".
+
+##### Palo Alto Networks Prisma AIRS - AI Supply Chain Security
+
+- Corrected the pack brand spelling in all display text from "Prisma AIRs" to "Prisma AIRS".

--- a/Packs/PaloAltoNetworks_Prisma_AIRs/TestPlaybooks/playbook-PaloAltoNetworks_Prisma_AIRs_DLP_Comprehensive_Test.yml
+++ b/Packs/PaloAltoNetworks_Prisma_AIRs/TestPlaybooks/playbook-PaloAltoNetworks_Prisma_AIRs_DLP_Comprehensive_Test.yml
@@ -1,0 +1,1753 @@
+description: |-
+  Comprehensive canary test for the Prisma AIRS DLP feature set - a simple LINEAR flow (no branching). Each run generates a 6-char RandomString suffix appended to every created object, so every pattern/dictionary/profile is brand-new and uniquely named - which means no find-or-create logic is needed (names never collide with archived objects). Flow: create+list+get+patch+get a custom data pattern; upload a keyword file then create+list+get+patch+get a dictionary; list profiles and resolve the predefined PII + Sensitive Content profile ids by name; create a custom profile referencing the pattern; create a master profile that composes custom+PII+Sensitive via multi_profile (composition at CREATE time, since patch composition is upstream-blocked); then attempt cleanup. The pass/fail gate is anchored only on operations that work today (pattern create, custom-profile create, composed master-profile create). Known upstream-blocked steps run as continueonerror canaries: profile patch/delete return HTTP 500, and pattern-delete returns HTTP 400 while still referenced by the un-deletable profile. ORPHAN WARNING: because profile-delete is blocked, each run leaves a custom profile, a master profile, and the referenced pattern behind (clean up manually in the SCM UI). The dictionary IS deleted (HTTP 204). NOT registered in Tests/conf.json - intended for occasional manual/canary runs.
+id: PaloAltoNetworks_Prisma_AIRs_DLP_Comprehensive_Test
+inputs:
+- key: PatternName
+  value:
+    simple: xsoar-ci-test-dlp-pattern
+  required: false
+  description: Base name of the custom DLP data pattern to create. The playbook appends the incident id to make a per-run-unique name (EffectivePatternName) so each run creates and references its own guaranteed-active pattern. The custom profile references this pattern by id, and the DLP API returns HTTP 400 if a profile references an archived pattern - reusing a shared base-named pattern across runs risks it being archived out from under the run.
+  playbookInputQuery:
+- key: PatternType
+  value:
+    simple: custom
+  required: false
+  description: Pattern type (predefined, custom, file_property).
+  playbookInputQuery:
+- key: PatternTechnique
+  value:
+    simple: regex
+  required: false
+  description: Detection technique (regex, weighted_regex, dictionary, etc.).
+  playbookInputQuery:
+- key: PatternMatchingRules
+  value:
+    simple: '{"regexes":[{"regex":"[0-9]{3}-[0-9]{2}-[0-9]{4}","weight":1}]}'
+  required: false
+  description: Matching rules JSON for the regex pattern (regexes with regex + weight).
+  playbookInputQuery:
+- key: DictionaryName
+  value:
+    simple: xsoar-ci-test-dlp-dictionary
+  required: false
+  description: Name of the custom DLP dictionary to create.
+  playbookInputQuery:
+- key: DictionaryCategory
+  value:
+    simple: Confidential
+  required: false
+  description: Dictionary category (Academic, Confidential, Employment, Financial, Government, Healthcare, Legal, Marketing, Source Code).
+  playbookInputQuery:
+- key: DictionaryRegion
+  value:
+    simple: United States
+  required: false
+  description: Dictionary region name. Must be a valid tenant region label (e.g. "United States"), NOT an AWS-style code like us-west-2 - an invalid region_name makes the create API return HTTP 400.
+  playbookInputQuery:
+- key: MasterProfileName
+  value:
+    simple: xsoar-ci-dlp-master
+  required: false
+  description: Base name of the master data profile to compose into. The playbook appends a 6-char RandomString to make a per-run-unique name (EffectiveMasterProfileName), because a profile archived via the UI keeps its name reserved with no API restore, which would otherwise cause create to fail with HTTP 409. IMPORTANT - the DLP data-profile name is capped at 32 chars by the server (the OpenAPI spec's maxLength 64 is wrong; over-32 names return a bare HTTP 400), so this base must stay short enough that base + "-" + 6-char suffix is <= 32. Note - profile delete is upstream-blocked, so each run leaves a persistent profile.
+  playbookInputQuery:
+- key: CustomProfileName
+  value:
+    simple: xsoar-ci-dlp-sub
+  required: false
+  description: Base name of the secondary ("sub") data profile that is created and then composed into the master profile (references the custom pattern created above). "sub" in the name distinguishes it from the master profile. The playbook appends a 6-char RandomString to make a per-run-unique name (EffectiveCustomProfileName), because a profile archived via the UI keeps its name reserved with no API restore, which would otherwise cause create to fail with HTTP 409. IMPORTANT - the DLP data-profile name is capped at 32 chars by the server (the OpenAPI spec's maxLength 64 is wrong; over-32 names return a bare HTTP 400), so this base must stay short enough that base + "-" + 6-char suffix is <= 32. Note - profile delete is upstream-blocked, so each run leaves a persistent profile.
+  playbookInputQuery:
+- key: PiiProfileName
+  value:
+    simple: PII
+  required: false
+  description: Exact name of the predefined data profile to OR into the master (default the predefined "PII" profile).
+  playbookInputQuery:
+- key: SensitiveContentProfileName
+  value:
+    simple: Sensitive Content
+  required: false
+  description: Exact name of the second predefined data profile to OR into the master (default the predefined "Sensitive Content" profile).
+  playbookInputQuery:
+name: PaloAltoNetworks_Prisma_AIRs_DLP_Comprehensive_Test
+outputs: []
+starttaskid: "0"
+tasks:
+  '0':
+    id: '0'
+    taskid: a0000000-0000-4000-8000-000000000000
+    type: start
+    task:
+      id: a0000000-0000-4000-8000-000000000000
+      version: -1
+      name: ''
+      description: ''
+      type: start
+      iscommand: false
+      brand: ''
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 50
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '1'
+  '1':
+    id: '1'
+    taskid: a0000000-0000-4000-8000-000000000001
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000001
+      version: -1
+      name: DeleteContext
+      description: Clear all context so the test starts clean.
+      type: regular
+      iscommand: false
+      brand: ''
+      scriptName: DeleteContext
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 220
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '2'
+    scriptarguments:
+      all:
+        simple: yes
+  '2':
+    id: '2'
+    taskid: a0000000-0000-4000-8000-000000000002
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000002
+      version: -1
+      name: GenerateRandomString
+      description: Generate a 6-char run token (RandomString) appended to every created object so each run is globally unique and never collides with archived objects.
+      type: regular
+      iscommand: false
+      brand: ''
+      scriptName: GenerateRandomString
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 390
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '3'
+    scriptarguments:
+      Length:
+        simple: '6'
+      Lowercase:
+        simple: 'true'
+      Digits:
+        simple: 'true'
+      Uppercase:
+        simple: 'false'
+      Punctuation:
+        simple: 'false'
+  '3':
+    id: '3'
+    taskid: a0000000-0000-4000-8000-000000000003
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000003
+      version: -1
+      name: Set EffectivePatternName
+      description: Per-run-unique pattern name.
+      type: regular
+      iscommand: false
+      brand: ''
+      scriptName: Set
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 560
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '4'
+    scriptarguments:
+      key:
+        simple: EffectivePatternName
+      value:
+        simple: ${inputs.PatternName}-${RandomString}
+  '4':
+    id: '4'
+    taskid: a0000000-0000-4000-8000-000000000004
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000004
+      version: -1
+      name: Set EffectiveDictionaryName
+      description: Per-run-unique dictionary name.
+      type: regular
+      iscommand: false
+      brand: ''
+      scriptName: Set
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 730
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '5'
+    scriptarguments:
+      key:
+        simple: EffectiveDictionaryName
+      value:
+        simple: ${inputs.DictionaryName}-${RandomString}
+  '5':
+    id: '5'
+    taskid: a0000000-0000-4000-8000-000000000005
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000005
+      version: -1
+      name: Set EffectiveMasterProfileName
+      description: Per-run-unique master profile name.
+      type: regular
+      iscommand: false
+      brand: ''
+      scriptName: Set
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 900
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '6'
+    scriptarguments:
+      key:
+        simple: EffectiveMasterProfileName
+      value:
+        simple: ${inputs.MasterProfileName}-${RandomString}
+  '6':
+    id: '6'
+    taskid: a0000000-0000-4000-8000-000000000006
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000006
+      version: -1
+      name: Set EffectiveCustomProfileName
+      description: Per-run-unique custom profile name.
+      type: regular
+      iscommand: false
+      brand: ''
+      scriptName: Set
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 1070
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '7'
+    scriptarguments:
+      key:
+        simple: EffectiveCustomProfileName
+      value:
+        simple: ${inputs.CustomProfileName}-${RandomString}
+  '7':
+    id: '7'
+    taskid: a0000000-0000-4000-8000-000000000007
+    type: title
+    task:
+      id: a0000000-0000-4000-8000-000000000007
+      version: -1
+      name: DLP - Data Patterns
+      description: ''
+      type: title
+      iscommand: false
+      brand: ''
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 1240
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '8'
+  '8':
+    id: '8'
+    taskid: a0000000-0000-4000-8000-000000000008
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000008
+      version: -1
+      name: prisma-airs-runtime-dlp-patterns-create
+      description: Create a custom regex DLP data pattern (unique name).
+      type: regular
+      iscommand: true
+      brand: ''
+      script: '|||prisma-airs-runtime-dlp-patterns-create'
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 1410
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '9'
+    scriptarguments:
+      name:
+        simple: ${EffectivePatternName}
+      type:
+        complex:
+          root: inputs.PatternType
+      detection_technique:
+        complex:
+          root: inputs.PatternTechnique
+      matching_rules:
+        complex:
+          root: inputs.PatternMatchingRules
+    continueonerror: true
+  '9':
+    id: '9'
+    taskid: a0000000-0000-4000-8000-000000000009
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000009
+      version: -1
+      name: Set PatternId
+      description: Capture PatternId from the create/list output.
+      type: regular
+      iscommand: false
+      brand: ''
+      scriptName: Set
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 1580
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '10'
+    scriptarguments:
+      key:
+        simple: PatternId
+      value:
+        complex:
+          root: PrismaAIRs.DlpPatternCreate
+          accessor: id
+    continueonerror: true
+  '10':
+    id: '10'
+    taskid: a0000000-0000-4000-8000-000000000010
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000010
+      version: -1
+      name: prisma-airs-runtime-dlp-patterns-list
+      description: List patterns (read verification).
+      type: regular
+      iscommand: true
+      brand: ''
+      script: '|||prisma-airs-runtime-dlp-patterns-list'
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 1750
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '11'
+    scriptarguments:
+      size:
+        simple: '200'
+    continueonerror: true
+  '11':
+    id: '11'
+    taskid: a0000000-0000-4000-8000-000000000011
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000011
+      version: -1
+      name: prisma-airs-runtime-dlp-patterns-get
+      description: Get the created pattern by id.
+      type: regular
+      iscommand: true
+      brand: ''
+      script: '|||prisma-airs-runtime-dlp-patterns-get'
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 1920
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '12'
+    scriptarguments:
+      pattern_id:
+        simple: ${PatternId}
+    continueonerror: true
+  '12':
+    id: '12'
+    taskid: a0000000-0000-4000-8000-000000000012
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000012
+      version: -1
+      name: prisma-airs-runtime-dlp-patterns-patch
+      description: Patch the pattern description.
+      type: regular
+      iscommand: true
+      brand: ''
+      script: '|||prisma-airs-runtime-dlp-patterns-patch'
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 2090
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '13'
+    scriptarguments:
+      pattern_id:
+        simple: ${PatternId}
+      name:
+        simple: ${EffectivePatternName}
+      type:
+        complex:
+          root: inputs.PatternType
+      detection_technique:
+        complex:
+          root: inputs.PatternTechnique
+      matching_rules:
+        complex:
+          root: inputs.PatternMatchingRules
+      description:
+        simple: Updated by DLP comprehensive test
+    continueonerror: true
+  '13':
+    id: '13'
+    taskid: a0000000-0000-4000-8000-000000000013
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000013
+      version: -1
+      name: prisma-airs-runtime-dlp-patterns-get
+      description: Get the patched pattern to confirm the update.
+      type: regular
+      iscommand: true
+      brand: ''
+      script: '|||prisma-airs-runtime-dlp-patterns-get'
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 2260
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '14'
+    scriptarguments:
+      pattern_id:
+        simple: ${PatternId}
+    continueonerror: true
+  '14':
+    id: '14'
+    taskid: a0000000-0000-4000-8000-000000000014
+    type: title
+    task:
+      id: a0000000-0000-4000-8000-000000000014
+      version: -1
+      name: DLP - Dictionaries
+      description: ''
+      type: title
+      iscommand: false
+      brand: ''
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 2430
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '15'
+  '15':
+    id: '15'
+    taskid: a0000000-0000-4000-8000-000000000015
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000015
+      version: -1
+      name: FileCreateAndUploadV2
+      description: Create a keyword file for the dictionary upload.
+      type: regular
+      iscommand: false
+      brand: ''
+      scriptName: FileCreateAndUploadV2
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 2600
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '16'
+    scriptarguments:
+      filename:
+        simple: dlp-keywords.txt
+      data:
+        simple: "acme-secret\nproject-zeus\nconfidential-alpha"
+  '16':
+    id: '16'
+    taskid: a0000000-0000-4000-8000-000000000016
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000016
+      version: -1
+      name: prisma-airs-runtime-dlp-dictionaries-create
+      description: Create a custom dictionary from the uploaded file (unique name).
+      type: regular
+      iscommand: true
+      brand: ''
+      script: '|||prisma-airs-runtime-dlp-dictionaries-create'
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 2770
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '17'
+    scriptarguments:
+      name:
+        simple: ${EffectiveDictionaryName}
+      category:
+        complex:
+          root: inputs.DictionaryCategory
+      region_name:
+        complex:
+          root: inputs.DictionaryRegion
+      entry_id:
+        simple: ${File.EntryID}
+      type:
+        simple: custom
+      description:
+        simple: Created by DLP comprehensive test
+    continueonerror: true
+  '17':
+    id: '17'
+    taskid: a0000000-0000-4000-8000-000000000017
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000017
+      version: -1
+      name: Set DictionaryId
+      description: Capture DictionaryId from the create/list output.
+      type: regular
+      iscommand: false
+      brand: ''
+      scriptName: Set
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 2940
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '18'
+    scriptarguments:
+      key:
+        simple: DictionaryId
+      value:
+        complex:
+          root: PrismaAIRs.DlpDictionaryCreate
+          accessor: id
+    continueonerror: true
+  '18':
+    id: '18'
+    taskid: a0000000-0000-4000-8000-000000000018
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000018
+      version: -1
+      name: prisma-airs-runtime-dlp-dictionaries-list
+      description: List dictionaries.
+      type: regular
+      iscommand: true
+      brand: ''
+      script: '|||prisma-airs-runtime-dlp-dictionaries-list'
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 3110
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '19'
+    scriptarguments:
+      size:
+        simple: '50'
+    continueonerror: true
+  '19':
+    id: '19'
+    taskid: a0000000-0000-4000-8000-000000000019
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000019
+      version: -1
+      name: prisma-airs-runtime-dlp-dictionaries-get
+      description: Get the dictionary (include keywords).
+      type: regular
+      iscommand: true
+      brand: ''
+      script: '|||prisma-airs-runtime-dlp-dictionaries-get'
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 3280
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '20'
+    scriptarguments:
+      dictionary_id:
+        simple: ${DictionaryId}
+      include_keywords:
+        simple: 'true'
+    continueonerror: true
+  '20':
+    id: '20'
+    taskid: a0000000-0000-4000-8000-000000000020
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000020
+      version: -1
+      name: prisma-airs-runtime-dlp-dictionaries-patch
+      description: Update the dictionary description.
+      type: regular
+      iscommand: true
+      brand: ''
+      script: '|||prisma-airs-runtime-dlp-dictionaries-patch'
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 3450
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '21'
+    scriptarguments:
+      dictionary_id:
+        simple: ${DictionaryId}
+      name:
+        simple: ${EffectiveDictionaryName}
+      category:
+        complex:
+          root: inputs.DictionaryCategory
+      original_file_name:
+        simple: dlp-keywords.txt
+      description:
+        simple: Updated by DLP comprehensive test
+    continueonerror: true
+  '21':
+    id: '21'
+    taskid: a0000000-0000-4000-8000-000000000021
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000021
+      version: -1
+      name: prisma-airs-runtime-dlp-dictionaries-get
+      description: Get the dictionary again to confirm the update.
+      type: regular
+      iscommand: true
+      brand: ''
+      script: '|||prisma-airs-runtime-dlp-dictionaries-get'
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 3620
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '22'
+    scriptarguments:
+      dictionary_id:
+        simple: ${DictionaryId}
+      include_keywords:
+        simple: 'true'
+    continueonerror: true
+  '22':
+    id: '22'
+    taskid: a0000000-0000-4000-8000-000000000022
+    type: title
+    task:
+      id: a0000000-0000-4000-8000-000000000022
+      version: -1
+      name: DLP - Data Profiles
+      description: ''
+      type: title
+      iscommand: false
+      brand: ''
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 3790
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '23'
+  '23':
+    id: '23'
+    taskid: a0000000-0000-4000-8000-000000000023
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000023
+      version: -1
+      name: prisma-airs-runtime-dlp-profiles-list
+      description: List profiles (locate predefined PII + Sensitive Content by name).
+      type: regular
+      iscommand: true
+      brand: ''
+      script: '|||prisma-airs-runtime-dlp-profiles-list'
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 3960
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '24'
+    scriptarguments:
+      size:
+        simple: '200'
+    continueonerror: true
+  '24':
+    id: '24'
+    taskid: a0000000-0000-4000-8000-000000000024
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000024
+      version: -1
+      name: Set PiiProfileId
+      description: Capture PiiProfileId from the create/list output.
+      type: regular
+      iscommand: false
+      brand: ''
+      scriptName: Set
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 4130
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '25'
+    scriptarguments:
+      key:
+        simple: PiiProfileId
+      value:
+        complex:
+          root: PrismaAIRs.DlpProfile
+          accessor: id
+          filters:
+          - - operator: isEqualString
+              left:
+                value:
+                  simple: PrismaAIRs.DlpProfile.name
+                iscontext: true
+              right:
+                value:
+                  simple: ${inputs.PiiProfileName}
+    continueonerror: true
+  '25':
+    id: '25'
+    taskid: a0000000-0000-4000-8000-000000000025
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000025
+      version: -1
+      name: Set SensitiveContentProfileId
+      description: Capture SensitiveContentProfileId from the create/list output.
+      type: regular
+      iscommand: false
+      brand: ''
+      scriptName: Set
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 4300
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '26'
+    scriptarguments:
+      key:
+        simple: SensitiveContentProfileId
+      value:
+        complex:
+          root: PrismaAIRs.DlpProfile
+          accessor: id
+          filters:
+          - - operator: isEqualString
+              left:
+                value:
+                  simple: PrismaAIRs.DlpProfile.name
+                iscontext: true
+              right:
+                value:
+                  simple: ${inputs.SensitiveContentProfileName}
+    continueonerror: true
+  '26':
+    id: '26'
+    taskid: a0000000-0000-4000-8000-000000000026
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000026
+      version: -1
+      name: Wait for pattern to settle
+      description: Short settle so the just-created pattern is fully committed before a profile references it. (The HTTP 400 seen in earlier runs was NOT an eventual-consistency lag - it was the over-32-char profile name being rejected; that is now fixed by the shortened name inputs. This brief wait is only defensive against genuine write-propagation.)
+      type: regular
+      iscommand: false
+      brand: ''
+      scriptName: Sleep
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 4470
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '27'
+    scriptarguments:
+      seconds:
+        simple: '15'
+  '27':
+    id: '27'
+    taskid: a0000000-0000-4000-8000-000000000027
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000027
+      version: -1
+      name: prisma-airs-runtime-dlp-profiles-create (custom)
+      description: Create a custom profile whose expression_tree references the created pattern (unique name).
+      type: regular
+      iscommand: true
+      brand: ''
+      script: '|||prisma-airs-runtime-dlp-profiles-create'
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 4640
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '28'
+    scriptarguments:
+      name:
+        simple: ${EffectiveCustomProfileName}
+      detection_rules:
+        simple: '[{"rule_type":"expression_tree","expression_tree":{"operator_type":"or","sub_expressions":[{"rule_item":{"detection_technique":"${inputs.PatternTechnique}","id":"${PatternId}","match_type":"include","confidence_level":"high","occurrence_operator_type":"any","occurrence_count":1}}]}}]'
+      description:
+        simple: Custom profile created by DLP comprehensive test
+    continueonerror: true
+  '28':
+    id: '28'
+    taskid: a0000000-0000-4000-8000-000000000028
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000028
+      version: -1
+      name: Set CustomProfileId
+      description: Capture CustomProfileId from the create/list output.
+      type: regular
+      iscommand: false
+      brand: ''
+      scriptName: Set
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 4810
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '29'
+    scriptarguments:
+      key:
+        simple: CustomProfileId
+      value:
+        complex:
+          root: PrismaAIRs.DlpProfileCreate
+          accessor: id
+    continueonerror: true
+  '29':
+    id: '29'
+    taskid: a0000000-0000-4000-8000-000000000029
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000029
+      version: -1
+      name: prisma-airs-runtime-dlp-profiles-get (custom)
+      description: Get the custom profile.
+      type: regular
+      iscommand: true
+      brand: ''
+      script: '|||prisma-airs-runtime-dlp-profiles-get'
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 4980
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '30'
+    scriptarguments:
+      profile_id:
+        simple: ${CustomProfileId}
+    continueonerror: true
+  '30':
+    id: '30'
+    taskid: a0000000-0000-4000-8000-000000000030
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000030
+      version: -1
+      name: prisma-airs-runtime-dlp-profiles-create (master, composed)
+      description: Create a master profile that composes the custom + PII + Sensitive Content profiles via multi_profile OR (composition at create time - patch composition is upstream-blocked HTTP 500).
+      type: regular
+      iscommand: true
+      brand: ''
+      script: '|||prisma-airs-runtime-dlp-profiles-create'
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 5150
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '31'
+    scriptarguments:
+      name:
+        simple: ${EffectiveMasterProfileName}
+      detection_rules:
+        simple: '[{"rule_type":"multi_profile","multi_profile":{"operator_type":"or","data_profile_ids":[${CustomProfileId},${PiiProfileId},${SensitiveContentProfileId}]}}]'
+      description:
+        simple: Master profile created by DLP comprehensive test
+    continueonerror: true
+  '31':
+    id: '31'
+    taskid: a0000000-0000-4000-8000-000000000031
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000031
+      version: -1
+      name: Set MasterProfileId
+      description: Capture MasterProfileId from the create/list output.
+      type: regular
+      iscommand: false
+      brand: ''
+      scriptName: Set
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 5320
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '32'
+    scriptarguments:
+      key:
+        simple: MasterProfileId
+      value:
+        complex:
+          root: PrismaAIRs.DlpProfileCreate
+          accessor: id
+          filters:
+          - - operator: isEqualString
+              left:
+                value:
+                  simple: PrismaAIRs.DlpProfileCreate.name
+                iscontext: true
+              right:
+                value:
+                  simple: ${EffectiveMasterProfileName}
+    continueonerror: true
+  '32':
+    id: '32'
+    taskid: a0000000-0000-4000-8000-000000000032
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000032
+      version: -1
+      name: prisma-airs-runtime-dlp-profiles-get (master)
+      description: Get the composed master profile.
+      type: regular
+      iscommand: true
+      brand: ''
+      script: '|||prisma-airs-runtime-dlp-profiles-get'
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 5490
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '33'
+    scriptarguments:
+      profile_id:
+        simple: ${MasterProfileId}
+    continueonerror: true
+  '33':
+    id: '33'
+    taskid: a0000000-0000-4000-8000-000000000033
+    type: title
+    task:
+      id: a0000000-0000-4000-8000-000000000033
+      version: -1
+      name: DLP - Cleanup
+      description: ''
+      type: title
+      iscommand: false
+      brand: ''
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 5660
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '39'
+  '34':
+    id: '34'
+    taskid: a0000000-0000-4000-8000-000000000034
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000034
+      version: -1
+      name: prisma-airs-runtime-dlp-profiles-delete (master)
+      description: 'CLEANUP STEP 3 - delete the master profile (now that its only custom member was dropped in step 1). CANARY: profile delete is upstream-blocked (HTTP 500).'
+      type: regular
+      iscommand: true
+      brand: ''
+      script: '|||prisma-airs-runtime-dlp-profiles-delete'
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 6170
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '35'
+    scriptarguments:
+      profile_id:
+        simple: ${MasterProfileId}
+    continueonerror: true
+  '35':
+    id: '35'
+    taskid: a0000000-0000-4000-8000-000000000035
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000035
+      version: -1
+      name: prisma-airs-runtime-dlp-profiles-delete (custom)
+      description: 'CLEANUP STEP 4 - delete the custom sub-profile (now that its custom pattern was swapped for the Ireland predefined pattern in step 2). CANARY: profile delete is upstream-blocked (HTTP 500).'
+      type: regular
+      iscommand: true
+      brand: ''
+      script: '|||prisma-airs-runtime-dlp-profiles-delete'
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 6340
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '36'
+    scriptarguments:
+      profile_id:
+        simple: ${CustomProfileId}
+    continueonerror: true
+  '36':
+    id: '36'
+    taskid: a0000000-0000-4000-8000-000000000036
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000036
+      version: -1
+      name: prisma-airs-runtime-dlp-patterns-delete
+      description: 'CLEANUP STEP 5 - delete the custom pattern, which should have no active-profile reference left after step 2. CANARY today: because step 2''s profile patch is 500-blocked, the pattern is still referenced and this returns HTTP 400; once upstream fixes the profile-patch 500, step 2 frees the pattern and this delete returns HTTP 204.'
+      type: regular
+      iscommand: true
+      brand: ''
+      script: '|||prisma-airs-runtime-dlp-patterns-delete'
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 6510
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '37'
+    scriptarguments:
+      pattern_id:
+        simple: ${PatternId}
+    continueonerror: true
+  '37':
+    id: '37'
+    taskid: a0000000-0000-4000-8000-000000000037
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000037
+      version: -1
+      name: prisma-airs-runtime-dlp-dictionaries-delete
+      description: Delete the dictionary (works - HTTP 204).
+      type: regular
+      iscommand: true
+      brand: ''
+      script: '|||prisma-airs-runtime-dlp-dictionaries-delete'
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 6680
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '38'
+    scriptarguments:
+      dictionary_id:
+        simple: ${DictionaryId}
+    continueonerror: true
+  '38':
+    id: '38'
+    taskid: a0000000-0000-4000-8000-000000000038
+    type: condition
+    task:
+      id: a0000000-0000-4000-8000-000000000038
+      version: -1
+      name: Validate DLP Lifecycle
+      description: 'Pass/fail gate: pattern created (PatternId), custom profile created referencing it (CustomProfileId), and composed master profile created (MasterProfileId).'
+      type: condition
+      iscommand: false
+      brand: ''
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 6850
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#default#':
+      - '98'
+      "yes":
+      - '99'
+    conditions:
+    - label: "yes"
+      condition:
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: PatternId
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: CustomProfileId
+            iscontext: true
+      - - operator: isExists
+          left:
+            value:
+              complex:
+                root: MasterProfileId
+            iscontext: true
+  '98':
+    id: '98'
+    taskid: a0000000-0000-4000-8000-000000000098
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000098
+      version: -1
+      name: Test Failed - Print Error
+      description: Validation failed - print error to fail the run.
+      type: regular
+      iscommand: false
+      brand: ''
+      scriptName: PrintErrorEntry
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 650,
+          "y": 7020
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    scriptarguments:
+      message:
+        simple: 'TEST FAILED: Prisma AIRS DLP comprehensive test failed the gated check. Expected PatternId, CustomProfileId, and MasterProfileId to all be set. Profile patch/delete and pattern-delete-while-referenced are known upstream-blocked (HTTP 400/500) canaries and do not gate pass/fail.'
+  '99':
+    id: '99'
+    taskid: a0000000-0000-4000-8000-000000000099
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000099
+      version: -1
+      name: Test Passed - Close Investigation
+      description: All gated validations passed.
+      type: regular
+      iscommand: true
+      brand: Builtin
+      script: Builtin|||closeInvestigation
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 7020
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    scriptarguments:
+      id:
+        simple: ${incident.id}
+      closeReason:
+        simple: Test passed - Prisma AIRS DLP comprehensive test validated successfully
+      closeNotes:
+        simple: 'DLP lifecycle validated: pattern create/list/get/patch/get, dictionary upload/create/list/get/patch/get/delete, profile list + PII/Sensitive Content lookup + custom-profile create referencing the pattern + composed master-profile create. Profile patch/delete and pattern-delete-while-referenced ran as upstream-blocked canaries (HTTP 400/500).'
+  '39':
+    id: '39'
+    taskid: a0000000-0000-4000-8000-000000000039
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000039
+      version: -1
+      name: 'prisma-airs-runtime-dlp-profiles-patch (master: drop custom)'
+      description: "CLEANUP STEP 1 - patch the master profile to remove the custom sub-profile, leaving only the predefined PII + Sensitive Content profiles. CANARY: profile patch is upstream-blocked (HTTP 500), so today this errors and the composition is unchanged; the intended effect (and this task's purpose) is to un-reference the custom profile so it can be deleted. Works once upstream fixes the 500."
+      type: regular
+      iscommand: true
+      brand: ''
+      script: '|||prisma-airs-runtime-dlp-profiles-patch'
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 5830
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '40'
+    scriptarguments:
+      profile_id:
+        simple: ${MasterProfileId}
+      name:
+        simple: ${EffectiveMasterProfileName}
+      profile_type:
+        simple: advanced
+      detection_rules:
+        simple: '[{"rule_type":"multi_profile","multi_profile":{"operator_type":"or","data_profile_ids":[${PiiProfileId},${SensitiveContentProfileId}]}}]'
+    continueonerror: true
+  '40':
+    id: '40'
+    taskid: a0000000-0000-4000-8000-000000000040
+    type: regular
+    task:
+      id: a0000000-0000-4000-8000-000000000040
+      version: -1
+      name: 'prisma-airs-runtime-dlp-profiles-patch (sub: swap pattern to Ireland)'
+      description: "CLEANUP STEP 2 - patch the custom sub-profile to replace the custom data pattern with the predefined 'Driver License - Ireland' pattern (id 68ff6020e66e2c793430df80), which frees the custom pattern from any active-profile reference so it can be deleted. CANARY: profile patch is upstream-blocked (HTTP 500), so today this errors and the custom pattern stays referenced (pattern delete then 400s). Works once upstream fixes the 500."
+      type: regular
+      iscommand: true
+      brand: ''
+      script: '|||prisma-airs-runtime-dlp-profiles-patch'
+    separatecontext: false
+    continueonerrortype: ''
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 6000
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
+    nexttasks:
+      '#none#':
+      - '34'
+    scriptarguments:
+      profile_id:
+        simple: ${CustomProfileId}
+      name:
+        simple: ${EffectiveCustomProfileName}
+      profile_type:
+        simple: advanced
+      detection_rules:
+        simple: '[{"rule_type":"expression_tree","expression_tree":{"operator_type":"or","sub_expressions":[{"rule_item":{"detection_technique":"regex","id":"68ff6020e66e2c793430df80","match_type":"include","confidence_level":"high","occurrence_operator_type":"any","occurrence_count":1}}]}}]'
+    continueonerror: true
+version: -1
+view: |-
+  {
+    "linkLabelsPosition": {},
+    "paper": {
+      "dimensions": {
+        "height": 7220,
+        "width": 900,
+        "x": 250,
+        "y": 50
+      }
+    }
+  }
+fromversion: 6.10.0

--- a/Packs/PaloAltoNetworks_Prisma_AIRs/TestPlaybooks/playbook-PaloAltoNetworks_Prisma_AIRs_DLP_Patterns_Test.yml
+++ b/Packs/PaloAltoNetworks_Prisma_AIRs/TestPlaybooks/playbook-PaloAltoNetworks_Prisma_AIRs_DLP_Patterns_Test.yml
@@ -1,4 +1,4 @@
-description: Test playbook for Prisma AIRs DLP data patterns. Tests pattern CRUD (list, create, get, patch, replace, delete), ensuring only the pattern created by this playbook is modified and deleted.
+description: Test playbook for Prisma AIRS DLP data patterns. Tests pattern CRUD (list, create, get, patch, replace, delete), ensuring only the pattern created by this playbook is modified and deleted.
 id: PaloAltoNetworks_Prisma_AIRs_DLP_Patterns_Test
 inputs:
 - key: PatternName

--- a/Packs/PaloAltoNetworks_Prisma_AIRs/TestPlaybooks/playbook-PaloAltoNetworks_Prisma_AIRs_Model_Security_Test.yml
+++ b/Packs/PaloAltoNetworks_Prisma_AIRs/TestPlaybooks/playbook-PaloAltoNetworks_Prisma_AIRs_Model_Security_Test.yml
@@ -1,4 +1,4 @@
-description: Test playbook for Prisma AIRs AI Supply Chain Security integration. Tests CRUD operations for model security groups.
+description: Test playbook for Prisma AIRS AI Supply Chain Security integration. Tests CRUD operations for model security groups.
 id: PaloAltoNetworks_Prisma_AIRs_Model_Security_Test
 inputs:
 - key: GroupName

--- a/Packs/PaloAltoNetworks_Prisma_AIRs/TestPlaybooks/playbook-PaloAltoNetworks_Prisma_AIRs_RedTeam_Prompts_Test.yml
+++ b/Packs/PaloAltoNetworks_Prisma_AIRs/TestPlaybooks/playbook-PaloAltoNetworks_Prisma_AIRs_RedTeam_Prompts_Test.yml
@@ -1,4 +1,4 @@
-description: Test playbook for Prisma AIRs Red Team integration. Tests CRUD operations for prompt sets and prompts.
+description: Test playbook for Prisma AIRS Red Team integration. Tests CRUD operations for prompt sets and prompts.
 id: PaloAltoNetworks_Prisma_AIRs_RedTeam_Prompts_Test
 inputs:
 - key: PromptSetName

--- a/Packs/PaloAltoNetworks_Prisma_AIRs/TestPlaybooks/playbook-PaloAltoNetworks_Prisma_AIRs_Runtime_Profiles_Test.yml
+++ b/Packs/PaloAltoNetworks_Prisma_AIRs/TestPlaybooks/playbook-PaloAltoNetworks_Prisma_AIRs_Runtime_Profiles_Test.yml
@@ -1,4 +1,4 @@
-description: Test playbook for Prisma AIRs Runtime security profiles and topics. Tests profile + topic CRUD and topic-apply, ensuring only the profile and topic created by this playbook are modified, applied, and deleted.
+description: Test playbook for Prisma AIRS Runtime security profiles and topics. Tests profile + topic CRUD and topic-apply, ensuring only the profile and topic created by this playbook are modified, applied, and deleted.
 id: PaloAltoNetworks_Prisma_AIRs_Runtime_Profiles_Test
 inputs:
 - key: ProfileName

--- a/Packs/PaloAltoNetworks_Prisma_AIRs/TestPlaybooks/playbook-PaloAltoNetworks_Prisma_AIRs_Runtime_Scan_Test.yml
+++ b/Packs/PaloAltoNetworks_Prisma_AIRs/TestPlaybooks/playbook-PaloAltoNetworks_Prisma_AIRs_Runtime_Scan_Test.yml
@@ -1,4 +1,4 @@
-description: Test playbook for Prisma AIRs runtime operations - deployment profiles, API key lifecycle, security profile CRUD (with prompt-injection block), and scanning with verdict assertions. Ensures only the API key, customer app, and security profile created by this playbook are modified and deleted.
+description: Test playbook for Prisma AIRS runtime operations - deployment profiles, API key lifecycle, security profile CRUD (with prompt-injection block), and scanning with verdict assertions. Ensures only the API key, customer app, and security profile created by this playbook are modified and deleted.
 id: PaloAltoNetworks_Prisma_AIRs_Runtime_Scan_Test
 inputs:
 - key: ApiKeyName

--- a/Packs/PaloAltoNetworks_Prisma_AIRs/pack_metadata.json
+++ b/Packs/PaloAltoNetworks_Prisma_AIRs/pack_metadata.json
@@ -1,8 +1,8 @@
 {
-    "name": "Palo Alto Networks - Prisma AIRs AI Security",
-    "description": "Integrate with Palo Alto Networks Prisma AIRs for AI security: runtime scanning, red teaming, AI supply chain security, and DLP configuration.",
+    "name": "Palo Alto Networks - Prisma AIRS AI Security",
+    "description": "Integrate with Palo Alto Networks Prisma AIRS for AI security: runtime scanning, red teaming, AI supply chain security, and DLP configuration.",
     "support": "community",
-    "currentVersion": "1.0.0",
+    "currentVersion": "1.0.1",
     "author": "Eric Partington",
     "url": "https://live.paloaltonetworks.com/t5/cortex-xsoar-discussions/bd-p/Cortex_XSOAR_Discussions",
     "email": "",

--- a/Tests/conf.json
+++ b/Tests/conf.json
@@ -5953,6 +5953,11 @@
         },
         {
             "integrations": "Palo Alto Networks Prisma AIRS - AI Runtime Security",
+            "playbookID": "PaloAltoNetworks_Prisma_AIRs_DLP_Comprehensive_Test",
+            "fromversion": "6.10.0"
+        },
+        {
+            "integrations": "Palo Alto Networks Prisma AIRS - AI Runtime Security",
             "playbookID": "PaloAltoNetworks_Prisma_AIRs_Runtime_Scan_Test",
             "fromversion": "6.10.0"
         }


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
<!-- To link a Jira ticket use fixes/related: link to the issue, for example relates: link to the issue

## Description
- Correct pack brand spelling "Prisma AIRs" -> "Prisma AIRS" across all display text and docs (identifiers/paths deliberately unchanged)
- Runtime: dlp-dictionaries-create/-replace region_name is now a predefined pick list of valid tenant region labels (default United States), avoiding the HTTP 400 the API returns for AWS-style codes like us-west-2
- Runtime: dlp-patterns-delete surfaces an actionable error when the pattern is still referenced by an active data profile (HTTP 400)
- Runtime: document the server-enforced 32-char DLP data-profile name limit (spec wrongly says 64)
- Pack README: refresh Known Limitations with the accurate DLP constraints
- Register the DLP Comprehensive test playbook (conf.json + Runtime tests list)
- Bump pack to 1.0.1 with release notes

## Must have
- [x] Tests
- [x] Documentation


relates: https://jira-dc.paloaltonetworks.com/browse/CIAC-17996