### PR TITLE
CSF report health on a successful Spotlight fetch

### DIFF
--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.py
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.py
@@ -5498,6 +5498,15 @@ async def fetch_spotlight_assets():
             "info",
         )
 
+        # An error written with is_error=True latches: it stays on the instance until something
+        # overwrites it with a non-error status. The only such write used to be at the end of
+        # fetch_cnapp_assets, which never runs when Spotlight is collected on its own - not when
+        # "Spotlight" is the only selected assets type, and not in the long-running mode, which
+        # calls this function directly. Those instances kept displaying a transient XSIAM error long
+        # after collection had recovered. send_data_to_xsiam_async does not write health at all, so
+        # reporting it here is the only way to clear the status.
+        demisto.updateModuleHealth({"assetsPulled": total_vulnerabilities})
+
     except (ContentClientError, Exception) as e:
         log_falcon_assets(f"Error during Spotlight fetch: {e}", "error")
 

--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.py
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon.py
@@ -5498,13 +5498,6 @@ async def fetch_spotlight_assets():
             "info",
         )
 
-        # An error written with is_error=True latches: it stays on the instance until something
-        # overwrites it with a non-error status. The only such write used to be at the end of
-        # fetch_cnapp_assets, which never runs when Spotlight is collected on its own - not when
-        # "Spotlight" is the only selected assets type, and not in the long-running mode, which
-        # calls this function directly. Those instances kept displaying a transient XSIAM error long
-        # after collection had recovered. send_data_to_xsiam_async does not write health at all, so
-        # reporting it here is the only way to clear the status.
         demisto.updateModuleHealth({"assetsPulled": total_vulnerabilities})
 
     except (ContentClientError, Exception) as e:

--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon_test.py
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon_test.py
@@ -12100,11 +12100,11 @@ class TestSpotlightFetchReportsHealth:
     @pytest.mark.asyncio
     async def test_successful_fetch_clears_a_previous_error(self, mocker):
         """The health write must be a non-error one, which is what actually clears the red status."""
-        from CrowdStrikeFalcon import fetch_spotlight_assets
+        import CrowdStrikeFalcon
 
         mock_health = self._run_fetch(mocker, parallel_return=(1234, {"aid-1", "aid-2"}))
 
-        await fetch_spotlight_assets()
+        await CrowdStrikeFalcon.fetch_spotlight_assets()
 
         assert mock_health.call_count == 1, "a completed Spotlight fetch reported no health at all"
         _args, kwargs = mock_health.call_args
@@ -12113,23 +12113,23 @@ class TestSpotlightFetchReportsHealth:
     @pytest.mark.asyncio
     async def test_health_reports_the_number_of_records_pulled(self, mocker):
         """Mirrors the CNAPP path's ``{"assetsPulled": n}`` so the UI shows a count, not just green."""
-        from CrowdStrikeFalcon import fetch_spotlight_assets
+        import CrowdStrikeFalcon
 
         mock_health = self._run_fetch(mocker, parallel_return=(1234, {"aid-1", "aid-2"}))
 
-        await fetch_spotlight_assets()
+        await CrowdStrikeFalcon.fetch_spotlight_assets()
 
         assert mock_health.call_args.args[0] == {"assetsPulled": 1234}
 
     @pytest.mark.asyncio
     async def test_failed_fetch_does_not_report_success(self, mocker):
         """A fetch that raises must leave the error standing rather than paint over it."""
-        from CrowdStrikeFalcon import fetch_spotlight_assets
+        import CrowdStrikeFalcon
 
         mock_health = self._run_fetch(mocker, parallel_side_effect=DemistoException("boom"))
 
         with pytest.raises(DemistoException):
-            await fetch_spotlight_assets()
+            await CrowdStrikeFalcon.fetch_spotlight_assets()
 
         assert mock_health.call_count == 0, "a failed fetch cleared the error status"
 

--- a/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon_test.py
+++ b/Packs/CrowdStrikeFalcon/Integrations/CrowdStrikeFalcon/CrowdStrikeFalcon_test.py
@@ -12054,6 +12054,86 @@ class StopLoop(Exception):
     """Sentinel used to break out of the long-running while-True loop in tests."""
 
 
