### PR TITLE
CRTX-271526: re-open identity.* modeling rules (PR 2 of 7)

### DIFF
--- a/Packs/CiscoFirepower/.pack-ignore
+++ b/Packs/CiscoFirepower/.pack-ignore
@@ -4,6 +4,3 @@ ignore=IM111
 [file:CiscoFirepower_1_3.yml]
 ignore=MR108
 
-[file:CiscoFirepower_2_11.yml]
-ignore=MR108
-

--- a/Packs/CiscoFirepower/ModelingRules/CiscoFirepower_2_11/CiscoFirepower_2_11.yml
+++ b/Packs/CiscoFirepower/ModelingRules/CiscoFirepower_2_11/CiscoFirepower_2_11.yml
@@ -1,6 +1,6 @@
 fromversion: 8.15.0
 id: CiscoFirepower_modeling_rule
-name: CiscoFirepower Modeling Rule
+name: Cisco Firepower Modeling Rule
 rules: ''
 schema: ''
 tags: CiscoFirepower

--- a/Packs/Office365/ModelingRules/Office365_2_11/Office365_2_11.yml
+++ b/Packs/Office365/ModelingRules/Office365_2_11/Office365_2_11.yml
@@ -1,6 +1,6 @@
 fromversion: 8.15.0
-id: Office_365_ModelingRule
-name: Office 365 Modeling Rule
+id: Office365_ModelingRule
+name: Office365 Modeling Rule
 rules: ''
 schema: ''
 tags: ''

--- a/Packs/Office365/ReleaseNotes/1_0_24.md
+++ b/Packs/Office365/ReleaseNotes/1_0_24.md
@@ -1,7 +1,7 @@
 
 #### Modeling Rules
 
-##### New: Office 365 Modeling Rule
+##### New: Office365 Modeling Rule
 
 - New: Added a new modeling rule version that maps the `xdm.*.identity.*` fields alongside the existing `xdm.*.user.*` fields.
 <~XSIAM> (Available from Cortex XSIAM 2.11).</~XSIAM>

--- a/Packs/UbiquitiUnifi/ModelingRules/UbiquitiUnifi_2_11/UbiquitiUnifi_2_11.yml
+++ b/Packs/UbiquitiUnifi/ModelingRules/UbiquitiUnifi_2_11/UbiquitiUnifi_2_11.yml
@@ -1,6 +1,6 @@
 fromversion: 8.15.0
-id: Ubiquiti_Unifi_ModelingRule
-name: Ubiquiti Unifi Modeling Rule
+id: UbiquitiUnifi_ModelingRule
+name: UbiquitiUnifi Modeling Rule
 rules: ''
 schema: ''
 tags: ''

--- a/Packs/UbiquitiUnifi/ReleaseNotes/1_0_4.md
+++ b/Packs/UbiquitiUnifi/ReleaseNotes/1_0_4.md
@@ -1,7 +1,7 @@
 
 #### Modeling Rules
 
-##### New: Ubiquiti Unifi Modeling Rule
+##### New: UbiquitiUnifi Modeling Rule
 
 - New: Added a new modeling rule version that maps the `xdm.*.identity.*` fields alongside the existing `xdm.*.user.*` fields.
 <~XSIAM> (Available from Cortex XSIAM 2.11).</~XSIAM>


### PR DESCRIPTION
## Context

The original CRTX-271526 PR 2 of 7 was merged into master via #45457, then a broad revert PR #45814 ("Revert ModelingRules changes across 88 packs") landed. That revert did **not** touch the three packs owned by this PR (Office365, CiscoFirepower, UbiquitiUnifi), but this PR re-opens the follow-up modeling-rule refinements cleanly on top of current master.

## Changes (3 packs, 6 files)

- **Office365**: modeling-rule id/name aligned to `Office365_ModelingRule` / `Office365 Modeling Rule` + matching release note (`1_0_24.md`).
- **UbiquitiUnifi**: modeling-rule id/name aligned to `UbiquitiUnifi_ModelingRule` / `UbiquitiUnifi Modeling Rule` + matching release note (`1_0_4.md`).
- **CiscoFirepower**: modeling-rule name aligned to `Cisco Firepower Modeling Rule`; removed the redundant `CiscoFirepower_2_11.yml` MR108 entry from `.pack-ignore`.

These are the `_2_11` (fromversion 8.15.0) identity.* modeling rules that map `xdm.*.identity.*` alongside `xdm.*.user.*`.

## Related
- Original merge: #45457
- Revert: #45814