### PR TITLE
CRTX-271526: re-open identity.* modeling rules (PR 2 of 7)

### DIFF
--- a/Packs/CiscoFirepower/.pack-ignore
+++ b/Packs/CiscoFirepower/.pack-ignore
@@ -4,6 +4,3 @@ ignore=IM111
 [file:CiscoFirepower_1_3.yml]
 ignore=MR108
 
-[file:CiscoFirepower_2_11.yml]
-ignore=MR108
-

--- a/Packs/CiscoFirepower/ModelingRules/CiscoFirepower_2_11/CiscoFirepower_2_11.yml
+++ b/Packs/CiscoFirepower/ModelingRules/CiscoFirepower_2_11/CiscoFirepower_2_11.yml
@@ -1,6 +1,6 @@
 fromversion: 8.15.0
 id: CiscoFirepower_modeling_rule
-name: CiscoFirepower Modeling Rule
+name: Cisco Firepower Modeling Rule
 rules: ''
 schema: ''
 tags: CiscoFirepower

--- a/Packs/Office365/ModelingRules/Office365_2_11/Office365_2_11.yml
+++ b/Packs/Office365/ModelingRules/Office365_2_11/Office365_2_11.yml
@@ -1,6 +1,6 @@
 fromversion: 8.15.0
-id: Office_365_ModelingRule
-name: Office 365 Modeling Rule
+id: Office365_ModelingRule
+name: Office365 Modeling Rule
 rules: ''
 schema: ''
 tags: ''

--- a/Packs/Office365/ReleaseNotes/1_0_24.md
+++ b/Packs/Office365/ReleaseNotes/1_0_24.md
@@ -1,7 +1,7 @@
 
 #### Modeling Rules
 
-##### New: Office 365 Modeling Rule
+##### New: Office365 Modeling Rule
 
 - New: Added a new modeling rule version that maps the `xdm.*.identity.*` fields alongside the existing `xdm.*.user.*` fields.
 <~XSIAM> (Available from Cortex XSIAM 2.11).</~XSIAM>

--- a/Packs/UbiquitiUnifi/ModelingRules/UbiquitiUnifi_2_11/UbiquitiUnifi_2_11.yml
+++ b/Packs/UbiquitiUnifi/ModelingRules/UbiquitiUnifi_2_11/UbiquitiUnifi_2_11.yml
@@ -1,6 +1,6 @@
 fromversion: 8.15.0
-id: Ubiquiti_Unifi_ModelingRule
-name: Ubiquiti Unifi Modeling Rule
+id: UbiquitiUnifi_ModelingRule
+name: UbiquitiUnifi Modeling Rule
 rules: ''
 schema: ''
 tags: ''

--- a/Packs/UbiquitiUnifi/ReleaseNotes/1_0_4.md
+++ b/Packs/UbiquitiUnifi/ReleaseNotes/1_0_4.md
@@ -1,7 +1,7 @@
 
 #### Modeling Rules
 
-##### New: Ubiquiti Unifi Modeling Rule
+##### New: UbiquitiUnifi Modeling Rule
 
 - New: Added a new modeling rule version that maps the `xdm.*.identity.*` fields alongside the existing `xdm.*.user.*` fields.
 <~XSIAM> (Available from Cortex XSIAM 2.11).</~XSIAM>


### PR DESCRIPTION
Re-apply the PR2 modeling-rule refinements on top of current master. Adjusts modeling rule id/name for Office365, UbiquitiUnifi and Cisco Firepower _2_11 folders, aligns the matching release notes, and removes the redundant CiscoFirepower_2_11 .pack-ignore MR108 entry.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
<!-- To link a Jira ticket use fixes/related: link to the issue, for example fixes: CIAC-XXXX -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

## Must have
- [ ] Tests
- [ ] Documentation