+class TestSpotlightFetchReportsHealth:
+    """XSUP-76105: a completed Spotlight fetch has to report health, or a stale error never clears.
+
+    ``updateModuleHealth(data, is_error=True)`` latches - the red status stays on the instance until
+    something overwrites it with a non-error write. ``fetch_cnapp_assets`` does that on its success
+    path, so an instance collecting CNAPP Alerts recovers on the next cycle. Spotlight had no
+    equivalent, and it is reachable without CNAPP in two ways: "Spotlight" selected as the only
+    assets type, and the long-running mode, which calls ``fetch_spotlight_assets`` directly. Those
+    instances kept displaying an error from a fetch that had long since recovered.
+    """
+
+    @staticmethod
+    def _run_fetch(mocker, parallel_side_effect=None, parallel_return=(0, set())):
+        """Run fetch_spotlight_assets with everything below the severity fan-out stubbed out.
+
+        Returns the updateModuleHealth mock.
+        """
+        import CrowdStrikeFalcon
+
+        mocker.patch("CrowdStrikeFalcon.demisto.params", return_value={})
+        mocker.patch("CrowdStrikeFalcon.log_falcon_assets")
+        mocker.patch("CrowdStrikeFalcon.ContentClientContextStore")
+        mocker.patch(
+            "CrowdStrikeFalcon.load_spotlight_state",
+            return_value=(mocker.MagicMock(), "snap-1", 0, 0, set(), [], []),
+        )
+        mocker.patch("CrowdStrikeFalcon.update_spotlight_state_and_metadata")
+        mocker.patch("CrowdStrikeFalcon.save_spotlight_state")
+
+        client = mocker.MagicMock()
+        client.aclose = mocker.AsyncMock()
+        mocker.patch("CrowdStrikeFalcon.create_spotlight_client", return_value=client)
+
+        mocker.patch.object(
+            CrowdStrikeFalcon,
+            "fetch_spotlight_by_severity_parallel",
+            new_callable=mocker.AsyncMock,
+            side_effect=parallel_side_effect,
+            return_value=parallel_return,
+        )
+
+        return mocker.patch("CrowdStrikeFalcon.demisto.updateModuleHealth")
+
+    @pytest.mark.asyncio
+    async def test_successful_fetch_clears_a_previous_error(self, mocker):
+        """The health write must be a non-error one, which is what actually clears the red status."""
+        from CrowdStrikeFalcon import fetch_spotlight_assets
+
+        mock_health = self._run_fetch(mocker, parallel_return=(1234, {"aid-1", "aid-2"}))
+
+        await fetch_spotlight_assets()
+
+        assert mock_health.call_count == 1, "a completed Spotlight fetch reported no health at all"
+        _args, kwargs = mock_health.call_args
+        assert kwargs.get("is_error", False) is False, "the success write must not be flagged as an error"
+
+    @pytest.mark.asyncio
+    async def test_health_reports_the_number_of_records_pulled(self, mocker):
+        """Mirrors the CNAPP path's ``{"assetsPulled": n}`` so the UI shows a count, not just green."""
+        from CrowdStrikeFalcon import fetch_spotlight_assets
+
+        mock_health = self._run_fetch(mocker, parallel_return=(1234, {"aid-1", "aid-2"}))
+
+        await fetch_spotlight_assets()
+
+        assert mock_health.call_args.args[0] == {"assetsPulled": 1234}
+
+    @pytest.mark.asyncio
+    async def test_failed_fetch_does_not_report_success(self, mocker):
+        """A fetch that raises must leave the error standing rather than paint over it."""
+        from CrowdStrikeFalcon import fetch_spotlight_assets
+
+        mock_health = self._run_fetch(mocker, parallel_side_effect=DemistoException("boom"))
+
+        with pytest.raises(DemistoException):
+            await fetch_spotlight_assets()
+
+        assert mock_health.call_count == 0, "a failed fetch cleared the error status"
+
+
 class TestLongRunningSpotlightExecution:
     """Tests for the opt-in long-running Spotlight fetch loop."""
 

--- a/Packs/CrowdStrikeFalcon/ReleaseNotes/2_13_1.md
+++ b/Packs/CrowdStrikeFalcon/ReleaseNotes/2_13_1.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### CrowdStrike Falcon
+
+- Fixed an issue where an instance fetching Spotlight vulnerabilities kept showing an error after the fetch recovered, because a successful fetch did not report its status.

--- a/Packs/CrowdStrikeFalcon/pack_metadata.json
+++ b/Packs/CrowdStrikeFalcon/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "CrowdStrike Falcon",
     "description": "The CrowdStrike Falcon OAuth 2 API (formerly the Falcon Firehose API), enables fetching and resolving detections, searching devices, getting behaviors by ID, containing hosts, and lifting host containment.",
     "support": "xsoar",
-    "currentVersion": "2.13.0",
+    "currentVersion": "2.13.1",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: XSUP-76105

## Description
An error written with is_error=True latches on the instance until something overwrites it with a non-error status. The only such write was at the end of fetch_cnapp_assets, which never runs when Spotlight is collected on its own - neither when "Spotlight" is the only selected assets type, nor in the long-running mode, which calls fetch_spotlight_assets directly. send_data_to_xsiam_async does not write health at all.

Those instances kept displaying a transient XSIAM error long after collection had recovered, which is what the customer on XSUP-76105 is looking at: the message still reads "Bad GatewayBad Gateway", a duplication that 2.13.0 removed, so the text predates the upgrade.

Reports {"assetsPulled": n} on the success path, mirroring fetch_cnapp_assets. A failed fetch still raises before reaching it, so a real error is not painted over.

## Must have
- [ ] Tests
- [ ] Documentation
