### PR TITLE
Fix PagerDuty v2 KeyError

### DIFF
--- a/Packs/PagerDuty/Integrations/PagerDuty/PagerDuty.py
+++ b/Packs/PagerDuty/Integrations/PagerDuty/PagerDuty.py
@@ -10,8 +10,8 @@ USE_SSL = not demisto.params().get("insecure", False)
 
 USE_PROXY = demisto.params().get("proxy", True)
 API_KEY = demisto.params().get("credentials_api_key", {}).get("password") or demisto.params().get("APIKey")
-SERVICE_KEY = demisto.params()["ServiceKey"]
-FETCH_INTERVAL = demisto.params()["FetchInterval"]
+SERVICE_KEY = demisto.params().get("ServiceKey")  # required: false - only for triggering, acknowledging and resolving events
+FETCH_INTERVAL = demisto.params().get("FetchInterval", "1")
 DEFAULT_REQUESTOR = demisto.params().get("DefaultRequestor", "")
 
 SERVER_URL = "https://api.pagerduty.com/"

--- a/Packs/PagerDuty/Integrations/PagerDuty/PagerDuty.yml
+++ b/Packs/PagerDuty/Integrations/PagerDuty/PagerDuty.yml
@@ -536,7 +536,7 @@ script:
   script: '-'
   subtype: python3
   type: python
-  dockerimage: demisto/python3:3.12.13.10116658
+  dockerimage: demisto/python3:3.12.14.12844876
 tests:
 - PagerDuty Test
 fromversion: 5.0.0

--- a/Packs/PagerDuty/ReleaseNotes/1_1_19.md
+++ b/Packs/PagerDuty/ReleaseNotes/1_1_19.md
@@ -1,0 +1,8 @@
+
+#### Integrations
+
+##### PagerDuty v2
+
+- Fixed an issue where commands failed with a `KeyError` when executed inside a playbook task.
+
+- Updated the Docker image to: *demisto/python3:3.12.14.12844876*.

--- a/Packs/PagerDuty/pack_metadata.json
+++ b/Packs/PagerDuty/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "PagerDuty",
     "description": "Alert and notify users using PagerDuty",
     "support": "xsoar",
-    "currentVersion": "1.1.18",
+    "currentVersion": "1.1.19",
     "author": "Cortex XSOAR",
     "url": "https://www.paloaltonetworks.com/cortex",
     "email": "",


### PR DESCRIPTION
## Related Issues
fixes: [XSUP-76680](https://jira-dc.paloaltonetworks.com/browse/XSUP-76680)

## Description
Fixed an issue where commands failed with a `KeyError` due to unsafe handling of optional configuration parameters.
